### PR TITLE
Fix CLI module dispatch

### DIFF
--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -32,5 +32,6 @@ if header_neto:
 
 
 def main():
-    from wsm.ui.review_links import preveri_in_povezi
-    preveri_in_povezi()
+    """Delegate execution to the full CLI implementation."""
+    from wsm_program_vnasanje.wsm.cli import main as real_main
+    real_main()


### PR DESCRIPTION
## Summary
- delegate `wsm.cli.main` to the full implementation located in `wsm_program_vnasanje/wsm`

## Testing
- `pytest -q` *(fails: Invalid statement in pyproject.toml)*
- `python -m wsm --help`

------
https://chatgpt.com/codex/tasks/task_e_683ff675c47c83218535392a4423835b