### PR TITLE
Ignore doc discounts when validating invoices

### DIFF
--- a/tests/test_validate_invoice.py
+++ b/tests/test_validate_invoice.py
@@ -1,0 +1,17 @@
+import pytest
+from pathlib import Path
+from wsm.parsing.eslog import parse_invoice, validate_invoice
+
+@pytest.mark.parametrize('xml_file', [
+    'PR5697-Slika2.XML',  # contains document-level discount
+    '2025-581-racun.xml',  # another with document discount
+])
+def test_validate_invoice_with_doc_discount(xml_file):
+    df, header_total = parse_invoice(Path('tests') / xml_file)
+    assert validate_invoice(df, header_total)
+
+
+def test_validate_invoice_no_doc_discount():
+    df, header_total = parse_invoice(Path('tests') / 'PR5690-Slika1.XML')
+    assert validate_invoice(df, header_total)
+

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -213,5 +213,13 @@ def validate_invoice(df, header_total: Decimal) -> bool:
     """
     if df is None or header_total is None:
         return False
-    line_sum = df['vrednost'].sum() if 'vrednost' in df.columns else Decimal("0")
+
+    if 'vrednost' not in df.columns:
+        line_sum = Decimal("0")
+    elif 'sifra_dobavitelja' in df.columns:
+        mask = df.get("sifra_dobavitelja") != "_DOC_"
+        line_sum = df.loc[mask, "vrednost"].sum()
+    else:
+        line_sum = df['vrednost'].sum()
+
     return abs(line_sum - header_total) < Decimal("0.05")


### PR DESCRIPTION
## Summary
- skip `_DOC_` rows when checking invoice totals
- test invoices with document-level discounts

## Testing
- `python -m pytest -q -c /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_68401893bad483219bebe225dd1d51fc