### PR TITLE
Enhance invoice validation with currency checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-﻿[build-system]
+[build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 

--- a/tests/test_validate_invoice.py
+++ b/tests/test_validate_invoice.py
@@ -7,11 +7,26 @@ from wsm.parsing.eslog import parse_invoice, validate_invoice
     '2025-581-racun.xml',  # another with document discount
 ])
 def test_validate_invoice_with_doc_discount(xml_file):
-    df, header_total = parse_invoice(Path('tests') / xml_file)
-    assert validate_invoice(df, header_total)
+    df, header_total, currency = parse_invoice(Path('tests') / xml_file)
+    assert validate_invoice(df, header_total, currency)
 
 
 def test_validate_invoice_no_doc_discount():
-    df, header_total = parse_invoice(Path('tests') / 'PR5690-Slika1.XML')
-    assert validate_invoice(df, header_total)
+    df, header_total, currency = parse_invoice(Path('tests') / 'PR5690-Slika1.XML')
+    assert validate_invoice(df, header_total, currency)
+
+
+def test_validate_negative_invoice():
+    df, header_total, currency = parse_invoice(Path('tests') / 'VP2025-1799-racun.xml')
+    assert validate_invoice(df, header_total, currency)
+
+
+def test_validate_currency_mismatch(tmp_path):
+    src = Path('tests') / 'PR5690-Slika1.XML'
+    data = src.read_text(encoding='utf-8')
+    data = data.replace('<D_6345>EUR</D_6345>', '<D_6345>USD</D_6345>')
+    temp = tmp_path / 'invoice_usd.xml'
+    temp.write_text(data, encoding='utf-8')
+    df, header_total, currency = parse_invoice(temp)
+    assert not validate_invoice(df, header_total, currency)
 

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -70,22 +70,28 @@ def validate_folder(input_folder):
             continue
 
         try:
-            df, header_total = parse_invoice(file)
+            df, header_total, currency = parse_invoice(file)
         except Exception as e:
             click.secho(f"[NAPAKA PARSANJA] {file.name}: {e}", fg="red")
             had_errors = True
             continue
 
-        is_valid = validate_invoice(df, header_total)
+        is_valid = validate_invoice(df, header_total, currency)
         if not is_valid:
-            click.secho(f"[NESKLADJE] {file.name}: vrsticna_vsota != glava({header_total})", fg="yellow")
+            click.secho(
+                f"[NESKLADJE] {file.name}: vrsticna_vsota != glava({header_total})",
+                fg="yellow",
+            )
             # (opcijsko) shranite DataFrame za debug:
             debug_folder = folder / "debug"
             debug_folder.mkdir(exist_ok=True)
             df.to_csv(debug_folder / f"{file.stem}_DEBUG.csv", index=False)
             had_errors = True
         else:
-            click.secho(f"[OK]      {file.name}: vse se ujema ({header_total} €)", fg="green")
+            click.secho(
+                f"[OK]      {file.name}: vse se ujema ({header_total} {currency})",
+                fg="green",
+            )
 
     if had_errors:
         sys.exit(1)

--- a/wsm/parsing/money.py
+++ b/wsm/parsing/money.py
@@ -49,3 +49,15 @@ def parse_invoice_total(xml_path: str | Path) -> Decimal:
             return _dec(_text(moa.find("./e:C_C516/e:D_5004", _eNS)))
 
     return Decimal("0")
+
+
+def parse_invoice_currency(xml_path: str | Path) -> str:
+    """Return the invoice currency (D_6345) if present, otherwise 'EUR'."""
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+        cur = root.find(".//e:D_6345", _eNS)
+        code = _text(cur)
+        return code if code else "EUR"
+    except Exception:
+        return "EUR"


### PR DESCRIPTION
## Summary
- parse currency from ESLOG invoice XML
- validate invoices require EUR currency
- show currency in CLI output
- improve test suite with negative invoices and currency mismatch cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684019f6846c8321959ca2191952b393