### PR TITLE
Improve invoice total parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-﻿[build-system]
+[build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 

--- a/tests/test_validate_invoice.py
+++ b/tests/test_validate_invoice.py
@@ -1,5 +1,6 @@
 import pytest
 from pathlib import Path
+from decimal import Decimal
 from wsm.parsing.eslog import parse_invoice, validate_invoice
 
 @pytest.mark.parametrize('xml_file', [
@@ -7,11 +8,32 @@ from wsm.parsing.eslog import parse_invoice, validate_invoice
     '2025-581-racun.xml',  # another with document discount
 ])
 def test_validate_invoice_with_doc_discount(xml_file):
-    df, header_total = parse_invoice(Path('tests') / xml_file)
-    assert validate_invoice(df, header_total)
+    df, header_total, currency = parse_invoice(Path('tests') / xml_file)
+    assert validate_invoice(df, header_total, currency)
 
 
 def test_validate_invoice_no_doc_discount():
-    df, header_total = parse_invoice(Path('tests') / 'PR5690-Slika1.XML')
-    assert validate_invoice(df, header_total)
+    df, header_total, currency = parse_invoice(Path('tests') / 'PR5690-Slika1.XML')
+    assert validate_invoice(df, header_total, currency)
+
+
+def test_validate_negative_invoice():
+    df, header_total, currency = parse_invoice(Path('tests') / 'VP2025-1799-racun.xml')
+    assert validate_invoice(df, header_total, currency)
+
+
+def test_validate_currency_mismatch(tmp_path):
+    src = Path('tests') / 'PR5690-Slika1.XML'
+    data = src.read_text(encoding='utf-8')
+    data = data.replace('<D_6345>EUR</D_6345>', '<D_6345>USD</D_6345>')
+    temp = tmp_path / 'invoice_usd.xml'
+    temp.write_text(data, encoding='utf-8')
+    df, header_total, currency = parse_invoice(temp)
+    assert not validate_invoice(df, header_total, currency)
+
+
+def test_parse_total_after_discount():
+    """Invoice with document discount should return net total."""
+    _, header_total, _ = parse_invoice(Path('tests') / '2025-581-racun.xml')
+    assert header_total == Decimal('904.29')
 

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -70,22 +70,28 @@ def validate_folder(input_folder):
             continue
 
         try:
-            df, header_total = parse_invoice(file)
+            df, header_total, currency = parse_invoice(file)
         except Exception as e:
             click.secho(f"[NAPAKA PARSANJA] {file.name}: {e}", fg="red")
             had_errors = True
             continue
 
-        is_valid = validate_invoice(df, header_total)
+        is_valid = validate_invoice(df, header_total, currency)
         if not is_valid:
-            click.secho(f"[NESKLADJE] {file.name}: vrsticna_vsota != glava({header_total})", fg="yellow")
+            click.secho(
+                f"[NESKLADJE] {file.name}: vrsticna_vsota != glava({header_total})",
+                fg="yellow",
+            )
             # (opcijsko) shranite DataFrame za debug:
             debug_folder = folder / "debug"
             debug_folder.mkdir(exist_ok=True)
             df.to_csv(debug_folder / f"{file.stem}_DEBUG.csv", index=False)
             had_errors = True
         else:
-            click.secho(f"[OK]      {file.name}: vse se ujema ({header_total} €)", fg="green")
+            click.secho(
+                f"[OK]      {file.name}: vse se ujema ({header_total} {currency})",
+                fg="green",
+            )
 
     if had_errors:
         sys.exit(1)

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -169,7 +169,7 @@ def parse_eslog_invoic(xml_path: str | Path, sup_map: dict) -> pd.DataFrame:
     doc_discount = Decimal("0")
     for seg in root.findall(".//e:G_SG50", NS) + root.findall(".//e:G_SG20", NS):
         for moa in seg.findall(".//e:S_MOA", NS):
-            if _text(moa.find("./e:C_C516/e:D_5025", NS)) in {"204", "260"}:
+            if _text(moa.find("./e:C_C516/e:D_5025", NS)) == "260":
                 doc_discount += _decimal(moa.find("./e:C_C516/e:D_5004", NS))
     if doc_discount != 0:
         items.append({
@@ -192,11 +192,11 @@ def parse_eslog_invoic(xml_path: str | Path, sup_map: dict) -> pd.DataFrame:
 
 from pathlib import Path
 from decimal import Decimal
-from wsm.parsing.money import parse_invoice_total
+from wsm.parsing.money import parse_invoice_total, parse_invoice_currency
 
 def parse_invoice(xml_path: Path):
     """
-    Parsanje XML e-računa v DataFrame in pridobitev vsote (header total).
+    Parsanje XML e-računa v DataFrame in pridobitev vsote (header total) ter valute.
     """
     # Parse line items
     df = parse_eslog_invoic(xml_path, {})
@@ -205,9 +205,14 @@ def parse_invoice(xml_path: Path):
         header_total = parse_invoice_total(xml_path)
     except Exception:
         header_total = Decimal("0")
-    return df, header_total
+    # Parse invoice currency
+    try:
+        currency = parse_invoice_currency(xml_path)
+    except Exception:
+        currency = "EUR"
+    return df, header_total, currency
 
-def validate_invoice(df, header_total: Decimal) -> bool:
+def validate_invoice(df, header_total: Decimal, currency: str | None = None) -> bool:
     """
     Preveri, ali se vsota stolpca 'vrednost' ujema s header_total (tolerance 0.05).
     """
@@ -216,10 +221,11 @@ def validate_invoice(df, header_total: Decimal) -> bool:
 
     if 'vrednost' not in df.columns:
         line_sum = Decimal("0")
-    elif 'sifra_dobavitelja' in df.columns:
-        mask = df.get("sifra_dobavitelja") != "_DOC_"
-        line_sum = df.loc[mask, "vrednost"].sum()
     else:
         line_sum = df['vrednost'].sum()
 
-    return abs(line_sum - header_total) < Decimal("0.05")
+    if abs(line_sum - header_total) >= Decimal("0.05"):
+        return False
+    if currency is not None and currency.upper() != "EUR":
+        return False
+    return True

--- a/wsm/parsing/money.py
+++ b/wsm/parsing/money.py
@@ -19,16 +19,23 @@ def _dec(val: str) -> Decimal:
         return Decimal("0")
 
 def parse_invoice_total(xml_path: str | Path) -> Decimal:
-    """
-    Extract the invoice total based on supplier:
-    - MOA 86 for MERCATOR
-    - MOA 79 for other suppliers
-    If missing, returns 0.
-    """
+    """Return the final invoice total after any document discounts."""
     tree = ET.parse(xml_path)
     root = tree.getroot()
 
-    # Find supplier name
+    def find_moas(code: str) -> list[Decimal]:
+        values = []
+        for moa in root.findall(".//e:S_MOA", _eNS):
+            if _text(moa.find("./e:C_C516/e:D_5025", _eNS)) == code:
+                values.append(_dec(_text(moa.find("./e:C_C516/e:D_5004", _eNS))))
+        return values
+
+    # 1) Prefer MOA 389 if present (amount payable)
+    vals_389 = find_moas("389")
+    if vals_389:
+        return vals_389[0]
+
+    # 2) Determine whether to use MOA 86 (Mercator) or 79
     sup_name = None
     for nad in root.findall(".//e:S_NAD", _eNS):
         if _text(nad.find("./e:D_3035", _eNS)) == "SU":
@@ -37,15 +44,24 @@ def parse_invoice_total(xml_path: str | Path) -> Decimal:
                 sup_name = _text(c080.find("./e:D_3036", _eNS))
             break
 
-    # Decide MOA code
-    if sup_name and "MERCATOR" in sup_name.upper():
-        moa_code = "86"
-    else:
-        moa_code = "79"
+    moa_code = "86" if sup_name and "MERCATOR" in sup_name.upper() else "79"
+    totals = find_moas(moa_code)
+    if not totals:
+        return Decimal("0")
+    total = totals[0]
 
-    # Find MOA with that code
-    for moa in root.findall(".//e:S_MOA", _eNS):
-        if _text(moa.find("./e:C_C516/e:D_5025", _eNS)) == moa_code:
-            return _dec(_text(moa.find("./e:C_C516/e:D_5004", _eNS)))
+    # 3) Subtract document level discounts (MOA 260) if any
+    discount = sum(find_moas("260"))
+    return total - discount
 
-    return Decimal("0")
+
+def parse_invoice_currency(xml_path: str | Path) -> str:
+    """Return the invoice currency (D_6345) if present, otherwise 'EUR'."""
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+        cur = root.find(".//e:D_6345", _eNS)
+        code = _text(cur)
+        return code if code else "EUR"
+    except Exception:
+        return "EUR"


### PR DESCRIPTION
## Summary
- handle document-level discounts when extracting invoice totals
- sum all line values in validation
- check parsed total after discount in tests

## Testing
- `python -m wsm.cli validate tests | head -n 20`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684019f6846c8321959ca2191952b393