### PR TITLE
Fix invoice parsing and amount extraction

### DIFF
--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -213,8 +213,12 @@ def parse_invoice(source: str | Path):
     else:
         root = ET.fromstring(source)
 
-    # header_total z upoštevanim dokumentarnim popustom
-    header_total = extract_total_amount(root)
+    # InvoiceTotal brez upoštevanja dokumentarnega popusta
+    total_str = root.findtext("InvoiceTotal") or "0.00"
+    header_total = Decimal(total_str.replace(",", ".")).quantize(Decimal("0.01"))
+    # Za interno preverjanje lahko še vedno izračunamo končni znesek
+    # (InvoiceTotal - DocumentDiscount) – ne vračamo ga, a ostane na volji
+    _ = extract_total_amount(root)
 
     rows = []
     for li in root.findall("LineItems/LineItem"):

--- a/wsm/parsing/money.py
+++ b/wsm/parsing/money.py
@@ -9,8 +9,9 @@ def extract_total_amount(xml_root: ET.Element) -> Decimal:
     odšteje vrednost iz <DocumentDiscount>. Če <InvoiceTotal> ali
     <DocumentDiscount> manjkata, privzame 0.00.
     """
-    base_str = xml_root.findtext("InvoiceTotal") or "0.00"
-    discount_str = xml_root.findtext("DocumentDiscount") or "0.00"
+    # Poiščemo elementa kjer koli v drevesu, ne le neposredno pod korenom
+    base_str = xml_root.findtext(".//InvoiceTotal") or "0.00"
+    discount_str = xml_root.findtext(".//DocumentDiscount") or "0.00"
 
     # Pretvorimo iz niza z vejico v Decimal
     base = Decimal(base_str.replace(",", "."))


### PR DESCRIPTION
## Summary
- handle nested `<InvoiceTotal>` and `<DocumentDiscount>` values
- return the pre-discount invoice total in `parse_invoice`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403cabc46c8321a9aae0997feb7328