### PR TITLE
Use review_links in CLI

### DIFF
--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -76,13 +76,13 @@ def review(supplier_file):
     supplier_file mora biti pot do suppliers.xlsx.
     """
     try:
-        from wsm.ui.review_links import preveri_in_povezi
+        from wsm.ui.review_links import review_links
     except ImportError as ie:
-        click.echo(f"[NAPAKA] Ne morem uvoziti funkcije preveri_in_povezi: {ie}")
+        click.echo(f"[NAPAKA] Ne morem uvoziti funkcije review_links: {ie}")
         return
 
     try:
-        preveri_in_povezi(supplier_file)
+        review_links(supplier_file)
     except Exception as e:
         click.echo(f"[NAPAKA GUI] {e}")
 


### PR DESCRIPTION
## Summary
- swap import of `preveri_in_povezi` for `review_links`
- call `review_links` when running `wsm review`

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846956ea1f48321bb52472f3b5ccbed