### PR TITLE
Popravi prikaz skupnih zneskov

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -263,6 +263,7 @@ def review_links(df: pd.DataFrame, wsm_df: pd.DataFrame, links_file: Path, invoi
     log.debug(f"df po inicializaciji: {df.head().to_dict()}")
     
     df_doc = df[df["sifra_dobavitelja"] == "_DOC_"]
+    doc_discount_total = df_doc["vrednost"].sum()
     df = df[df["sifra_dobavitelja"] != "_DOC_"]
     df["cena_pred_rabatom"] = (df["vrednost"] + df["rabata"]) / df["kolicina"]
     df["cena_po_rabatu"] = df["vrednost"] / df["kolicina"]
@@ -365,7 +366,7 @@ def review_links(df: pd.DataFrame, wsm_df: pd.DataFrame, links_file: Path, invoi
 
     linked_total = df[df['wsm_sifra'].notna()]['total_net'].sum()
     unlinked_total = df[df['wsm_sifra'].isna()]['total_net'].sum()
-    total_sum = linked_total + unlinked_total
+    total_sum = linked_total + unlinked_total + doc_discount_total
     match_symbol = "✓" if abs(total_sum - invoice_total) < Decimal("0.01") else "✗"
     
     tk.Label(total_frame, text=f"Skupaj povezano: {_fmt(linked_total)} € + Skupaj ostalo: {_fmt(unlinked_total)} € = Skupni seštevek: {_fmt(total_sum)} € | Skupna vrednost računa: {_fmt(invoice_total)} € {match_symbol}", 
@@ -374,7 +375,7 @@ def review_links(df: pd.DataFrame, wsm_df: pd.DataFrame, links_file: Path, invoi
     def _update_totals():
         linked_total = df[df['wsm_sifra'].notna()]['total_net'].sum()
         unlinked_total = df[df['wsm_sifra'].isna()]['total_net'].sum()
-        total_sum = linked_total + unlinked_total
+        total_sum = linked_total + unlinked_total + doc_discount_total
         match_symbol = "✓" if abs(total_sum - invoice_total) < Decimal("0.01") else "✗"
         total_frame.children['total_sum'].config(text=f"Skupaj povezano: {_fmt(linked_total)} € + Skupaj ostalo: {_fmt(unlinked_total)} € = Skupni seštevek: {_fmt(total_sum)} € | Skupna vrednost računa: {_fmt(invoice_total)} € {match_symbol}")
 


### PR DESCRIPTION
## Notes
- Adjust totals in review GUI to include document-level discount when comparing to invoice total.

## Summary
- capture document-level discount before dropping `_DOC_` row
- compute `total_sum` including the discount for correct match with invoice value

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469960fccc8321b9f4a0c65185c86b