### PR TITLE
Handle Decimal values throughout parsing

### DIFF
--- a/wsm/discounts.py
+++ b/wsm/discounts.py
@@ -1,14 +1,19 @@
+from decimal import Decimal
+
+
 def calculate_discounts(items):
-    total = 0.0
-    total_discount = 0.0
+    """Return total value and total discount for a list of invoice items."""
+    total = Decimal("0")
+    total_discount = Decimal("0")
 
     for item in items:
-        price = float(item['cena'])
-        qty = float(item['kolicina'])
-        discount = float(item.get('rabata', 0))
+        price = Decimal(str(item['cena']))
+        qty = Decimal(str(item['kolicina']))
+        discount = Decimal(str(item.get('rabata', 0)))
 
         total_item_value = (price * qty) - discount
         total += total_item_value
         total_discount += discount
 
     return total, total_discount
+

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -264,7 +264,8 @@ def parse_invoice(source: str | Path):
     """
     Parsira e-račun (ESLOG INVOIC) iz XML ali PDF (če je implementirano).
     Vrne:
-      • df: DataFrame s vrsticami in stolpci ['cena_netto','kolicina','rabata_pct','izracunana_vrednost']
+      • df: DataFrame s stolpci ['cena_netto','kolicina','rabata_pct','izracunana_vrednost']
+        (vrednosti so Decimal v object stolpcih)
       • header_total: Decimal (InvoiceTotal – DocumentDiscount)
     Uporablja se v CLI (wsm/cli.py).
     """
@@ -280,11 +281,11 @@ def parse_invoice(source: str | Path):
         df_items = parse_eslog_invoice(source, {})
         header_total = extract_header_net(Path(source) if isinstance(source, (str, Path)) else source)
         df = pd.DataFrame({
-            'cena_netto': df_items['cena_netto'].astype(float),
-            'kolicina': df_items['kolicina'].astype(float),
-            'rabata_pct': df_items['rabata_pct'].astype(float),
-            'izracunana_vrednost': df_items['vrednost'].astype(float),
-        })
+            'cena_netto': df_items['cena_netto'],
+            'kolicina': df_items['kolicina'],
+            'rabata_pct': df_items['rabata_pct'],
+            'izracunana_vrednost': df_items['vrednost'],
+        }, dtype=object)
         return df, header_total
 
     # izvzamemo glavo (InvoiceTotal – DocumentDiscount)
@@ -308,10 +309,10 @@ def parse_invoice(source: str | Path):
         ).quantize(Decimal("0.01"), ROUND_HALF_UP)
 
         rows.append({
-            "cena_netto":           float(cena),
-            "kolicina":             float(kolic),
-            "rabata_pct":           float(rabata_pct),
-            "izracunana_vrednost":  float(izracun_val),
+            "cena_netto":           cena,
+            "kolicina":             kolic,
+            "rabata_pct":           rabata_pct,
+            "izracunana_vrednost":  izracun_val,
         })
 
     # Če ni nobenih vrstic, naredimo prazen DataFrame z ustreznimi stolpci
@@ -320,7 +321,7 @@ def parse_invoice(source: str | Path):
             "cena_netto", "kolicina", "rabata_pct", "izracunana_vrednost"
         ])
     else:
-        df = pd.DataFrame(rows)
+        df = pd.DataFrame(rows, dtype=object)
 
     return df, header_total
 

--- a/wsm/parsing/money.py
+++ b/wsm/parsing/money.py
@@ -21,10 +21,10 @@ def extract_line_items(xml_root: ET.Element) -> pd.DataFrame:
     Iz <LineItems> vsak <LineItem> prebere 'PriceNet', 'Quantity', 'DiscountPct'
     in izračuna izracunana_vrednost = price_net * quantity * (1 - discount_pct/100).
     Vrne DataFrame s stolpci:
-      - cena_netto (float)
-      - kolicina   (float)
-      - rabata_pct (float)
-      - izracunana_vrednost (float)
+      - cena_netto (Decimal)
+      - kolicina   (Decimal)
+      - rabata_pct (Decimal)
+      - izracunana_vrednost (Decimal)
     """
     rows = []
     for li in xml_root.findall("LineItems/LineItem"):
@@ -41,13 +41,13 @@ def extract_line_items(xml_root: ET.Element) -> pd.DataFrame:
         ).quantize(Decimal("0.01"))
 
         rows.append({
-            "cena_netto": float(cena),
-            "kolicina": float(kolic),
-            "rabata_pct": float(rabata_pct),
-            "izracunana_vrednost": float(izracun_val),
+            "cena_netto": cena,
+            "kolicina": kolic,
+            "rabata_pct": rabata_pct,
+            "izracunana_vrednost": izracun_val,
         })
 
-    return pd.DataFrame(rows)
+    return pd.DataFrame(rows, dtype=object)
 
 def validate_invoice(df: pd.DataFrame, header_total: Decimal) -> bool:
     """


### PR DESCRIPTION
## Summary
- retain `Decimal` types in parsed invoice DataFrames
- keep decimals when extracting simple invoices
- ensure monetary calculations in `calculate_discounts` work with `Decimal`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b9166b008321ad6369676d2a1658