### PR TITLE
Add high precision invoice test

### DIFF
--- a/tests/test_decimal_precision.py
+++ b/tests/test_decimal_precision.py
@@ -1,0 +1,26 @@
+import pytest
+from decimal import Decimal
+from wsm.parsing.eslog import parse_invoice
+
+
+def test_parse_invoice_high_precision_values():
+    xml = (
+        "<Invoice>"
+        "  <InvoiceTotal>131.9999</InvoiceTotal>"
+        "  <LineItems>"
+        "    <LineItem>"
+        "      <PriceNet>50.5555</PriceNet>"
+        "      <Quantity>1</Quantity>"
+        "      <DiscountPct>0.00</DiscountPct>"
+        "    </LineItem>"
+        "    <LineItem>"
+        "      <PriceNet>81.4444</PriceNet>"
+        "      <Quantity>1</Quantity>"
+        "      <DiscountPct>0.00</DiscountPct>"
+        "    </LineItem>"
+        "  </LineItems>"
+        "</Invoice>"
+    )
+    df, header_total = parse_invoice(xml)
+    assert header_total == Decimal("132.00")
+    assert sum(df["izracunana_vrednost"]) == Decimal("132.00")


### PR DESCRIPTION
## Summary
- add test for parse_invoice with values having more than two decimals

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846bce559f08321835bd18ac25c7b36