### PR TITLE
Add documentation to discounts module

### DIFF
--- a/wsm/discounts.py
+++ b/wsm/discounts.py
@@ -1,8 +1,34 @@
+"""Utilities for calculating invoice totals and discounts.
+
+Each element of ``items`` should be a mapping (e.g. ``dict`` or
+``pandas.Series``) containing at least the following keys:
+
+  - ``cena``     – unit price
+  - ``kolicina`` – quantity
+  - ``rabata``   – line level discount (optional, defaults to ``0``)
+
+The :func:`calculate_discounts` function returns a tuple of ``Decimal`` values:
+``(total_value, total_discount)``.
+"""
 from decimal import Decimal
 
 
 def calculate_discounts(items):
-    """Return total value and total discount for a list of invoice items."""
+    """Compute totals from invoice line items.
+
+    Parameters
+    ----------
+    items : Iterable[Mapping]
+        Collection of line items.  Each mapping must provide ``cena`` and
+        ``kolicina`` values and may provide ``rabata`` for the line discount.
+
+    Returns
+    -------
+    tuple[Decimal, Decimal]
+        ``(total_value, total_discount)`` where ``total_value`` is the sum of
+        item values after discounts and ``total_discount`` is the aggregated
+        discount amount.
+    """
     total = Decimal("0")
     total_discount = Decimal("0")
 


### PR DESCRIPTION
## Summary
- document invoice calculation utilities
- expand `calculate_discounts` explanation of inputs and returns

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846bee1974c832188dc67f2fdf0a854