### PR TITLE
Add analyze_invoice integration test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_analyze_invoice.py
+++ b/tests/test_analyze_invoice.py
@@ -1,0 +1,23 @@
+from decimal import Decimal
+from pathlib import Path
+
+from wsm import analyze
+from wsm.parsing.eslog import extract_header_net
+
+
+def test_analyze_invoice_merges_duplicates():
+    path = Path("tests/CUSTOMERINVOICES_2025-04-01T14-29-47_2081078.xml")
+    df, total, ok = analyze.analyze_invoice(path)
+
+    # Item 00002122 appears three times with the same discount; should be merged
+    row = df[(df["sifra_artikla"] == "00002122") & (df["rabata_pct"] == Decimal("4.99"))].iloc[0]
+    assert row["kolicina"] == Decimal("72.00")
+    assert row["vrednost"] == Decimal("50.25")
+
+    # Another repeated item with weight normalization
+    row2 = df[(df["sifra_artikla"] == "5998710960798") & (df["rabata_pct"] == Decimal("5.04"))].iloc[0]
+    assert row2["kolicina"] == Decimal("3.200")
+    assert row2["vrednost"] == Decimal("23.76")
+
+    assert total == extract_header_net(path)
+    assert ok


### PR DESCRIPTION
## Summary
- add conftest to put repository root on `sys.path`
- add integration test that loads a sample invoice and verifies `analyze_invoice` merges repeated items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d648fcbc832197bce2f9caefa47f