### PR TITLE
Support document-wide discount in totals

### DIFF
--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -1,0 +1,16 @@
+from decimal import Decimal
+
+from wsm.discounts import calculate_discounts
+
+
+def test_calculate_discounts_with_doc_discount():
+    items = [
+        {"cena": Decimal("10"), "kolicina": 2, "rabata": Decimal("1")},
+        {"cena": Decimal("5"), "kolicina": 1, "rabata": Decimal("0")},
+    ]
+
+    total, discount = calculate_discounts(items, doc_discount=Decimal("3"))
+
+    assert total == Decimal("21")
+    assert discount == Decimal("4")
+

--- a/wsm/discounts.py
+++ b/wsm/discounts.py
@@ -13,7 +13,7 @@ The :func:`calculate_discounts` function returns a tuple of ``Decimal`` values:
 from decimal import Decimal
 
 
-def calculate_discounts(items):
+def calculate_discounts(items, doc_discount: Decimal = Decimal("0")):
     """Compute totals from invoice line items.
 
     Parameters
@@ -21,6 +21,9 @@ def calculate_discounts(items):
     items : Iterable[Mapping]
         Collection of line items.  Each mapping must provide ``cena`` and
         ``kolicina`` values and may provide ``rabata`` for the line discount.
+    doc_discount : Decimal, optional
+        Discount applied on the whole document level.  It is subtracted from
+        the final total and added to ``total_discount``.  Defaults to ``0``.
 
     Returns
     -------
@@ -31,6 +34,7 @@ def calculate_discounts(items):
     """
     total = Decimal("0")
     total_discount = Decimal("0")
+    doc_discount = Decimal(str(doc_discount))
 
     for item in items:
         price = Decimal(str(item['cena']))
@@ -40,6 +44,9 @@ def calculate_discounts(items):
         total_item_value = (price * qty) - discount
         total += total_item_value
         total_discount += discount
+
+    total -= doc_discount
+    total_discount += doc_discount
 
     return total, total_discount
 


### PR DESCRIPTION
## Summary
- extend `calculate_discounts` with `doc_discount`
- adjust totals calculation to subtract the document discount
- document parameter and its effect
- test document level discount handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e8cebc088321bf807b77207272dc