### PR TITLE
Fix document discount summing

### DIFF
--- a/tests/test_parse_eslog_document_discount.py
+++ b/tests/test_parse_eslog_document_discount.py
@@ -22,11 +22,10 @@ def _compute_doc_discount(xml_path: Path) -> Decimal:
                 amt = Decimal((val_el.text or "0").replace(",", "."))
                 discounts[code] += amt.quantize(Decimal("0.01"), ROUND_HALF_UP)
 
-    doc_discount = Decimal("0")
-    for code in DEFAULT_DOC_DISCOUNT_CODES:
-        if discounts.get(code):
-            doc_discount = discounts[code]
-            break
+    # Sum all matching discount codes
+    doc_discount = sum(
+        (discounts.get(code) or Decimal("0")) for code in DEFAULT_DOC_DISCOUNT_CODES
+    )
     return doc_discount.quantize(Decimal("0.01"), ROUND_HALF_UP)
 
 
@@ -64,5 +63,35 @@ def test_parse_eslog_invoice_handles_additional_discount_codes(tmp_path):
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
     assert doc_row["vrednost"] == Decimal("-2.50")
+    assert doc_row["rabata_pct"] == Decimal("100.00")
+
+
+def test_parse_eslog_invoice_sums_multiple_discount_codes(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>0001</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>204</D_5025><D_5004>1.50</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>260</D_5025><D_5004>2.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    xml_path = tmp_path / "disc_multi.xml"
+    xml_path.write_text(xml)
+
+    df = parse_eslog_invoice(xml_path, {})
+    doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
+
+    assert doc_row["vrednost"] == Decimal("-3.50")
     assert doc_row["rabata_pct"] == Decimal("100.00")
 

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -258,12 +258,10 @@ def parse_eslog_invoice(
                     .quantize(Decimal("0.01"), ROUND_HALF_UP)
                 )
 
-    doc_discount = Decimal("0")
-    for code in discount_codes:
-        if discounts.get(code):
-            doc_discount = discounts[code]
-            break
-    doc_discount = doc_discount.quantize(Decimal("0.01"), ROUND_HALF_UP)
+    # Sum all discount code amounts instead of only the first
+    doc_discount = sum(
+        (discounts.get(code) or Decimal("0")) for code in discount_codes
+    ).quantize(Decimal("0.01"), ROUND_HALF_UP)
 
 
     if doc_discount != 0:


### PR DESCRIPTION
## Summary
- sum all discount codes when calculating document discount in `parse_eslog_invoice`
- adjust helper in tests
- add regression test for multiple discount codes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847f44e50548321a920bf2d0be467db