### PR TITLE
Add automatic keyword extraction from manual links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
    ```
    Program odpre grafični vmesnik, kjer povezave shranjujete v podmapo
    `links/<ime_dobavitelja>/`. Posodobljene tabele najdete v datotekah
-   `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
+  `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
+
+Pri samodejnem povezovanju lahko program iz teh ročno
+shranjenih datotek sam izdela datoteko `keywords.xlsx`.
+Če ta datoteka ne obstaja, jo funkcija `povezi_z_wsm`
+samodejno napolni z najpogostejšimi izrazi iz `*_povezane.xlsx`.
 
 5. Analizo in združevanje postavk lahko izvedete z:
    ```bash

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,0 +1,53 @@
+import pandas as pd
+from pathlib import Path
+
+from wsm.utils import extract_keywords, povezi_z_wsm
+
+
+def _setup_manual_links(tmp_path: Path) -> Path:
+    links_dir = tmp_path / "links"
+    supplier_dir = links_dir / "Test"
+    supplier_dir.mkdir(parents=True)
+    df = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP", "SUP", "SUP", "SUP"],
+        "naziv": ["Coca Cola 1L", "Coca Cola Zero 2L", "Fanta Orange 1L", "Sprite 1L"],
+        "naziv_ckey": ["", "", "", ""],
+        "wsm_sifra": ["100", "100", "200", "300"],
+    })
+    path = supplier_dir / "SUP_Test_povezane.xlsx"
+    df.to_excel(path, index=False)
+
+    suppliers = pd.DataFrame({"sifra": ["SUP"], "ime": ["Test"], "override_H87_to_kg": [False]})
+    suppliers.to_excel(links_dir / "suppliers.xlsx", index=False)
+
+    return links_dir
+
+
+def test_extract_keywords(tmp_path):
+    links_dir = _setup_manual_links(tmp_path)
+    keywords_path = tmp_path / "keywords.xlsx"
+
+    kw_df = extract_keywords(links_dir, keywords_path)
+    assert keywords_path.exists()
+    tokens = set(kw_df[kw_df["wsm_sifra"] == "100"]["keyword"].tolist())
+    assert "coca" in tokens
+    assert "cola" in tokens
+
+
+def test_povezi_z_wsm_autolearn(tmp_path):
+    links_dir = _setup_manual_links(tmp_path)
+    sifre_path = tmp_path / "sifre_wsm.xlsx"
+    pd.DataFrame({"wsm_sifra": ["100"], "wsm_naziv": ["Coca Cola"]}).to_excel(sifre_path, index=False)
+
+    keywords_path = tmp_path / "keywords.xlsx"  # non-existent
+
+    df_items = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP"],
+        "naziv": ["Coca Cola Zero Sugar 0.5L"],
+    })
+
+    result = povezi_z_wsm(df_items, str(sifre_path), str(keywords_path), links_dir, "SUP")
+    assert result.loc[0, "wsm_sifra"] == "100"
+    assert result.loc[0, "status"] == "KLJUCNA_BES"
+    assert keywords_path.exists()
+


### PR DESCRIPTION
## Summary
- implement `extract_keywords` to build keywords from existing *_povezane.xlsx files
- auto-create and refresh `keywords.xlsx` when missing in `povezi_z_wsm`
- test keyword extraction and automatic usage
- document automatic keyword learning in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847fab4901c8321840be1ecbf1d1dbf