### PR TITLE
Allow GUI to load WSM codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
    `links/<ime_dobavitelja>/`. Posodobljene tabele najdete v datotekah
   `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
 
+Datoteka `sifre_wsm.xlsx` z vsemi WSM šiframi naj bo v korenu projekta,
+da jo GUI ob zagonu samodejno prebere.
+
 Pri samodejnem povezovanju lahko program iz teh ročno
 shranjenih datotek sam izdela datoteko `keywords.xlsx`.
 Če ta datoteka ne obstaja, jo funkcija `povezi_z_wsm`

--- a/wsm/run.py
+++ b/wsm/run.py
@@ -58,8 +58,17 @@ def _open_gui(invoice_path: Path) -> None:
     links_dir.mkdir(exist_ok=True)
     links_file = links_dir / f"{supplier_code}_povezave.xlsx"
 
-    # WSM codes are optional; start with an empty table
-    wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+    # WSM codes are optional; try to load them from sifre_wsm.xlsx
+    sifre_file = Path("sifre_wsm.xlsx")
+    if sifre_file.exists():
+        try:
+            wsm_df = pd.read_excel(sifre_file, dtype=str)
+        except Exception as exc:
+            logging.warning(f"Napaka pri branju {sifre_file}: {exc}")
+            wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+    else:
+        wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+
     review_links(df, wsm_df, links_file, total)
 
 


### PR DESCRIPTION
## Summary
- enable loading `sifre_wsm.xlsx` in GUI mode
- document where to place the WSM codes file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ffc8a0ec8321911c9b920a8f7531