### PR TITLE
Update review command to parse invoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,17 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
    ```
    kjer `<mapa_z_racuni>` vsebuje XML ali PDF datoteke z e‑računi.
 
-4. Za ročno povezovanje WSM šifer uporabite ukaz:
+4. Za ročno povezovanje WSM šifer podajte pot do računa:
    ```bash
-   python -m wsm.cli review links/suppliers.xlsx
+   python -m wsm.cli review <invoice.xml>
    ```
+   (po želji dodajte `--wsm-codes pot/do/sifre_wsm.xlsx`)
    Program odpre grafični vmesnik, kjer povezave shranjujete v podmapo
    `links/<ime_dobavitelja>/`. Posodobljene tabele najdete v datotekah
   `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
 
-Datoteka `sifre_wsm.xlsx` z vsemi WSM šiframi naj bo v korenu projekta,
-da jo GUI ob zagonu samodejno prebere.
+Če `--wsm-codes` ni podan, program poskuša prebrati `sifre_wsm.xlsx` v
+korenu projekta.
 
 Pri samodejnem povezovanju lahko program iz teh ročno
 shranjenih datotek sam izdela datoteko `keywords.xlsx`.

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -1,9 +1,11 @@
 # File: wsm/cli.py
 import click
+import pandas as pd
 from pathlib import Path
 from decimal import Decimal
 
 from wsm.parsing.eslog import parse_invoice, validate_invoice
+from wsm.parsing.pdf import parse_pdf
 from wsm.analyze import analyze_invoice
 
 @click.group()
@@ -69,20 +71,56 @@ def analyze(invoice, suppliers):
     click.echo(f"{status}: vsota vrstic {total:.2f} €")
 
 @main.command()
-@click.argument("supplier_file", type=click.Path(exists=True))
-def review(supplier_file):
-    """
-    Zaženi GUI za povezovanje šifer glede na dobavnice. 
-    supplier_file mora biti pot do suppliers.xlsx.
-    """
+@click.argument("invoice", type=click.Path(exists=True))
+@click.option(
+    "--wsm-codes",
+    type=click.Path(exists=True),
+    default=None,
+    help="Pot do sifre_wsm.xlsx",
+)
+def review(invoice, wsm_codes):
+    """Odpri GUI za ročno povezovanje WSM šifer."""
     try:
         from wsm.ui.review_links import review_links
     except ImportError as ie:
         click.echo(f"[NAPAKA] Ne morem uvoziti funkcije review_links: {ie}")
         return
 
+    invoice_path = Path(invoice)
     try:
-        review_links(supplier_file)
+        if invoice_path.suffix.lower() == ".xml":
+            df, total, _ = analyze_invoice(str(invoice_path))
+        elif invoice_path.suffix.lower() == ".pdf":
+            df = parse_pdf(str(invoice_path))
+            total = df.get("vrednost", pd.Series(dtype=float)).sum()
+            if "rabata" not in df.columns:
+                df["rabata"] = Decimal("0")
+        else:
+            click.echo(f"[NAPAKA] Nepodprta datoteka: {invoice}")
+            return
+    except Exception as e:
+        click.echo(f"[NAPAKA PARSANJA] {e}")
+        return
+
+    supplier_code = df["sifra_dobavitelja"].iloc[0] if not df.empty else "unknown"
+    links_dir = Path("links")
+    links_dir.mkdir(exist_ok=True)
+    links_file = links_dir / f"{supplier_code}_povezave.xlsx"
+
+    sifre_path = Path(wsm_codes) if wsm_codes else Path("sifre_wsm.xlsx")
+    if sifre_path.exists():
+        try:
+            wsm_df = pd.read_excel(sifre_path, dtype=str)
+        except Exception as exc:
+            click.echo(f"[NAPAKA] Napaka pri branju {sifre_path}: {exc}")
+            wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+    else:
+        if wsm_codes:
+            click.echo(f"[NAPAKA] Datoteka {sifre_path} ne obstaja.")
+        wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+
+    try:
+        review_links(df, wsm_df, links_file, total)
     except Exception as e:
         click.echo(f"[NAPAKA GUI] {e}")
 


### PR DESCRIPTION
## Summary
- allow `review` CLI command to accept an invoice path and optional WSM codes path
- parse XML or PDF invoices and launch GUI with `review_links`
- show helpful errors if files are missing
- document new usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684800c1eba88321a632a7814c1ce354