### PR TITLE
Enable fullscreen GUI

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -297,8 +297,9 @@ def review_links(df: pd.DataFrame, wsm_df: pd.DataFrame, links_file: Path, invoi
 
     root = tk.Tk()
     root.title(f"Ročna revizija – {supplier_name}")
-    # Slightly smaller default window size
-    root.geometry("1080x800")
+    # Start in fullscreen; press Esc to exit
+    root.attributes("-fullscreen", True)
+    root.bind("<Escape>", lambda e: root.attributes("-fullscreen", False))
 
     frame = tk.Frame(root)
     frame.pack(fill="both", expand=True)


### PR DESCRIPTION
## Summary
- default the review GUI to open in fullscreen
- Escape exits fullscreen mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848075b75808321bb986dcf7da6b3f1