### PR TITLE
Add service date tracking

### DIFF
--- a/tests/test_service_date.py
+++ b/tests/test_service_date.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from wsm.parsing.eslog import extract_service_date
+
+
+def test_extract_service_date_delivery():
+    xml = Path("tests/CUSTOMERINVOICES_2025-04-01T14-29-47_2081078.xml")
+    assert extract_service_date(xml) == "2025-03-31"
+
+
+def test_extract_service_date_fallback():
+    xml = Path("tests/VP2025-1799-racun.xml")
+    assert extract_service_date(xml) == "2025-03-06"

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -120,7 +120,7 @@ def review(invoice, wsm_codes):
         wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
 
     try:
-        review_links(df, wsm_df, links_file, total)
+        review_links(df, wsm_df, links_file, total, Path(invoice))
     except Exception as e:
         click.echo(f"[NAPAKA GUI] {e}")
 

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -98,6 +98,26 @@ def extract_header_net(xml_path: Path | str) -> Decimal:
         pass
     return Decimal('0')
 
+# ───────────────────── datum opravljene storitve ─────────────────────
+def extract_service_date(xml_path: Path | str) -> str | None:
+    """Vrne datum opravljene storitve (DTM 35) ali datum računa (DTM 137)."""
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+        for dtm in root.findall('.//e:S_DTM', NS):
+            if _text(dtm.find('./e:C_C507/e:D_2005', NS)) == '35':
+                date = _text(dtm.find('./e:C_C507/e:D_2380', NS))
+                if date:
+                    return date
+        for dtm in root.findall('.//e:S_DTM', NS):
+            if _text(dtm.find('./e:C_C507/e:D_2005', NS)) == '137':
+                date = _text(dtm.find('./e:C_C507/e:D_2380', NS))
+                if date:
+                    return date
+    except Exception:
+        pass
+    return None
+
 # ──────────────────── glavni parser za ESLOG INVOIC ────────────────────
 def parse_eslog_invoice(
     xml_path: str | Path,

--- a/wsm/run.py
+++ b/wsm/run.py
@@ -69,7 +69,7 @@ def _open_gui(invoice_path: Path) -> None:
     else:
         wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
 
-    review_links(df, wsm_df, links_file, total)
+    review_links(df, wsm_df, links_file, total, invoice_path)
 
 
 def main() -> None:

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -225,11 +225,13 @@ def log_price_history(
     df: pd.DataFrame,
     history_file: Union[str, Path],
     *,
+    service_date: str | None = None,
     max_entries_per_code: int = 50
 ) -> None:
     """
-    Zapiše zgodovino cen v links/<ime_dobavitelja>/price_history.xlsx.
-    Shrani edinstven identifikator artikla (sifra_dobavitelja + naziv), ceno in čas.
+    Zapiše zgodovino cen v ``links/<ime_dobavitelja>/price_history.xlsx``.
+    Shranjeni so identifikator artikla (``sifra_dobavitelja + naziv``), cena,
+    trenutni čas in opcijsko datum opravljene storitve.
     """
     suppliers_file = Path("links") / "suppliers.xlsx"
     sup_map = _load_supplier_map(suppliers_file)
@@ -248,6 +250,7 @@ def log_price_history(
     df_hist = df_hist[["key", "cena_bruto"]].copy()
     df_hist.columns = ["key", "cena"]
     df_hist["time"] = pd.Timestamp.now()
+    df_hist["service_date"] = service_date
 
     # Preveri, ali so podatki pravilni
     if df_hist["key"].isna().any() or df_hist["key"].str.strip().eq("").any():


### PR DESCRIPTION
## Summary
- add `extract_service_date` to read service/delivery dates from invoices
- store optional `service_date` when logging price history
- log price history when closing the review GUI
- propagate invoice path through CLI/GUI entry points
- test service date extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848154160848321bd7da501e4f35de1