### PR TITLE
Per-supplier settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
    python -m wsm.cli review <invoice.xml>
    ```
    (po želji dodajte `--wsm-codes pot/do/sifre_wsm.xlsx`)
-   Program odpre grafični vmesnik, kjer povezave shranjujete v podmapo
-   `links/<ime_dobavitelja>/`. Posodobljene tabele najdete v datotekah
-  `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
+  Program odpre grafični vmesnik, kjer povezave shranjujete v podmapo
+  `links/<ime_dobavitelja>/`. Posodobljene tabele najdete v datotekah
+ `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
+  V isti mapi je tudi datoteka `supplier.json`, ki vsebuje ime
+  dobavitelja in nastavitev `override_H87_to_kg`.
 
 Če `--wsm-codes` ni podan, program poskuša prebrati `sifre_wsm.xlsx` v
 korenu projekta.
@@ -56,7 +58,7 @@ samodejno napolni z najpogostejšimi izrazi iz `*_povezane.xlsx`.
 
 5. Analizo in združevanje postavk lahko izvedete z:
    ```bash
-   python -m wsm.cli analyze <invoice.xml> --suppliers links/suppliers.xlsx
+   python -m wsm.cli analyze <invoice.xml> --suppliers links
    ```
    Ukaz izpiše povzetek po WSM šifrah in preveri, ali se vsota ujema z
    vrednostjo na računu.

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -2,6 +2,7 @@ import pandas as pd
 from pathlib import Path
 
 from wsm.utils import extract_keywords, povezi_z_wsm
+import json
 
 
 def _setup_manual_links(tmp_path: Path) -> Path:
@@ -17,8 +18,8 @@ def _setup_manual_links(tmp_path: Path) -> Path:
     path = supplier_dir / "SUP_Test_povezane.xlsx"
     df.to_excel(path, index=False)
 
-    suppliers = pd.DataFrame({"sifra": ["SUP"], "ime": ["Test"], "override_H87_to_kg": [False]})
-    suppliers.to_excel(links_dir / "suppliers.xlsx", index=False)
+    info = {"sifra": "SUP", "ime": "Test", "override_H87_to_kg": False}
+    (supplier_dir / "supplier.json").write_text(json.dumps(info))
 
     return links_dir
 

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -63,7 +63,7 @@ def _validate_file(file_path: Path):
 
 @main.command()
 @click.argument("invoice", type=click.Path(exists=True))
-@click.option("--suppliers", type=click.Path(exists=True), default=None, help="Pot do suppliers.xlsx")
+@click.option("--suppliers", type=click.Path(exists=True), default=None, help="Mapa z dobavitelji ali legacy suppliers.xlsx")
 def analyze(invoice, suppliers):
     """Prikaži združene postavke in preveri seštevek."""
     df, total, ok = analyze_invoice(invoice, suppliers)

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -128,7 +128,7 @@ def load_wsm_data(
     else:
         kw_df = kw_all[["wsm_sifra", "keyword"]] if "keyword" in kw_all.columns else pd.DataFrame(columns=["wsm_sifra", "keyword"])
 
-    suppliers_file = links_dir / "suppliers.xlsx"
+    suppliers_file = links_dir
     sup_map = _load_supplier_map(suppliers_file)
     
     supplier_info = sup_map.get(supplier_code, {})
@@ -198,7 +198,7 @@ def povezi_z_wsm(
 
     # če so novosti → posodobi datoteko povezav
     if new_links:
-        suppliers_file = links_dir / "suppliers.xlsx"
+        suppliers_file = links_dir
         sup_map = _load_supplier_map(suppliers_file)
         supplier_info = sup_map.get(supplier_code, {})
         supplier_name = supplier_info.get('ime', supplier_code) if isinstance(supplier_info, dict) else supplier_code
@@ -233,7 +233,7 @@ def log_price_history(
     Shranjeni so identifikator artikla (``sifra_dobavitelja + naziv``), cena,
     trenutni čas in opcijsko datum opravljene storitve.
     """
-    suppliers_file = Path("links") / "suppliers.xlsx"
+    suppliers_file = Path("links")
     sup_map = _load_supplier_map(suppliers_file)
 
     df["supplier_name"] = df["sifra_dobavitelja"].apply(


### PR DESCRIPTION
## Summary
- store supplier info in `links/<dobavitelj>/supplier.json`
- support reading the legacy `suppliers.xlsx` file for backwards compatibility
- update CLI help and README
- adjust tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849323780048321997be516530cb823