### PR TITLE
Enable setting override_H87_to_kg via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,14 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
   Program odpre grafični vmesnik, kjer povezave shranjujete v podmapo
   `links/<ime_dobavitelja>/`. Posodobljene tabele najdete v datotekah
  `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
-  V isti mapi je tudi datoteka `supplier.json`, ki vsebuje ime
-  dobavitelja in nastavitev `override_H87_to_kg`.
+ V isti mapi je tudi datoteka `supplier.json`, ki vsebuje ime
+ dobavitelja in nastavitev `override_H87_to_kg`.
+ Nastavitev lahko spremenite z ukazom:
+ ```bash
+ python -m wsm.cli override SUP --set
+ ```
+ kjer `SUP` zamenjajte z želeno šifro dobavitelja
+ (namesto `--set` uporabite `--unset` za izklop).
 
 Če `--wsm-codes` ni podan, program poskuša prebrati `sifre_wsm.xlsx` v
 korenu projekta.

--- a/tests/test_cli_override.py
+++ b/tests/test_cli_override.py
@@ -1,0 +1,61 @@
+import json
+from decimal import Decimal
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from wsm.cli import main
+from wsm import analyze
+
+
+XML = (
+    "<Invoice xmlns='urn:eslog:2.00'>"
+    "  <M_INVOIC>"
+    "    <G_SG2>"
+    "      <S_NAD>"
+    "        <D_3035>SE</D_3035>"
+    "        <C_C082><D_3039>SUP</D_3039></C_C082>"
+    "        <C_C080><D_3036>Test</D_3036></C_C080>"
+    "      </S_NAD>"
+    "    </G_SG2>"
+    "    <G_SG26>"
+    "      <S_QTY><C_C186><D_6060>2.5</D_6060><D_6411>H87</D_6411></C_C186></S_QTY>"
+    "      <S_LIN><C_C212><D_7140>0001</D_7140></C_C212></S_LIN>"
+    "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+    "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>4</D_5118></C_C509></S_PRI>"
+    "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+    "    </G_SG26>"
+    "    <G_SG50>"
+    "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+    "    </G_SG50>"
+    "  </M_INVOIC>"
+    "</Invoice>"
+)
+
+
+def test_cli_override(tmp_path):
+    links = tmp_path / "links"
+    supplier_dir = links / "Test"
+    supplier_dir.mkdir(parents=True)
+
+    info = {"sifra": "SUP", "ime": "Test", "override_H87_to_kg": False}
+    (supplier_dir / "supplier.json").write_text(json.dumps(info))
+
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        "override", "SUP", "--suppliers", str(links), "--set"
+    ])
+    assert result.exit_code == 0
+
+    data = json.loads((supplier_dir / "supplier.json").read_text())
+    assert data["override_H87_to_kg"] is True
+
+    xml_path = tmp_path / "invoice.xml"
+    xml_path.write_text(XML)
+
+    df, total, ok = analyze.analyze_invoice(xml_path, str(links))
+    row = df[df["sifra_dobavitelja"] == "SUP"].iloc[0]
+    assert row["enota"] == "kg"
+    assert row["kolicina"] == Decimal("2.5")
+    assert total == Decimal("10")
+    assert ok

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -132,5 +132,32 @@ def review(invoice, wsm_codes):
     except Exception as e:
         click.echo(f"[NAPAKA GUI] {e}")
 
+
+@main.command(name="override")
+@click.argument("supplier_code")
+@click.option(
+    "--suppliers",
+    type=click.Path(),
+    default="links",
+    help="Mapa z dobavitelji ali legacy suppliers.xlsx",
+)
+@click.option("--set", "override", flag_value=True, help="Omogoči pretvorbo H87 v kg")
+@click.option("--unset", "override", flag_value=False, help="Onemogoči pretvorbo H87 v kg")
+def override_cmd(supplier_code, suppliers, override):
+    """Uredi nastavitev ``override_H87_to_kg`` za dobavitelja."""
+    if override is None:
+        click.echo("Uporabite --set ali --unset za nastavitev vrednosti.")
+        return
+
+    from wsm.ui.review_links import _load_supplier_map, _write_supplier_map
+
+    sup_file = Path(suppliers)
+    sup_map = _load_supplier_map(sup_file)
+    info = sup_map.get(supplier_code, {"ime": supplier_code, "override_H87_to_kg": False})
+    info["override_H87_to_kg"] = override
+    sup_map[supplier_code] = info
+    _write_supplier_map(sup_map, sup_file)
+    click.echo(f"{supplier_code}: override_H87_to_kg = {override}")
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add new `override` command in CLI for editing supplier flag
- persist override updates in GUI save routine
- document how to change `override_H87_to_kg`
- test CLI override command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849411c17a88321bcf9da56051e7dbc