### PR TITLE
Prevent duplicate price entries for same invoice

### DIFF
--- a/tests/test_price_history_duplicates.py
+++ b/tests/test_price_history_duplicates.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from decimal import Decimal
+
+from wsm import utils
+
+
+def test_log_price_history_avoids_duplicates(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        'sifra_dobavitelja': ['SUP'],
+        'naziv': ['Artikel'],
+        'cena_bruto': [Decimal('10')],
+    })
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(utils, '_load_supplier_map', lambda path: {'SUP': {'ime': 'Test', 'override_H87_to_kg': False}})
+    hist_base = tmp_path / 'base.xlsx'
+    utils.log_price_history(df, hist_base, invoice_id='abc')
+    utils.log_price_history(df, hist_base, invoice_id='abc')
+    hist_path = hist_base.parent / 'Test' / 'price_history.xlsx'
+    hist = pd.read_excel(hist_path, dtype=str)
+    assert len(hist) == 1
+

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -342,6 +342,7 @@ def _save_and_close(
     except Exception as e:
         log.error(f"Napaka pri shranjevanju v {links_file}: {e}")
 
+    invoice_hash = None
     if invoice_path and invoice_path.suffix.lower() == ".xml":
         try:
             from wsm.parsing.eslog import extract_service_date
@@ -350,13 +351,22 @@ def _save_and_close(
         except Exception as exc:
             log.warning(f"Napaka pri branju datuma storitve: {exc}")
             service_date = None
+        try:
+            invoice_hash = hashlib.md5(invoice_path.read_bytes()).hexdigest()
+        except Exception as exc:
+            log.warning(f"Napaka pri izračunu hash: {exc}")
     else:
         service_date = None
+        if invoice_path and invoice_path.exists():
+            try:
+                invoice_hash = hashlib.md5(invoice_path.read_bytes()).hexdigest()
+            except Exception as exc:
+                log.warning(f"Napaka pri izračunu hash: {exc}")
 
     try:
         from wsm.utils import log_price_history
 
-        log_price_history(df, links_file, service_date=service_date)
+        log_price_history(df, links_file, service_date=service_date, invoice_id=invoice_hash)
     except Exception as exc:
         log.warning(f"Napaka pri beleženju zgodovine cen: {exc}")
 

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -226,7 +226,8 @@ def log_price_history(
     history_file: Union[str, Path],
     *,
     service_date: str | None = None,
-    max_entries_per_code: int = 50
+    max_entries_per_code: int = 50,
+    invoice_id: str | None = None,
 ) -> None:
     """
     Zapiše zgodovino cen v ``links/<ime_dobavitelja>/price_history.xlsx``.
@@ -251,6 +252,7 @@ def log_price_history(
     df_hist.columns = ["key", "cena"]
     df_hist["time"] = pd.Timestamp.now()
     df_hist["service_date"] = service_date
+    df_hist["invoice_id"] = invoice_id
 
     # Preveri, ali so podatki pravilni
     if df_hist["key"].isna().any() or df_hist["key"].str.strip().eq("").any():
@@ -259,6 +261,11 @@ def log_price_history(
 
     if history_path.exists():
         old = pd.read_excel(history_path, dtype={"key": str})
+        if "invoice_id" not in old.columns:
+            old["invoice_id"] = pd.NA
+        if invoice_id is not None:
+            mask = (old["invoice_id"] == invoice_id) & (old["key"].isin(df_hist["key"]))
+            old = old[~mask]
         df_hist = pd.concat([old, df_hist], ignore_index=True)
 
     df_hist = (


### PR DESCRIPTION
## Summary
- add optional `invoice_id` to `log_price_history`
- compute invoice hash in `review_links._save_and_close`
- avoid writing duplicate price history entries
- test for duplicate invoice logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494b4ab9e48321a9f332df167e3cdd