### PR TITLE
Add simple main menu GUI

### DIFF
--- a/wsm/run.py
+++ b/wsm/run.py
@@ -3,92 +3,20 @@ from __future__ import annotations
 
 import logging
 import sys
-from pathlib import Path
-
-import pandas as pd
-from decimal import Decimal
-import tkinter as tk
-from tkinter import filedialog, messagebox
 
 from wsm.cli import main as cli_main
-from wsm.analyze import analyze_invoice
-from wsm.parsing.pdf import parse_pdf, get_supplier_name_from_pdf
-from wsm.parsing.eslog import get_supplier_name
-from wsm.utils import sanitize_folder_name
-from wsm.ui.review_links import review_links
+from wsm.ui.main_menu import launch_main_menu
 
 logging.basicConfig(level=logging.INFO)
-
-
-def _select_invoice() -> Path | None:
-    """Open a file dialog and return the chosen path."""
-    root = tk.Tk()
-    root.withdraw()
-    file_path = filedialog.askopenfilename(
-        title="Izberite e-račun",
-        filetypes=[("e-računi", "*.xml *.pdf"), ("XML", "*.xml"), ("PDF", "*.pdf")],
-    )
-    root.destroy()
-    return Path(file_path) if file_path else None
-
-
-def _open_gui(invoice_path: Path) -> None:
-    """Parse invoice and launch the review GUI."""
-    try:
-        if invoice_path.suffix.lower() == ".xml":
-            df, total, _ = analyze_invoice(str(invoice_path))
-
-            if "rabata" in df.columns:
-                df["rabata"] = df["rabata"].fillna(Decimal("0"))
-            else:
-                df["rabata"] = Decimal("0")
-
-        elif invoice_path.suffix.lower() == ".pdf":
-            df = parse_pdf(str(invoice_path))
-            if "rabata" not in df.columns:
-                df["rabata"] = Decimal("0")
-            total = df["vrednost"].sum()
-        else:
-            messagebox.showerror("Napaka", f"Nepodprta datoteka: {invoice_path}")
-            return
-    except Exception as exc:
-        messagebox.showerror("Napaka", str(exc))
-        return
-
-    supplier_code = df["sifra_dobavitelja"].iloc[0] if not df.empty else "unknown"
-    if invoice_path.suffix.lower() == ".xml":
-        name = get_supplier_name(invoice_path) or supplier_code
-    elif invoice_path.suffix.lower() == ".pdf":
-        name = get_supplier_name_from_pdf(invoice_path) or supplier_code
-    else:
-        name = supplier_code
-    safe_name = sanitize_folder_name(name)
-    links_dir = Path("links") / safe_name
-    links_dir.mkdir(parents=True, exist_ok=True)
-    links_file = links_dir / f"{supplier_code}_{safe_name}_povezane.xlsx"
-
-    # WSM codes are optional; try to load them from sifre_wsm.xlsx
-    sifre_file = Path("sifre_wsm.xlsx")
-    if sifre_file.exists():
-        try:
-            wsm_df = pd.read_excel(sifre_file, dtype=str)
-        except Exception as exc:
-            logging.warning(f"Napaka pri branju {sifre_file}: {exc}")
-            wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
-    else:
-        wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
-
-    review_links(df, wsm_df, links_file, total, invoice_path)
 
 
 def main() -> None:
     if len(sys.argv) > 1:
         cli_main()
     else:
-        invoice = _select_invoice()
-        if invoice:
-            _open_gui(invoice)
+        launch_main_menu()
 
 
 if __name__ == "__main__":
     main()
+

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -1,0 +1,80 @@
+# File: wsm/ui/common.py
+"""Helper functions shared by GUI components."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from decimal import Decimal
+
+import pandas as pd
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+from wsm.analyze import analyze_invoice
+from wsm.parsing.pdf import parse_pdf, get_supplier_name_from_pdf
+from wsm.parsing.eslog import get_supplier_name
+from wsm.utils import sanitize_folder_name
+from wsm.ui.review_links import review_links
+
+logging.basicConfig(level=logging.INFO)
+
+
+def select_invoice() -> Path | None:
+    """Open a file dialog and return the chosen path."""
+    root = tk.Tk()
+    root.withdraw()
+    file_path = filedialog.askopenfilename(
+        title="Izberite e-račun",
+        filetypes=[("e-računi", "*.xml *.pdf"), ("XML", "*.xml"), ("PDF", "*.pdf")],
+    )
+    root.destroy()
+    return Path(file_path) if file_path else None
+
+
+def open_invoice_gui(invoice_path: Path) -> None:
+    """Parse invoice and launch the review GUI."""
+    try:
+        if invoice_path.suffix.lower() == ".xml":
+            df, total, _ = analyze_invoice(str(invoice_path))
+
+            if "rabata" in df.columns:
+                df["rabata"] = df["rabata"].fillna(Decimal("0"))
+            else:
+                df["rabata"] = Decimal("0")
+
+        elif invoice_path.suffix.lower() == ".pdf":
+            df = parse_pdf(str(invoice_path))
+            if "rabata" not in df.columns:
+                df["rabata"] = Decimal("0")
+            total = df["vrednost"].sum()
+        else:
+            messagebox.showerror("Napaka", f"Nepodprta datoteka: {invoice_path}")
+            return
+    except Exception as exc:
+        messagebox.showerror("Napaka", str(exc))
+        return
+
+    supplier_code = df["sifra_dobavitelja"].iloc[0] if not df.empty else "unknown"
+    if invoice_path.suffix.lower() == ".xml":
+        name = get_supplier_name(invoice_path) or supplier_code
+    elif invoice_path.suffix.lower() == ".pdf":
+        name = get_supplier_name_from_pdf(invoice_path) or supplier_code
+    else:
+        name = supplier_code
+    safe_name = sanitize_folder_name(name)
+    links_dir = Path("links") / safe_name
+    links_dir.mkdir(parents=True, exist_ok=True)
+    links_file = links_dir / f"{supplier_code}_{safe_name}_povezane.xlsx"
+
+    sifre_file = Path("sifre_wsm.xlsx")
+    if sifre_file.exists():
+        try:
+            wsm_df = pd.read_excel(sifre_file, dtype=str)
+        except Exception as exc:
+            logging.warning(f"Napaka pri branju {sifre_file}: {exc}")
+            wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+    else:
+        wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+
+    review_links(df, wsm_df, links_file, total, invoice_path)
+

--- a/wsm/ui/main_menu.py
+++ b/wsm/ui/main_menu.py
@@ -1,0 +1,37 @@
+# File: wsm/ui/main_menu.py
+"""Simple main menu for the WSM application."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox
+
+from wsm.ui.common import select_invoice, open_invoice_gui
+
+
+def launch_main_menu() -> None:
+    """Launch the main menu window."""
+    root = tk.Tk()
+    root.title("WSM")
+    root.geometry("300x200")
+
+    def _enter_invoice() -> None:
+        root.withdraw()
+        path = select_invoice()
+        root.deiconify()
+        if path:
+            open_invoice_gui(path)
+
+    def _watch_prices() -> None:
+        messagebox.showinfo(
+            "Spremljaj cene",
+            "Funkcija še ni implementirana.",
+        )
+
+    btn_invoice = tk.Button(root, text="Unesi račun", width=20, command=_enter_invoice)
+    btn_invoice.pack(pady=20)
+
+    btn_prices = tk.Button(root, text="Spremljaj cene", width=20, command=_watch_prices)
+    btn_prices.pack(pady=10)
+
+    root.mainloop()
+


### PR DESCRIPTION
## Summary
- add helper functions to `wsm.ui.common`
- implement `wsm.ui.main_menu` with buttons for entering invoices and monitoring prices
- simplify `wsm.run` to launch the main menu when no CLI arguments are given

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494eba0bac8321ba1db8c43ad5adbd