### PR TITLE
Add VAT rate extraction

### DIFF
--- a/tests/test_vat_rate.py
+++ b/tests/test_vat_rate.py
@@ -1,0 +1,16 @@
+from decimal import Decimal
+from pathlib import Path
+from wsm.parsing.eslog import parse_eslog_invoice
+
+
+def test_vat_rate_22():
+    df = parse_eslog_invoice(Path('tests/VP2025-1799-racun.xml'), {})
+    df = df[df['sifra_dobavitelja'] != '_DOC_']
+    assert 'ddv_stopnja' in df.columns
+    assert df['ddv_stopnja'].iloc[0] == Decimal('22.00')
+
+
+def test_vat_rate_9_5():
+    df = parse_eslog_invoice(Path('tests/PR5691-Slika2.XML'), {})
+    df = df[df['sifra_dobavitelja'] != '_DOC_']
+    assert set(df['ddv_stopnja'].unique()) == {Decimal('9.5')}

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -138,6 +138,7 @@ def parse_eslog_invoice(
       - rabata           (Decimal)
       - rabata_pct       (Decimal)
       - vrednost         (Decimal)
+      - ddv_stopnja      (Decimal)
       - sifra_artikla    (string)
 
     Parameters
@@ -209,6 +210,14 @@ def parse_eslog_invoice(
 
                 break
 
+        # stopnja DDV (npr. 9.5 ali 22)
+        vat_rate = Decimal("0")
+        for tax in sg26.findall(".//e:G_SG34/e:S_TAX", NS):
+            rate = _decimal(tax.find("./e:C_C243/e:D_5278", NS))
+            if rate != 0:
+                vat_rate = rate
+                break
+
         # rabat na ravni vrstice
         rebate = Decimal("0")
         explicit_pct: Decimal | None = None
@@ -260,6 +269,7 @@ def parse_eslog_invoice(
             "rabata":           rebate,
             "rabata_pct":       rabata_pct,
             "vrednost":         net_amount,
+            "ddv_stopnja":      vat_rate,
             "sifra_artikla":    art_code,
         })
 


### PR DESCRIPTION
## Summary
- extract VAT rate (`ddv_stopnja`) from ESLOG line items
- test VAT rate parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495790be3c8321a7cadc3c3ae3793b