### PR TITLE
Dodana funkcija za spremljanje cen

### DIFF
--- a/wsm/ui/main_menu.py
+++ b/wsm/ui/main_menu.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import tkinter as tk
-from tkinter import messagebox
 
 from wsm.ui.common import select_invoice, open_invoice_gui
+from wsm.ui.price_watch import launch_price_watch
 
 
 def launch_main_menu() -> None:
@@ -22,12 +22,11 @@ def launch_main_menu() -> None:
             open_invoice_gui(path)
 
     def _watch_prices() -> None:
-        messagebox.showinfo(
-            "Spremljaj cene",
-            "Funkcija še ni implementirana.",
-        )
+        root.withdraw()
+        launch_price_watch()
+        root.deiconify()
 
-    btn_invoice = tk.Button(root, text="Unesi račun", width=20, command=_enter_invoice)
+    btn_invoice = tk.Button(root, text="Vnesi račun", width=20, command=_enter_invoice)
     btn_invoice.pack(pady=20)
 
     btn_prices = tk.Button(root, text="Spremljaj cene", width=20, command=_watch_prices)

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -1,0 +1,89 @@
+# File: wsm/ui/price_watch.py
+"""Simple GUI for watching price history of items."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk, messagebox
+from pathlib import Path
+
+import pandas as pd
+
+from wsm.ui.review_links import _load_supplier_map
+from wsm.utils import sanitize_folder_name
+
+
+def launch_price_watch() -> None:
+    """Launch the price watch window."""
+    root = tk.Tk()
+    root.title("Spremljanje cen")
+    root.geometry("500x400")
+
+    suppliers = _load_supplier_map(Path("links"))
+    supplier_codes = sorted(suppliers)
+    supplier_names = [suppliers[c]["ime"] for c in supplier_codes]
+
+    selected_code = tk.StringVar()
+    combo = ttk.Combobox(root, values=[f"{c} - {suppliers[c]['ime']}" for c in supplier_codes], width=40)
+    combo.pack(pady=10)
+
+    listbox = tk.Listbox(root, width=60)
+    listbox.pack(pady=10, fill=tk.BOTH, expand=True)
+
+    canvas = tk.Canvas(root, width=450, height=150)
+    canvas.pack(pady=10)
+
+    item_data: dict[str, pd.DataFrame] = {}
+
+    def on_supplier_selected(event=None):
+        sel = combo.get()
+        if not sel:
+            return
+        code = sel.split(" - ")[0]
+        name = suppliers.get(code, {}).get("ime", code)
+        safe_name = sanitize_folder_name(name)
+        hist_path = Path("links") / safe_name / "price_history.xlsx"
+        listbox.delete(0, tk.END)
+        item_data.clear()
+        if not hist_path.exists():
+            messagebox.showwarning("Opozorilo", "Za izbranega dobavitelja ni podatkov o cenah.")
+            return
+        df = pd.read_excel(hist_path)
+        if "key" not in df.columns:
+            return
+        for key in sorted(df["key"].unique()):
+            listbox.insert(tk.END, key)
+            item_data[key] = df[df["key"] == key].sort_values("time")
+
+    def on_item_selected(event=None):
+        if not listbox.curselection():
+            return
+        key = listbox.get(listbox.curselection()[0])
+        df_item = item_data.get(key)
+        if df_item is None or df_item.empty:
+            return
+        canvas.delete("all")
+        prices = df_item["cena"].astype(float).tolist()
+        min_p, max_p = min(prices), max(prices)
+        width, height = 450, 150
+        margin = 20
+        scale = (height - 2 * margin) / (max_p - min_p) if max_p != min_p else 1
+        for i in range(1, len(prices)):
+            x1 = margin + (i - 1) * (width - 2 * margin) / max(1, len(prices) - 1)
+            y1 = height - margin - (prices[i - 1] - min_p) * scale
+            x2 = margin + i * (width - 2 * margin) / max(1, len(prices) - 1)
+            y2 = height - margin - (prices[i] - min_p) * scale
+            canvas.create_line(x1, y1, x2, y2, fill="blue", width=2)
+        if len(prices) >= 2:
+            last, prev = prices[-1], prices[-2]
+            if last > prev:
+                arrow = "↑"
+            elif last < prev:
+                arrow = "↓"
+            else:
+                arrow = "→"
+            canvas.create_text(width - margin, margin, text=arrow, font=("Arial", 16))
+
+    combo.bind("<<ComboboxSelected>>", on_supplier_selected)
+    listbox.bind("<<ListboxSelect>>", on_item_selected)
+
+    root.mainloop()


### PR DESCRIPTION
## Summary
- popravljen napis gumba v glavnem meniju
- dodan modul za spremljanje cen artiklov
- glavnemu meniju dodana povezava na novo okno za spremljanje cen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684957ec032c83218664dd7b956e10b6