### PR TITLE
Add invoice number support

### DIFF
--- a/tests/test_invoice_number.py
+++ b/tests/test_invoice_number.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+from wsm.parsing.eslog import extract_invoice_number
+
+
+def test_extract_invoice_number():
+    xml = Path("tests/VP2025-1799-racun.xml")
+    assert extract_invoice_number(xml) == "VP2025-1799"
+

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -118,6 +118,30 @@ def extract_service_date(xml_path: Path | str) -> str | None:
         pass
     return None
 
+# ───────────────────── številka računa ─────────────────────
+def extract_invoice_number(xml_path: Path | str) -> str | None:
+    """Vrne številko računa iz segmenta BGM (D_1004)."""
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+        bgm = root.find('.//e:S_BGM', NS)
+        if bgm is None:
+            for node in root.iter():
+                if node.tag.split('}')[-1] == 'S_BGM':
+                    bgm = node
+                    break
+        if bgm is not None:
+            num_el = bgm.find('.//e:C_C106/e:D_1004', NS)
+            if num_el is None:
+                num_el = next((el for el in bgm.iter() if el.tag.split('}')[-1] == 'D_1004'), None)
+            if num_el is not None:
+                num = _text(num_el)
+                if num:
+                    return num
+    except Exception:
+        pass
+    return None
+
 # ──────────────────── glavni parser za ESLOG INVOIC ────────────────────
 def parse_eslog_invoice(
     xml_path: str | Path,

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -411,6 +411,17 @@ def review_links(
     default_name = supplier_info.get("ime", supplier_code)
     override_h87_to_kg = supplier_info.get("override_H87_to_kg", False)
 
+    service_date = None
+    invoice_number = None
+    if invoice_path and invoice_path.suffix.lower() == ".xml":
+        try:
+            from wsm.parsing.eslog import extract_service_date, extract_invoice_number
+
+            service_date = extract_service_date(invoice_path)
+            invoice_number = extract_invoice_number(invoice_path)
+        except Exception as exc:
+            log.warning(f"Napaka pri branju glave računa: {exc}")
+
     inv_name = None
     if invoice_path and invoice_path.suffix.lower() == ".xml":
         try:
@@ -548,9 +559,12 @@ def review_links(
 
     root = tk.Tk()
     root.title(f"Ročna revizija – {supplier_name}")
-    tk.Label(
-        root, text=f"Dobavitelj: {supplier_name}", font=("Arial", 14, "bold")
-    ).pack(pady=4)
+    header = f"Dobavitelj: {supplier_name}"
+    if service_date:
+        header += f" | Datum storitve: {service_date}"
+    if invoice_number:
+        header += f" | Račun: {invoice_number}"
+    tk.Label(root, text=header, font=("Arial", 14, "bold")).pack(pady=4)
     # Start in fullscreen; press Esc to exit
     root.attributes("-fullscreen", True)
     root.bind("<Escape>", lambda e: root.attributes("-fullscreen", False))


### PR DESCRIPTION
## Summary
- extract invoice number from eSLOG XML
- show service date and invoice number in review GUI
- test invoice number extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684970a9920c8321bbfdc078f1c042fc