### PR TITLE
Implement dynamic rounding in invoice processing

### DIFF
--- a/wsm/analyze.py
+++ b/wsm/analyze.py
@@ -6,6 +6,7 @@ import pandas as pd
 from wsm.parsing.eslog import parse_eslog_invoice
 from wsm.ui.review_links import _norm_unit, _load_supplier_map
 from wsm.parsing.eslog import extract_header_net
+from wsm.parsing.money import quantize_like
 
 
 def analyze_invoice(xml_path: str, suppliers_file: str | None = None) -> tuple[pd.DataFrame, Decimal, bool]:
@@ -55,6 +56,6 @@ def analyze_invoice(xml_path: str, suppliers_file: str | None = None) -> tuple[p
     result = pd.concat([grouped, df_doc], ignore_index=True)
 
     header_total = extract_header_net(Path(xml_path))
-    line_sum = Decimal(str(result['vrednost'].sum())).quantize(Decimal('0.01'))
+    line_sum = quantize_like(Decimal(str(result['vrednost'].sum())), header_total)
     ok = abs(line_sum - header_total) <= Decimal('0.05')
     return result, header_total, ok

--- a/wsm/parsing/money.py
+++ b/wsm/parsing/money.py
@@ -1,5 +1,11 @@
 # File: wsm/parsing/money.py
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
+
+
+def quantize_like(value: Decimal, reference: Decimal, rounding=ROUND_HALF_UP) -> Decimal:
+    """Quantize ``value`` with the same precision as ``reference``."""
+    quant = Decimal('1').scaleb(reference.as_tuple().exponent)
+    return value.quantize(quant, rounding=rounding)
 import xml.etree.ElementTree as ET
 import pandas as pd
 
@@ -65,7 +71,7 @@ def validate_invoice(df: pd.DataFrame, header_total: Decimal) -> bool:
     # Če sum vrne int ali float, ga pretvorimo v Decimal; če je že Decimal, OK
     if not isinstance(total_sum, Decimal):
         total_sum = Decimal(str(total_sum))
-    line_sum = total_sum.quantize(Decimal("0.01"))
+    line_sum = quantize_like(total_sum, header_total)
 
     # 3) Primerjamo z header_total
     return abs(line_sum - header_total) < Decimal("0.05")


### PR DESCRIPTION
## Summary
- add `quantize_like` helper to round decimals by the header precision
- use new helper when validating invoices and when analyzing invoice totals

## Testing
- `pytest -q` *(fails: tests/test_unlinked_total.py::test_unlinked_total_zero_when_all_lines_linked)*

------
https://chatgpt.com/codex/tasks/task_e_68498b11918c83219130a16a78a6ef76