### PR TITLE
Fix Treeview row indexing

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -529,6 +529,8 @@ def review_links(
     df_doc = df[df["sifra_dobavitelja"] == "_DOC_"]
     doc_discount_total = df_doc["vrednost"].sum()
     df = df[df["sifra_dobavitelja"] != "_DOC_"]
+    # Ensure a clean sequential index so Treeview item IDs are predictable
+    df = df.reset_index(drop=True)
     df["cena_pred_rabatom"] = df.apply(
         lambda r: (r["vrednost"] + r["rabata"]) / r["kolicina"]
         if r["kolicina"]


### PR DESCRIPTION
## Summary
- reset the dataframe index after removing _DOC_ lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a956d05148321b2832f7a2bec3f82