### PR TITLE
Fix unit selection in review_links

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -835,7 +835,7 @@ def review_links(
         df["enota"] = new_u
         for item in tree.get_children():
             tree.set(item, "enota_norm", new_u)
-        root.update_idletasks()
+        root.update()  # refresh UI so the combobox selection is respected
         _update_summary()
         _update_totals()
 


### PR DESCRIPTION
## Summary
- call `root.update()` when applying units in `review_links` to ensure the UI refreshes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aa2b159e483218afd3564ebef164d