### PR TITLE
Improve unit debug logging

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -297,6 +297,11 @@ def _save_and_close(
     log.debug(
         f"Shranjevanje: supplier_name={supplier_name}, supplier_code={supplier_code}"
     )
+    log.info(
+        f"Shranjujem {len(df)} vrstic z enotami: {df['enota_norm'].value_counts().to_dict()}"
+    )
+    if unit_value:
+        log.info(f"Enota izbirnika: {unit_value}")
 
     # Preverimo prazne sifra_dobavitelja
     empty_sifra = df["sifra_dobavitelja"].isna() | (df["sifra_dobavitelja"] == "")
@@ -356,10 +361,18 @@ def _save_and_close(
     if manual_new.empty:
         # Če ni obstoječih povezav, začni z df_links
         manual_new = df_links.copy()
+        log.debug(
+            "Starting new mapping DataFrame with units: %s",
+            manual_new["enota_norm"].value_counts().to_dict(),
+        )
     else:
         manual_new.loc[
             df_links.index, ["naziv", "wsm_sifra", "dobavitelj", "enota_norm"]
         ] = df_links
+        log.debug(
+            "Updated existing mappings with new units: %s",
+            manual_new["enota_norm"].value_counts().to_dict(),
+        )
 
     # Dodaj nove elemente, ki niso v manual_new
     new_items = df_links[~df_links.index.isin(manual_new.index)]
@@ -371,6 +384,11 @@ def _save_and_close(
     # Shrani v Excel
     log.info(f"Shranjujem {len(manual_new)} povezav v {links_file}")
     log.debug(f"Primer shranjenih povezav: {manual_new.head().to_dict()}")
+    if "enota_norm" in manual_new.columns:
+        log.debug(
+            "Units written to file: %s",
+            manual_new["enota_norm"].value_counts().to_dict(),
+        )
     try:
         manual_new.to_excel(links_file, index=False)
         log.info(f"Uspešno shranjeno v {links_file}")
@@ -401,7 +419,9 @@ def _save_and_close(
     try:
         from wsm.utils import log_price_history
 
-        log_price_history(df, links_file, service_date=service_date, invoice_id=invoice_hash)
+        log_price_history(
+            df, links_file, service_date=service_date, invoice_id=invoice_hash
+        )
     except Exception as exc:
         log.warning(f"Napaka pri beleženju zgodovine cen: {exc}")
 
@@ -536,9 +556,11 @@ def review_links(
     # Ensure a clean sequential index so Treeview item IDs are predictable
     df = df.reset_index(drop=True)
     df["cena_pred_rabatom"] = df.apply(
-        lambda r: (r["vrednost"] + r["rabata"]) / r["kolicina"]
-        if r["kolicina"]
-        else Decimal("0"),
+        lambda r: (
+            (r["vrednost"] + r["rabata"]) / r["kolicina"]
+            if r["kolicina"]
+            else Decimal("0")
+        ),
         axis=1,
     )
     df["cena_po_rabatu"] = df.apply(
@@ -563,12 +585,21 @@ def review_links(
         ]
     )
     if old_unit_dict:
+        log.debug(f"Old unit mapping loaded: {old_unit_dict}")
+
         def _restore_unit(r):
             if override_h87_to_kg and str(r["enota"]).upper() == "H87":
                 return r["enota_norm"]
             return old_unit_dict.get(r["sifra_dobavitelja"], r["enota_norm"])
 
+        before = df["enota_norm"].copy()
         df["enota_norm"] = df.apply(_restore_unit, axis=1)
+        changed = (before != df["enota_norm"]).sum()
+        log.debug(f"Units restored from old map: {changed} rows updated")
+        log.debug(
+            "Units after applying saved mapping: %s",
+            df["enota_norm"].value_counts().to_dict(),
+        )
     df["kolicina_norm"] = df["kolicina_norm"].astype(float)
     log.debug(f"df po normalizaciji: {df.head().to_dict()}")
 
@@ -590,7 +621,6 @@ def review_links(
             df_doc.loc[df_doc.index, "rabata"] += abs(diff)
         else:
             log.debug(
-
                 f"Dodajam _DOC_ vrstico za razliko {diff} med vrsticami in računom"
             )
             df_doc = pd.DataFrame(
@@ -607,7 +637,6 @@ def review_links(
                         "vrednost": diff,
                     }
                 ]
-
             )
             doc_discount_total += diff
 
@@ -725,15 +754,17 @@ def review_links(
                 .reset_index()
             )
 
-            summary_df["neto_brez_popusta"] = summary_df["vrednost"] + summary_df["rabata"]
+            summary_df["neto_brez_popusta"] = (
+                summary_df["vrednost"] + summary_df["rabata"]
+            )
             summary_df["wsm_naziv"] = summary_df["wsm_sifra"].map(
                 wsm_df.set_index("wsm_sifra")["wsm_naziv"]
             )
             summary_df["rabata_pct"] = [
                 (
-                    (row["rabata"] / row["neto_brez_popusta"] * Decimal("100")).quantize(
-                        Decimal("0.01")
-                    )
+                    (
+                        row["rabata"] / row["neto_brez_popusta"] * Decimal("100")
+                    ).quantize(Decimal("0.01"))
                     if row["neto_brez_popusta"]
                     else Decimal("0.00")
                 )
@@ -832,16 +863,63 @@ def review_links(
         value=_last_unit if _last_unit in unit_options else unit_options[0]
     )
     unit_menu = ttk.Combobox(
-        bottom, values=unit_options, textvariable=unit_var, state="readonly", width=5
+        bottom,
+        values=unit_options,
+        textvariable=unit_var,
+        state="readonly",
+        width=5,
     )
+    log.debug("Inicializiran combobox z vrednostjo %s", unit_var.get())
+
+    def _on_unit_select(event=None):
+        val = unit_var.get()
+        log.info(f"Combobox selected: {val}")
+        log.debug("unit_menu.get()=%s", unit_menu.get())
+        log.debug(
+            "Units before any override: %s",
+            df["enota_norm"].value_counts().to_dict(),
+        )
+
+    def _on_unit_write(*_):
+        log.info(f"unit_var changed: {unit_var.get()}")
+        log.debug("trace info: %s", unit_var.trace_info())
+
+    unit_menu.bind("<<ComboboxSelected>>", _on_unit_select)
+    unit_var.trace_add("write", _on_unit_write)
 
     def _set_all_units():
         new_u = unit_var.get()
+        log.debug(
+            "_set_all_units invoked with unit_var=%s unit_menu=%s",
+            new_u,
+            unit_menu.get(),
+        )
+        before = df["enota_norm"].copy()
+        log.info(f"Nastavljam vse enote na {new_u}")
+        log.debug(
+            "Units distribution pre-override: %s",
+            before.value_counts().to_dict(),
+        )
         df["enota_norm"] = new_u
         df["enota"] = new_u
         for item in tree.get_children():
             tree.set(item, "enota_norm", new_u)
+        changed = (before != df["enota_norm"]).sum()
+        if changed:
+            log.info(f"Spremenjenih vrstic: {changed}")
+        else:
+            log.warning("Nobena vrstica ni bila spremenjena pri nastavitvi enote")
+        log.info(
+            "Units after override: %s",
+            df["enota_norm"].value_counts().to_dict(),
+        )
         root.update()  # refresh UI so the combobox selection is respected
+        log.debug(
+            "Units after root.update: %s (combobox=%s)",
+            df["enota_norm"].value_counts().to_dict(),
+            unit_var.get(),
+        )
+        log.debug("Combobox actual value after update: %s", unit_menu.get())
         _update_summary()
         _update_totals()
 
@@ -984,16 +1062,21 @@ def review_links(
         if col != "#3" or not row_id:
             return
         idx = int(row_id)
+        log.debug("Editing row %s current unit=%s", idx, df.at[idx, "enota_norm"])
         top = tk.Toplevel(root)
         top.title("Spremeni enoto")
         var = tk.StringVar(value=df.at[idx, "enota_norm"])
         cb = ttk.Combobox(top, values=unit_options, textvariable=var, state="readonly")
         cb.pack(padx=10, pady=10)
+        log.debug("Edit dialog opened with value %s", var.get())
 
         def _apply(_=None):
             new_u = var.get()
+            before = df.at[idx, "enota_norm"]
             df.at[idx, "enota_norm"] = new_u
             tree.set(row_id, "enota_norm", new_u)
+            log.info("Updated row %s unit from %s to %s", idx, before, new_u)
+            log.debug("Combobox in edit dialog value: %s", cb.get())
             _update_summary()
             _update_totals()
             top.destroy()


### PR DESCRIPTION
## Summary
- expand logs for combobox write events
- log current value when editing a row unit and when it changes
- print combobox state and trace info for troubleshooting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aaca406a083219097fc11d9c1a331