### PR TITLE
Fix unit editing

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -1088,6 +1088,7 @@ def review_links(
             new_u = var.get()
             before = df.at[idx, "enota_norm"]
             df.at[idx, "enota_norm"] = new_u
+            df.at[idx, "enota"] = new_u
             tree.set(row_id, "enota_norm", new_u)
 
             log.info("Updated row %s unit from %s to %s", idx, before, new_u)


### PR DESCRIPTION
## Summary
- ensure edited unit is saved by updating both `enota` and `enota_norm`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acb0c7b3c8321a0d6eaa0764199c5