### PR TITLE
Handle nonexistent supplier directories

### DIFF
--- a/tests/test_cli_override.py
+++ b/tests/test_cli_override.py
@@ -59,3 +59,24 @@ def test_cli_override(tmp_path):
     assert row["kolicina"] == Decimal("2.5")
     assert total == Decimal("10")
     assert ok
+
+
+def test_cli_override_creates_dir(tmp_path):
+    links = tmp_path / "links"
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["override", "SUP", "--suppliers", str(links), "--set"])
+    assert result.exit_code == 0
+
+    supplier_json = links / "SUP" / "supplier.json"
+    assert supplier_json.exists()
+
+    xml_path = tmp_path / "invoice.xml"
+    xml_path.write_text(XML)
+
+    df, total, ok = analyze.analyze_invoice(xml_path, str(links))
+    row = df[df["sifra_dobavitelja"] == "SUP"].iloc[0]
+    assert row["enota"] == "kg"
+    assert row["kolicina"] == Decimal("2.5")
+    assert total == Decimal("10")
+    assert ok

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -253,7 +253,14 @@ def _write_supplier_map(sup_map: dict, sup_file: Path):
         log.info(f"Datoteka uspešno zapisana: {sup_file}")
         return
 
-    links_dir = sup_file if sup_file.is_dir() else sup_file.parent
+    # When `sup_file` points to a directory path that does not yet exist and
+    # has no suffix, create it and use it directly. Otherwise use the existing
+    # directory or the parent when a file path is given.
+    if not sup_file.exists() and sup_file.suffix == "":
+        sup_file.mkdir(parents=True, exist_ok=True)
+        links_dir = sup_file
+    else:
+        links_dir = sup_file if sup_file.is_dir() else sup_file.parent
     for code, info in sup_map.items():
         from wsm.utils import sanitize_folder_name
 


### PR DESCRIPTION
## Summary
- make `_write_supplier_map` create missing supplier directories
- test CLI override with a non-existent suppliers path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad209f5e88321a74d4299deb2a1b4