### PR TITLE
Add suppliers option for CLI review and fix GUI base path

### DIFF
--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -1,0 +1,56 @@
+import json
+from decimal import Decimal
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from wsm.cli import main
+
+XML = (
+    "<Invoice xmlns='urn:eslog:2.00'>"
+    "  <M_INVOIC>"
+    "    <G_SG2>"
+    "      <S_NAD>"
+    "        <D_3035>SE</D_3035>"
+    "        <C_C082><D_3039>SUP</D_3039></C_C082>"
+    "        <C_C080><D_3036>Test</D_3036></C_C080>"
+    "      </S_NAD>"
+    "    </G_SG2>"
+    "    <G_SG26>"
+    "      <S_QTY><C_C186><D_6060>2.5</D_6060><D_6411>H87</D_6411></C_C186></S_QTY>"
+    "      <S_LIN><C_C212><D_7140>0001</D_7140></C_C212></S_LIN>"
+    "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+    "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>4</D_5118></C_C509></S_PRI>"
+    "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+    "    </G_SG26>"
+    "    <G_SG50>"
+    "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+    "    </G_SG50>"
+    "  </M_INVOIC>"
+    "</Invoice>"
+)
+
+def test_cli_review_respects_override(tmp_path, monkeypatch):
+    invoice = tmp_path / "invoice.xml"
+    invoice.write_text(XML)
+
+    links = tmp_path / "links"
+    supplier = links / "Test"
+    supplier.mkdir(parents=True)
+    info = {"sifra": "SUP", "ime": "Test", "override_H87_to_kg": True}
+    (supplier / "supplier.json").write_text(json.dumps(info))
+
+    captured = {}
+
+    def fake_review_links(df, wsm_df, links_file, total, invoice_path):
+        captured["df"] = df
+
+    monkeypatch.setattr("wsm.ui.review_links.review_links", fake_review_links)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["review", str(invoice), "--suppliers", str(links)])
+    assert result.exit_code == 0
+
+    row = captured["df"][captured["df"]["sifra_dobavitelja"] == "SUP"].iloc[0]
+    assert row["enota"] == "kg"
+    assert row["kolicina"] == Decimal("2.5")

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -80,7 +80,13 @@ def analyze(invoice, suppliers):
     default=None,
     help="Pot do sifre_wsm.xlsx",
 )
-def review(invoice, wsm_codes):
+@click.option(
+    "--suppliers",
+    type=click.Path(),
+    default="links",
+    help="Mapa z dobavitelji ali legacy suppliers.xlsx",
+)
+def review(invoice, wsm_codes, suppliers):
     """Odpri GUI za ročno povezovanje WSM šifer."""
     try:
         from wsm.ui.review_links import review_links
@@ -91,7 +97,7 @@ def review(invoice, wsm_codes):
     invoice_path = Path(invoice)
     try:
         if invoice_path.suffix.lower() == ".xml":
-            df, total, _ = analyze_invoice(str(invoice_path))
+            df, total, _ = analyze_invoice(str(invoice_path), suppliers)
         elif invoice_path.suffix.lower() == ".pdf":
             df = parse_pdf(str(invoice_path))
             total = df.get("vrednost", pd.Series(dtype=float)).sum()
@@ -114,7 +120,8 @@ def review(invoice, wsm_codes):
     else:
         name = supplier_code
     safe_name = sanitize_folder_name(name)
-    links_dir = Path("links") / safe_name
+    base = Path(suppliers)
+    links_dir = base / safe_name
     links_dir.mkdir(parents=True, exist_ok=True)
     links_file = links_dir / f"{supplier_code}_{safe_name}_povezane.xlsx"
 

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -31,11 +31,11 @@ def select_invoice() -> Path | None:
     return Path(file_path) if file_path else None
 
 
-def open_invoice_gui(invoice_path: Path) -> None:
+def open_invoice_gui(invoice_path: Path, suppliers: Path = Path("links")) -> None:
     """Parse invoice and launch the review GUI."""
     try:
         if invoice_path.suffix.lower() == ".xml":
-            df, total, _ = analyze_invoice(str(invoice_path))
+            df, total, _ = analyze_invoice(str(invoice_path), str(suppliers))
 
             if "rabata" in df.columns:
                 df["rabata"] = df["rabata"].fillna(Decimal("0"))
@@ -64,7 +64,7 @@ def open_invoice_gui(invoice_path: Path) -> None:
     else:
         name = supplier_code
     safe_name = sanitize_folder_name(name)
-    links_dir = Path("links") / safe_name
+    links_dir = suppliers / safe_name
     links_dir.mkdir(parents=True, exist_ok=True)
     links_file = links_dir / f"{supplier_code}_{safe_name}_povezane.xlsx"
 


### PR DESCRIPTION
## Summary
- allow supplying suppliers directory in `wsm.cli.review`
- use that directory when computing links paths
- allow `open_invoice_gui()` to receive suppliers path
- test CLI review honours supplier unit overrides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bcba852b4832186ebd4aff0c71283