### PR TITLE
Add supplier editing dialog

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -660,12 +660,22 @@ def review_links(
 
     root = tk.Tk()
     root.title(f"Ročna revizija – {supplier_name}")
-    header = f"Dobavitelj: {supplier_name}"
-    if service_date:
-        header += f" | Datum storitve: {service_date}"
-    if invoice_number:
-        header += f" | Račun: {invoice_number}"
-    tk.Label(root, text=header, font=("Arial", 14, "bold")).pack(pady=4)
+
+    header_var = tk.StringVar()
+
+    def _refresh_header():
+        header = f"Dobavitelj: {supplier_name}"
+        if service_date:
+            header += f" | Datum storitve: {service_date}"
+        if invoice_number:
+            header += f" | Račun: {invoice_number}"
+        header_var.set(header)
+        root.title(f"Ročna revizija – {supplier_name}")
+
+    _refresh_header()
+
+    header_lbl = tk.Label(root, textvariable=header_var, font=("Arial", 14, "bold"))
+    header_lbl.pack(pady=4)
     # Start in fullscreen; press Esc to exit
     root.attributes("-fullscreen", True)
     root.bind("<Escape>", lambda e: root.attributes("-fullscreen", False))
@@ -975,6 +985,41 @@ def review_links(
         ),
     )
 
+    def _edit_supplier():
+        nonlocal supplier_name, override_h87_to_kg
+        top = tk.Toplevel(root)
+        top.title("Uredi dobavitelja")
+        tk.Label(top, text="Ime dobavitelja:").pack(padx=10, pady=(10, 0))
+        name_entry = tk.Entry(top)
+        name_entry.insert(0, supplier_name)
+        name_entry.pack(padx=10, pady=5)
+        chk_var = tk.BooleanVar(value=override_h87_to_kg)
+        tk.Checkbutton(
+            top,
+            text="override_H87_to_kg",
+            variable=chk_var,
+            onvalue=True,
+            offvalue=False,
+        ).pack(padx=10, pady=5)
+
+        def _apply():
+            supplier_name = name_entry.get().strip() or supplier_name
+            override_h87_to_kg = chk_var.get()
+            sup_map[supplier_code] = {
+                "ime": supplier_name,
+                "override_H87_to_kg": override_h87_to_kg,
+            }
+            _write_supplier_map(sup_map, suppliers_file)
+            df["dobavitelj"] = supplier_name
+            for iid in tree.get_children():
+                vals = list(tree.item(iid, "values"))
+                vals[cols.index("dobavitelj")] = supplier_name
+                tree.item(iid, values=vals)
+            _refresh_header()
+            top.destroy()
+
+        tk.Button(top, text="Potrdi", command=_apply).pack(pady=(0, 10))
+
     def _exit():
         if remember_var.get():
             try:
@@ -992,6 +1037,14 @@ def review_links(
     )
     exit_btn.pack(side="right", padx=(6, 0))
     save_btn.pack(side="right", padx=(6, 0))
+
+    edit_btn = tk.Button(
+        bottom,
+        text="Uredi dobavitelja",
+        width=14,
+        command=_edit_supplier,
+    )
+    edit_btn.pack(side="right", padx=(6, 0))
     tk.Checkbutton(
         bottom,
         text="Zapomni enoto",


### PR DESCRIPTION
## Summary
- add StringVar header to allow dynamic updates
- enable editing supplier name/override from UI
- write supplier updates to disk and refresh the view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd05e2ea48321ac39c86fec57e9df