### PR TITLE
Fix suppliers dir handling in review GUI

### DIFF
--- a/tests/test_price_history_duplicates.py
+++ b/tests/test_price_history_duplicates.py
@@ -13,8 +13,8 @@ def test_log_price_history_avoids_duplicates(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(utils, '_load_supplier_map', lambda path: {'SUP': {'ime': 'Test', 'override_H87_to_kg': False}})
     hist_base = tmp_path / 'base.xlsx'
-    utils.log_price_history(df, hist_base, invoice_id='abc')
-    utils.log_price_history(df, hist_base, invoice_id='abc')
+    utils.log_price_history(df, hist_base, suppliers_dir=tmp_path, invoice_id='abc')
+    utils.log_price_history(df, hist_base, suppliers_dir=tmp_path, invoice_id='abc')
     hist_path = hist_base.parent / 'Test' / 'price_history.xlsx'
     hist = pd.read_excel(hist_path, dtype=str)
     assert len(hist) == 1

--- a/tests/test_supplier_edit_save.py
+++ b/tests/test_supplier_edit_save.py
@@ -1,0 +1,52 @@
+import json
+from decimal import Decimal
+from pathlib import Path
+import pandas as pd
+from wsm.ui.review_links import _save_and_close
+
+class DummyRoot:
+    def quit(self):
+        pass
+
+def test_supplier_edit_saved_to_custom_dir(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP"],
+        "naziv": ["Item"],
+        "kolicina": [Decimal("1")],
+        "enota": ["kg"],
+        "cena_bruto": [Decimal("5")],
+        "cena_netto": [Decimal("5")],
+        "vrednost": [Decimal("5")],
+        "rabata": [Decimal("0")],
+        "wsm_sifra": [pd.NA],
+        "dobavitelj": ["Test"],
+        "kolicina_norm": [1.0],
+        "enota_norm": ["kg"],
+    })
+    manual_old = pd.DataFrame(columns=["sifra_dobavitelja", "naziv", "wsm_sifra", "dobavitelj", "enota_norm"])
+    wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+
+    base_dir = tmp_path / "suppliers"
+    links_dir = base_dir / "Test"
+    links_dir.mkdir(parents=True)
+    links_file = links_dir / "SUP_Test_povezane.xlsx"
+
+    monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
+
+    _save_and_close(
+        df,
+        manual_old,
+        wsm_df,
+        links_file,
+        DummyRoot(),
+        "Test",
+        "SUP",
+        {},
+        base_dir,
+    )
+
+    info_file = links_dir / "supplier.json"
+    assert info_file.exists()
+    data = json.loads(info_file.read_text())
+    assert data["sifra"] == "SUP"
+    assert data["ime"] == "Test"

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -436,7 +436,11 @@ def _save_and_close(
         from wsm.utils import log_price_history
 
         log_price_history(
-            df, links_file, service_date=service_date, invoice_id=invoice_hash
+            df,
+            links_file,
+            service_date=service_date,
+            suppliers_dir=sup_file,
+            invoice_id=invoice_hash,
         )
     except Exception as exc:
         log.warning(f"Napaka pri beleženju zgodovine cen: {exc}")
@@ -461,7 +465,7 @@ def review_links(
 ) -> pd.DataFrame:
     df = df.copy()
     supplier_code = links_file.stem.split("_")[0]
-    suppliers_file = Path("links")
+    suppliers_file = links_file.parent.parent
     log.debug(f"Pot do mape links: {suppliers_file}")
     sup_map = _load_supplier_map(suppliers_file)
 

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -239,6 +239,7 @@ def log_price_history(
     history_file: Union[str, Path],
     *,
     service_date: str | None = None,
+    suppliers_dir: Union[str, Path] | None = None,
     max_entries_per_code: int = 50,
     invoice_id: str | None = None,
 ) -> None:
@@ -247,8 +248,8 @@ def log_price_history(
     Shranjeni so identifikator artikla (``sifra_dobavitelja + naziv``), cena,
     trenutni čas in opcijsko datum opravljene storitve.
     """
-    suppliers_file = Path("links")
-    sup_map = _load_supplier_map(suppliers_file)
+    suppliers_path = Path(suppliers_dir) if suppliers_dir is not None else Path("links")
+    sup_map = _load_supplier_map(suppliers_path)
 
     df["supplier_name"] = df["sifra_dobavitelja"].apply(
         lambda x: sup_map.get(str(x), {}).get('ime', str(x))


### PR DESCRIPTION
## Summary
- derive supplier path from links file in review GUI
- allow passing a supplier directory to `log_price_history`
- persist supplier info to the chosen directory
- test price history logging with a custom dir
- regression test that supplier edits save correctly

## Testing
- `pytest -q tests/test_price_history_duplicates.py::test_log_price_history_avoids_duplicates`
- `pytest -q tests/test_cli_review.py tests/test_cli_override.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684be18a4f808321af04e49cf4147bfe