### PR TITLE
Fix last unit handling for custom suppliers

### DIFF
--- a/tests/test_supplier_edit_save.py
+++ b/tests/test_supplier_edit_save.py
@@ -50,3 +50,54 @@ def test_supplier_edit_saved_to_custom_dir(tmp_path, monkeypatch):
     data = json.loads(info_file.read_text())
     assert data["sifra"] == "SUP"
     assert data["ime"] == "Test"
+
+
+def test_remember_unit_custom_dir(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP"],
+        "naziv": ["Item"],
+        "kolicina": [Decimal("1")],
+        "enota": ["kg"],
+        "cena_bruto": [Decimal("5")],
+        "cena_netto": [Decimal("5")],
+        "vrednost": [Decimal("5")],
+        "rabata": [Decimal("0")],
+        "wsm_sifra": [pd.NA],
+        "dobavitelj": ["Test"],
+        "kolicina_norm": [1.0],
+        "enota_norm": ["kg"],
+    })
+    manual_old = pd.DataFrame(
+        columns=["sifra_dobavitelja", "naziv", "wsm_sifra", "dobavitelj", "enota_norm"]
+    )
+    wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+
+    base_dir = tmp_path / "suppliers"
+    links_dir = base_dir / "Test"
+    links_dir.mkdir(parents=True)
+    links_file = links_dir / "SUP_Test_povezane.xlsx"
+    last_unit_path = base_dir / "last_unit.txt"
+
+    monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
+
+    _save_and_close(
+        df,
+        manual_old,
+        wsm_df,
+        links_file,
+        DummyRoot(),
+        "Test",
+        "SUP",
+        {},
+        base_dir,
+        last_unit_file=last_unit_path,
+        remember=True,
+        unit_value="L",
+    )
+
+    assert last_unit_path.exists()
+    assert last_unit_path.read_text().strip() == "L"
+
+    derived = links_file.parent.parent / "last_unit.txt"
+    assert derived == last_unit_path
+    assert derived.read_text().strip() == "L"

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -12,13 +12,14 @@ from wsm.ui.review_links import _load_supplier_map
 from wsm.utils import sanitize_folder_name
 
 
-def launch_price_watch() -> None:
+def launch_price_watch(suppliers: Path | str = Path("links")) -> None:
     """Launch the price watch window."""
+    suppliers = Path(suppliers)
     root = tk.Tk()
     root.title("Spremljanje cen")
     root.geometry("500x400")
 
-    suppliers = _load_supplier_map(Path("links"))
+    suppliers = _load_supplier_map(suppliers)
     supplier_codes = sorted(suppliers)
 
     combo_values = [f"{c} - {suppliers[c]['ime']}" for c in supplier_codes]
@@ -45,7 +46,7 @@ def launch_price_watch() -> None:
         code = sel.split(" - ")[0]
         name = suppliers.get(code, {}).get("ime", code)
         safe_name = sanitize_folder_name(name)
-        hist_path = Path("links") / safe_name / "price_history.xlsx"
+        hist_path = suppliers / safe_name / "price_history.xlsx"
         listbox.delete(0, tk.END)
         item_data.clear()
         if not hist_path.exists():

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -302,7 +302,7 @@ def _save_and_close(
     *,
     override_h87_to_kg: bool = False,
     invoice_path=None,
-    unit_file: Path | None = None,
+    last_unit_file: Path | None = None,
     remember: bool = False,
     unit_value: str = "",
 ):
@@ -445,12 +445,12 @@ def _save_and_close(
     except Exception as exc:
         log.warning(f"Napaka pri beleženju zgodovine cen: {exc}")
 
-    if remember and unit_file:
+    if remember and last_unit_file:
         try:
-            unit_file.parent.mkdir(parents=True, exist_ok=True)
-            unit_file.write_text(unit_value)
+            last_unit_file.parent.mkdir(parents=True, exist_ok=True)
+            last_unit_file.write_text(unit_value)
         except Exception as exc:
-            log.warning(f"Napaka pri zapisu {unit_file}: {exc}")
+            log.warning(f"Napaka pri zapisu {last_unit_file}: {exc}")
 
     root.quit()
 
@@ -877,7 +877,7 @@ def review_links(
 
     # --- Unit change widgets ---
     unit_options = ["kos", "kg", "L"]
-    last_unit_file = Path("links") / "last_unit.txt"
+    last_unit_file = links_file.parent.parent / "last_unit.txt"
 
     unit_from_xml = df["enota_norm"].mode().iat[0] if not df.empty else "kg"
     remember_default = False
@@ -983,7 +983,7 @@ def review_links(
             suppliers_file,
             override_h87_to_kg=override_h87_to_kg,
             invoice_path=invoice_path,
-            unit_file=last_unit_file,
+            last_unit_file=last_unit_file,
             remember=remember_var.get(),
             unit_value=unit_var.get(),
         ),
@@ -1097,7 +1097,7 @@ def review_links(
             suppliers_file,
             override_h87_to_kg=override_h87_to_kg,
             invoice_path=invoice_path,
-            unit_file=last_unit_file,
+            last_unit_file=last_unit_file,
             remember=remember_var.get(),
             unit_value=unit_var.get(),
         ),


### PR DESCRIPTION
## Summary
- reference `last_unit_file` relative to the links file
- rename `_save_and_close` argument to `last_unit_file`
- allow price watch to accept a custom suppliers directory
- test remembering units when a custom path is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be689c4448321a5595eb8ca7d79a3