### PR TITLE
Clean up unused imports and lambdas

### DIFF
--- a/tests/test_cli_override.py
+++ b/tests/test_cli_override.py
@@ -1,6 +1,5 @@
 import json
 from decimal import Decimal
-from pathlib import Path
 
 from click.testing import CliRunner
 

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -1,6 +1,5 @@
 import json
 from decimal import Decimal
-from pathlib import Path
 
 from click.testing import CliRunner
 

--- a/tests/test_main_supplier_code.py
+++ b/tests/test_main_supplier_code.py
@@ -1,6 +1,5 @@
 import json
 from decimal import Decimal
-from pathlib import Path
 
 from wsm import analyze
 

--- a/tests/test_override_h87.py
+++ b/tests/test_override_h87.py
@@ -1,6 +1,5 @@
 import json
 from decimal import Decimal
-from pathlib import Path
 
 from wsm import analyze
 

--- a/tests/test_supplier_edit_save.py
+++ b/tests/test_supplier_edit_save.py
@@ -1,6 +1,5 @@
 import json
 from decimal import Decimal
-from pathlib import Path
 import pandas as pd
 from wsm.ui.review_links import _save_and_close
 

--- a/tests/test_unlinked_total.py
+++ b/tests/test_unlinked_total.py
@@ -45,7 +45,6 @@ def _calc_unlinked_total(xml_path: Path) -> Decimal:
 
     # all lines linked
     df["wsm_sifra"] = "X"
-    linked_total = df[df["wsm_sifra"].notna()]["total_net"].sum() + doc_discount_total
     unlinked_total = df[df["wsm_sifra"].isna()]["total_net"].sum()
     return unlinked_total
 

--- a/wsm/analyze.py
+++ b/wsm/analyze.py
@@ -6,7 +6,7 @@ import pandas as pd
 from wsm.parsing.eslog import parse_eslog_invoice
 from wsm.ui.review_links import _norm_unit, _load_supplier_map
 from wsm.parsing.eslog import extract_header_net
-from wsm.parsing.money import quantize_like, detect_round_step, round_to_step
+from wsm.parsing.money import detect_round_step, round_to_step
 
 
 def analyze_invoice(xml_path: str, suppliers_file: str | None = None) -> tuple[pd.DataFrame, Decimal, bool]:

--- a/wsm/parsing/__init__.py
+++ b/wsm/parsing/__init__.py
@@ -1,1 +1,1 @@
-from .eslog import parse_eslog_invoice
+

--- a/wsm/parsing/money.py
+++ b/wsm/parsing/money.py
@@ -1,6 +1,7 @@
 # File: wsm/parsing/money.py
 from decimal import Decimal, ROUND_HALF_UP
-
+import xml.etree.ElementTree as ET
+import pandas as pd
 
 def round_to_step(value: Decimal, step: Decimal, rounding=ROUND_HALF_UP) -> Decimal:
     """Round ``value`` to the nearest ``step`` (e.g. 0.01 or 0.05)."""
@@ -24,8 +25,6 @@ def quantize_like(value: Decimal, reference: Decimal, rounding=ROUND_HALF_UP) ->
     """Quantize ``value`` with the same precision as ``reference``."""
     quant = Decimal('1').scaleb(reference.as_tuple().exponent)
     return value.quantize(quant, rounding=rounding)
-import xml.etree.ElementTree as ET
-import pandas as pd
 
 def extract_total_amount(xml_root: ET.Element) -> Decimal:
     """

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -34,7 +34,10 @@ _rx_mass = re.compile(
     r"(?:teža|masa|weight)?\s*[:\s]?\s*([0-9]+[\.,]?[0-9]*)\s*((?:kgm?)|kgr|g|gr|gram|grams|mg|milligram|milligrams)\b",
     re.I,
 )
-_dec = lambda x: Decimal(x.replace(",", "."))
+
+def _dec(x: str) -> Decimal:
+    """Convert a comma-separated string to ``Decimal``."""
+    return Decimal(x.replace(",", "."))
 
 
 def _norm_unit(

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -24,7 +24,10 @@ def sanitize_folder_name(name: str) -> str:
         raise TypeError(f"sanitize_folder_name expects a string, got {type(name)}")
     return re.sub(r'[\\/*?:"<>|]', "_", name)
 
-_clean = lambda s: re.sub(r"\s+", " ", s.strip().lower())
+
+def _clean(s: str) -> str:
+    """Normalize whitespace and lowercase the string."""
+    return re.sub(r"\s+", " ", s.strip().lower())
 
 # Helper to retrieve the first real supplier code from a DataFrame. ``_DOC_``
 # rows appear in some invoices due to document-level discounts and should be


### PR DESCRIPTION
## Summary
- remove unused `Path` imports in tests
- drop unused variable in `test_unlinked_total`
- remove unused imports in `analyze.py` and `parsing/__init__.py`
- move imports to top in `money.py`
- replace `_dec` and `_clean` lambdas with functions

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684beb7516348321a9b5b6a1d1eaeaff