### PR TITLE
Fix override H87 unit conversion

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -923,7 +923,25 @@ def review_links(
     unit_var.trace_add("write", _on_unit_write)
 
     def _set_all_units():
-        new_u = unit_var.get()
+        """Apply the unit from ``unit_menu`` to all rows.
+
+        When ``override_h87_to_kg`` is enabled we always force the unit to
+        ``kg`` regardless of the combobox value.  This mirrors the behaviour of
+        the old application where checking the override instantly converted all
+        lines to kilograms.
+        """
+
+        selected = unit_var.get()
+
+        if override_h87_to_kg:
+            log.debug(
+                "override_H87_to_kg active -> overriding '%s' with 'kg'",
+                selected,
+            )
+            new_u = "kg"
+            unit_var.set("kg")
+        else:
+            new_u = selected
 
         log.debug(
             "_set_all_units invoked with unit_var=%s unit_menu=%s",


### PR DESCRIPTION
## Summary
- override dropdown choice when forcing H87 units to kg

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0b209a508321b21ddc9e58af363a