### PR TITLE
Add VAT-based unit fallback

### DIFF
--- a/tests/test_analyze_groupby.py
+++ b/tests/test_analyze_groupby.py
@@ -17,6 +17,7 @@ def test_grouping_by_code_and_discount(monkeypatch):
             'rabata_pct': Decimal('5'),
             'vrednost': Decimal('10'),
             'sifra_artikla': '001',
+            'ddv_stopnja': Decimal('22'),
         },
         {
             'sifra_dobavitelja': 'SUP',
@@ -29,6 +30,7 @@ def test_grouping_by_code_and_discount(monkeypatch):
             'rabata_pct': Decimal('5'),
             'vrednost': Decimal('15'),
             'sifra_artikla': '001',
+            'ddv_stopnja': Decimal('22'),
         },
         {
             'sifra_dobavitelja': 'SUP',
@@ -41,13 +43,14 @@ def test_grouping_by_code_and_discount(monkeypatch):
             'rabata_pct': Decimal('10'),
             'vrednost': Decimal('5'),
             'sifra_artikla': '001',
+            'ddv_stopnja': Decimal('22'),
         },
     ])
 
     # Patch parse_eslog_invoice to return our DataFrame
     monkeypatch.setattr(analyze, 'parse_eslog_invoice', lambda path, sup: data)
     # Identity normalization
-    monkeypatch.setattr(analyze, '_norm_unit', lambda q, u, n: (q, u))
+    monkeypatch.setattr(analyze, '_norm_unit', lambda q, u, n, vat=None: (q, u))
     # Header total equals sum of values
     monkeypatch.setattr(analyze, 'extract_header_net', lambda path: Decimal('30'))
 

--- a/tests/test_norm_unit.py
+++ b/tests/test_norm_unit.py
@@ -3,13 +3,19 @@ from wsm.ui.review_links import _norm_unit
 
 
 def test_norm_unit_mg_unit():
-    q, unit = _norm_unit(Decimal('500'), 'mg', 'Vitamin C')
+    q, unit = _norm_unit(Decimal('500'), 'mg', 'Vitamin C', Decimal('22'))
     assert unit == 'kg'
     assert q == Decimal('0.0005')
 
 
 def test_norm_unit_mg_in_name_with_kos():
-    q, unit = _norm_unit(Decimal('1'), 'kos', 'Tabletka 250 mg')
+    q, unit = _norm_unit(Decimal('1'), 'kos', 'Tabletka 250 mg', Decimal('9.5'))
     assert unit == 'kg'
     assert q == Decimal('0.00025')
+
+
+def test_norm_unit_vat_fallback():
+    q, unit = _norm_unit(Decimal('36'), 'H87', 'KREMA rast. za kuhanje  1/1', Decimal('9.5'))
+    assert unit == 'kg'
+    assert q == Decimal('36')
 

--- a/wsm/analyze.py
+++ b/wsm/analyze.py
@@ -24,7 +24,7 @@ def analyze_invoice(xml_path: str, suppliers_file: str | None = None) -> tuple[p
 
     # normalize units
     df[['kolicina', 'enota']] = [
-        _norm_unit(row['kolicina'], row['enota'], row['naziv'])
+        _norm_unit(row['kolicina'], row['enota'], row['naziv'], row['ddv_stopnja'])
         for _, row in df.iterrows()
     ]
 


### PR DESCRIPTION
## Summary
- support VAT hint when normalizing units
- update analyze logic to pass VAT rates
- adjust UI review normalization
- extend tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff02731088321992e1b02abd0961c