### PR TITLE
Add PDF metadata extraction

### DIFF
--- a/tests/sample_invoice.pdf
+++ b/tests/sample_invoice.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250616111726+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250616111726+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 162
+>>
+stream
+Gaq3^_$\%5&4H!cME+]\EAo][4UMr3dRtDF;HHgg"!s1\^/6FmQoWA0(^=RA08BOt"G_`J%e9U$[Xqb'Q6Q)$T6e@/>6;rjSE"B]N3Pk,>n%D7+E,=BAZsS\AbTEW)NL=HjGfpO&;)1(VbTdo,\ue)nfN`"^-F!F~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<99ebfd5cfbfe6f268ad5b0e367d6e530><99ebfd5cfbfe6f268ad5b0e367d6e530>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1079
+%%EOF

--- a/tests/test_pdf_header.py
+++ b/tests/test_pdf_header.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+from wsm.parsing.pdf import extract_service_date, extract_invoice_number
+
+SAMPLE = Path('tests/sample_invoice.pdf')
+
+def test_extract_service_date_pdf():
+    assert extract_service_date(SAMPLE) == '2025-05-20'
+
+def test_extract_invoice_number_pdf():
+    assert extract_invoice_number(SAMPLE) == 'INV-001'

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -414,6 +414,18 @@ def _save_and_close(
             invoice_hash = hashlib.md5(invoice_path.read_bytes()).hexdigest()
         except Exception as exc:
             log.warning(f"Napaka pri izračunu hash: {exc}")
+    elif invoice_path and invoice_path.suffix.lower() == ".pdf":
+        try:
+            from wsm.parsing.pdf import extract_service_date
+
+            service_date = extract_service_date(invoice_path)
+        except Exception as exc:
+            log.warning(f"Napaka pri branju datuma storitve: {exc}")
+            service_date = None
+        try:
+            invoice_hash = hashlib.md5(invoice_path.read_bytes()).hexdigest()
+        except Exception as exc:
+            log.warning(f"Napaka pri izračunu hash: {exc}")
     else:
         service_date = None
         if invoice_path and invoice_path.exists():
@@ -461,6 +473,14 @@ def review_links(
     if invoice_path and invoice_path.suffix.lower() == ".xml":
         try:
             from wsm.parsing.eslog import extract_service_date, extract_invoice_number
+
+            service_date = extract_service_date(invoice_path)
+            invoice_number = extract_invoice_number(invoice_path)
+        except Exception as exc:
+            log.warning(f"Napaka pri branju glave računa: {exc}")
+    elif invoice_path and invoice_path.suffix.lower() == ".pdf":
+        try:
+            from wsm.parsing.pdf import extract_service_date, extract_invoice_number
 
             service_date = extract_service_date(invoice_path)
             invoice_number = extract_invoice_number(invoice_path)


### PR DESCRIPTION
## Summary
- add PDF helpers to extract service date and invoice number
- support PDF metadata parsing in GUI
- log service dates from PDF invoices
- test the new helpers with a sample invoice

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ffca34ef48321925e2d22780cc821