### PR TITLE
Normalize service date in eslog parser

### DIFF
--- a/tests/service_date_dd_mm_yyyy.xml
+++ b/tests/service_date_dd_mm_yyyy.xml
@@ -1,0 +1,10 @@
+<Invoice xmlns='urn:eslog:2.00'>
+  <M_INVOIC>
+    <S_DTM>
+      <C_C507>
+        <D_2005>35</D_2005>
+        <D_2380>31.03.2025</D_2380>
+      </C_C507>
+    </S_DTM>
+  </M_INVOIC>
+</Invoice>

--- a/tests/service_date_yyyymmdd.xml
+++ b/tests/service_date_yyyymmdd.xml
@@ -1,0 +1,10 @@
+<Invoice xmlns='urn:eslog:2.00'>
+  <M_INVOIC>
+    <S_DTM>
+      <C_C507>
+        <D_2005>35</D_2005>
+        <D_2380>20250331</D_2380>
+      </C_C507>
+    </S_DTM>
+  </M_INVOIC>
+</Invoice>

--- a/tests/test_service_date.py
+++ b/tests/test_service_date.py
@@ -10,3 +10,13 @@ def test_extract_service_date_delivery():
 def test_extract_service_date_fallback():
     xml = Path("tests/VP2025-1799-racun.xml")
     assert extract_service_date(xml) == "2025-03-06"
+
+
+def test_service_date_normalizes_dot_format():
+    xml = Path("tests/service_date_dd_mm_yyyy.xml")
+    assert extract_service_date(xml) == "2025-03-31"
+
+
+def test_service_date_normalizes_plain_format():
+    xml = Path("tests/service_date_yyyymmdd.xml")
+    assert extract_service_date(xml) == "2025-03-31"

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -36,6 +36,19 @@ def _decimal(el: ET.Element | None) -> Decimal:
     except Exception:
         return Decimal("0")
 
+def _normalize_date(date_str: str) -> str:
+    """Convert ``DD.MM.YYYY`` or ``YYYYMMDD`` into ``YYYY-MM-DD``."""
+    s = date_str.replace(" ", "").replace("\xa0", "")
+    m = re.match(r"(\d{1,2})\.(\d{1,2})\.(\d{4})$", s)
+    if m:
+        d, mth, y = m.groups()
+        return f"{y}-{int(mth):02d}-{int(d):02d}"
+    m = re.match(r"(\d{4})(\d{2})(\d{2})$", s)
+    if m:
+        y, mth, d = m.groups()
+        return f"{y}-{mth}-{d}"
+    return s
+
 # Namespace za ESLOG (če je prisoten)
 NS = {"e": "urn:eslog:2.00"}
 
@@ -108,12 +121,12 @@ def extract_service_date(xml_path: Path | str) -> str | None:
             if _text(dtm.find('./e:C_C507/e:D_2005', NS)) == '35':
                 date = _text(dtm.find('./e:C_C507/e:D_2380', NS))
                 if date:
-                    return date
+                    return _normalize_date(date)
         for dtm in root.findall('.//e:S_DTM', NS):
             if _text(dtm.find('./e:C_C507/e:D_2005', NS)) == '137':
                 date = _text(dtm.find('./e:C_C507/e:D_2380', NS))
                 if date:
-                    return date
+                    return _normalize_date(date)
     except Exception:
         pass
     return None


### PR DESCRIPTION
## Summary
- normalize service dates from ESLOG XML files
- update `extract_service_date` to return normalized value
- add regression tests for dotted and plain numeric formats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685005a388a48321a9fb62fed61dbbe9