### PR TITLE
refactor: share normalize_date helper

### DIFF
--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -18,6 +18,7 @@ import xml.etree.ElementTree as ET
 from typing import List, Dict, Optional, Tuple
 
 import pandas as pd
+from .utils import _normalize_date
 
 # Uvoz pomožnih funkcij iz money.py:
 from wsm.parsing.money import extract_total_amount, validate_invoice as validate_line_values
@@ -36,18 +37,6 @@ def _decimal(el: ET.Element | None) -> Decimal:
     except Exception:
         return Decimal("0")
 
-def _normalize_date(date_str: str) -> str:
-    """Convert ``DD.MM.YYYY`` or ``YYYYMMDD`` into ``YYYY-MM-DD``."""
-    s = date_str.replace(" ", "").replace("\xa0", "")
-    m = re.match(r"(\d{1,2})\.(\d{1,2})\.(\d{4})$", s)
-    if m:
-        d, mth, y = m.groups()
-        return f"{y}-{int(mth):02d}-{int(d):02d}"
-    m = re.match(r"(\d{4})(\d{2})(\d{2})$", s)
-    if m:
-        y, mth, d = m.groups()
-        return f"{y}-{mth}-{d}"
-    return s
 
 # Namespace za ESLOG (če je prisoten)
 NS = {"e": "urn:eslog:2.00"}

--- a/wsm/parsing/pdf.py
+++ b/wsm/parsing/pdf.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 import pandas as pd
 import pdfplumber
+from .utils import _normalize_date
 
 # ───────────────────── ime dobavitelja (za CLI) ──────────────────────
 def get_supplier_name_from_pdf(pdf_path: str | Path) -> Optional[str]:
@@ -75,14 +76,6 @@ _date_label_rx = re.compile(r"(?:Datum\s+storitve|Service\s+date|Datum\s+opravlj
 _date_value_rx = re.compile(r"(\d{4}-\d{2}-\d{2}|\d{1,2}\.?\s*\d{1,2}\.?\s*\d{4})")
 _invoice_label_rx = re.compile(r"(?:\u0160t\.\s*ra\u010duna|Invoice\s*no\.?|Invoice\s*number)", re.I)
 _invoice_value_rx = re.compile(r"([A-Za-z0-9-_/]+)")
-
-def _normalize_date(date_str: str) -> str:
-    s = date_str.replace(" ", "").replace("\xa0", "")
-    m = re.match(r"(\d{1,2})\.?\s*(\d{1,2})\.?\s*(\d{4})", s)
-    if m:
-        d, mth, y = m.groups()
-        return f"{y}-{int(mth):02d}-{int(d):02d}"
-    return s
 
 def extract_service_date(pdf_path: Path) -> str | None:
     """Extract service date from first PDF pages if possible."""

--- a/wsm/parsing/utils.py
+++ b/wsm/parsing/utils.py
@@ -1,0 +1,17 @@
+# File: wsm/parsing/utils.py
+"""Utility helpers for parsers."""
+from __future__ import annotations
+import re
+
+def _normalize_date(date_str: str) -> str:
+    """Convert ``DD.MM.YYYY`` or ``YYYYMMDD`` and similar into ``YYYY-MM-DD``."""
+    s = date_str.replace(" ", "").replace("\xa0", "")
+    m = re.match(r"(\d{4})(\d{2})(\d{2})$", s)
+    if m:
+        y, mth, d = m.groups()
+        return f"{y}-{mth}-{d}"
+    m = re.match(r"(\d{1,2})\.?\s*(\d{1,2})\.?\s*(\d{4})$", s)
+    if m:
+        d, mth, y = m.groups()
+        return f"{y}-{int(mth):02d}-{int(d):02d}"
+    return s


### PR DESCRIPTION
## Summary
- extract `_normalize_date` from PDF and ESLOG parsers
- share the helper via `wsm.parsing.utils`
- update parsers to import the shared function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68500ee4f3648321a340370ad75461aa