### PR TITLE
Stop starting review GUI in fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
    ```bash
    python -m wsm.cli review <invoice.xml>
    ```
-   (po želji dodajte `--wsm-codes pot/do/sifre_wsm.xlsx`)
+  (po želji dodajte `--wsm-codes pot/do/sifre_wsm.xlsx`)
   Program odpre grafični vmesnik, kjer povezave shranjujete v podmapo
   `links/<ime_dobavitelja>/`. Posodobljene tabele najdete v datotekah
- `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
+  `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
+  Okno se odpre v običajni velikosti (ne več čez cel zaslon), zato ga po
+  potrebi ročno povečajte.
 
 Če `--wsm-codes` ni podan, program poskuša prebrati `sifre_wsm.xlsx` v
 korenu projekta.

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -688,8 +688,9 @@ def review_links(
 
     header_lbl = tk.Label(root, textvariable=header_var, font=("Arial", 14, "bold"))
     header_lbl.pack(pady=4)
-    # Start in fullscreen; press Esc to exit
-    root.attributes("-fullscreen", True)
+    # Window starts in normal mode. Press Esc to exit fullscreen if enabled
+    # manually (e.g. via the window manager).
+    # root.attributes("-fullscreen", True)
     root.bind("<Escape>", lambda e: root.attributes("-fullscreen", False))
 
     frame = tk.Frame(root)


### PR DESCRIPTION
## Summary
- prevent `review_links` window from forcing fullscreen at startup
- document the windowed start behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850129ed8f88321b7fe8d7873c1061a