### PR TITLE
Improve sanitize_folder_name

### DIFF
--- a/tests/test_sanitize_folder_name.py
+++ b/tests/test_sanitize_folder_name.py
@@ -1,0 +1,13 @@
+import pytest
+from wsm.utils import sanitize_folder_name
+
+
+def test_invalid_chars_replaced():
+    assert sanitize_folder_name("A<B>:C?") == "A_B__C_"
+
+def test_trailing_dot_and_space_removed():
+    assert sanitize_folder_name("Supplier. ") == "Supplier"
+
+def test_non_string_raises_type_error():
+    with pytest.raises(TypeError):
+        sanitize_folder_name(None)

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -19,10 +19,15 @@ log = logging.getLogger(__name__)
 
 # ────────────────────────── skupna orodja ───────────────────────────
 def sanitize_folder_name(name: str) -> str:
-    """Prepovedane znake zamenja z “_” (Windows/Linux združljivo)."""
+    """Prepovedane znake zamenja z ``_`` in odstrani končne presledke/pike."""
     if not isinstance(name, str):
-        raise TypeError(f"sanitize_folder_name expects a string, got {type(name)}")
-    return re.sub(r'[\\/*?:"<>|]', "_", name)
+        raise TypeError(
+            f"sanitize_folder_name expects a string, got {type(name)}"
+        )
+    cleaned = re.sub(r'[\\/*?:"<>|]', "_", name)
+    # Trailing dots and spaces niso dovoljeni na Windows
+    cleaned = re.sub(r"[\s.]+$", "", cleaned)
+    return cleaned
 
 
 def _clean(s: str) -> str:


### PR DESCRIPTION
## Summary
- sanitize trailing characters from folder names
- add tests for sanitize_folder_name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513348253c83218c864346d48a7acf