### PR TITLE
Improve header info widgets

### DIFF
--- a/tests/test_decimal_precision.py
+++ b/tests/test_decimal_precision.py
@@ -1,4 +1,3 @@
-import pytest
 from decimal import Decimal
 from wsm.parsing.eslog import parse_invoice
 

--- a/tests/test_parse_eslog_document_discount.py
+++ b/tests/test_parse_eslog_document_discount.py
@@ -2,7 +2,11 @@ from decimal import Decimal, ROUND_HALF_UP
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
-from wsm.parsing.eslog import parse_eslog_invoice, DEFAULT_DOC_DISCOUNT_CODES
+from wsm.parsing.eslog import (
+    parse_eslog_invoice,
+    DEFAULT_DOC_DISCOUNT_CODES,
+    extract_header_net,
+)
 
 
 def _compute_doc_discount(xml_path: Path) -> Decimal:
@@ -99,9 +103,6 @@ def test_parse_eslog_invoice_sums_multiple_discount_codes(tmp_path):
 
     assert doc_row["vrednost"] == Decimal("-3.50")
     assert doc_row["rabata_pct"] == Decimal("100.00")
-
-
-from wsm.parsing.eslog import extract_header_net
 
 
 def test_line_and_doc_discount_total_matches_header():

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -1,11 +1,16 @@
 # File: wsm/ui/review_links.py
 # -*- coding: utf-8 -*-
 from __future__ import annotations
-import math, re, logging, hashlib, json
+import hashlib
+import json
+import logging
+import math
+import re
 from decimal import Decimal
 from wsm.parsing.money import detect_round_step
 from pathlib import Path
 from typing import Tuple
+from wsm.utils import short_supplier_name
 
 import pandas as pd
 import tkinter as tk
@@ -463,7 +468,7 @@ def review_links(
 
     log.info(f"Supplier code extracted: {supplier_code}")
     supplier_info = sup_map.get(supplier_code, {})
-    default_name = supplier_info.get("ime", supplier_code)
+    default_name = short_supplier_name(supplier_info.get("ime", supplier_code))
 
     service_date = None
     invoice_number = None
@@ -500,7 +505,7 @@ def review_links(
         except Exception:
             inv_name = None
     if inv_name:
-        default_name = inv_name
+        default_name = short_supplier_name(inv_name)
 
     log.info(f"Default name retrieved: {default_name}")
     log.debug(f"Supplier info: {supplier_info}")
@@ -533,12 +538,12 @@ def review_links(
 
     existing_names = sorted(
         {
-            n
+            short_supplier_name(n)
             for n in manual_old.get("dobavitelj", [])
             if isinstance(n, str) and n.strip()
         }
     )
-    supplier_name = default_name
+    supplier_name = short_supplier_name(default_name)
     if supplier_name and supplier_name not in existing_names:
         existing_names.insert(0, supplier_name)
     supplier_name = existing_names[0] if existing_names else supplier_code
@@ -674,6 +679,9 @@ def review_links(
 
     display_name = supplier_name[:20]
     header_var = tk.StringVar()
+    supplier_var = tk.StringVar()
+    date_var = tk.StringVar()
+    invoice_var = tk.StringVar()
 
     def _refresh_header():
         parts_full = [supplier_name]
@@ -688,39 +696,77 @@ def review_links(
                 date_txt = f"{d}.{m}.{y}"
             parts_full.append(date_txt)
             parts_display.append(date_txt)
+            date_var.set(date_txt)
+        else:
+            date_var.set("")
         if invoice_number:
             parts_full.append(str(invoice_number))
             parts_display.append(str(invoice_number))
+            invoice_var.set(str(invoice_number))
+        else:
+            invoice_var.set("")
+        supplier_var.set(supplier_name)
         header_var.set(" – ".join(parts_display))
         root.title(f"Ročna revizija – {' – '.join(parts_full)}")
 
     _refresh_header()
 
-    info_lbl = tk.Label(
-        root,
-        textvariable=header_var,
-        font=("Arial", 12),
-        anchor="w",
-        justify="left",
-    )
-    info_lbl.pack(anchor="w", padx=8)
-
     header_lbl = tk.Label(
         root,
         textvariable=header_var,
-        font=("Arial", 32, "bold"),
+        font=("Arial", 24, "bold"),
         anchor="center",
         justify="center",
     )
-    header_lbl.pack(fill="x", pady=8)
+    header_lbl.pack(fill="x", pady=4)
+
+    info_frame = tk.Frame(root)
+    info_frame.pack(anchor="w", padx=8, pady=(0, 4))
+
+    def _copy(val: str) -> None:
+        root.clipboard_clear()
+        root.clipboard_append(val)
+
+    tk.Label(info_frame, text="Dobavitelj:").grid(row=0, column=0, sticky="w")
+    tk.Entry(
+        info_frame,
+        textvariable=supplier_var,
+        state="readonly",
+        width=40,
+        readonlybackground="white",
+        fg="black",
+    ).grid(row=0, column=1, sticky="w", padx=(4, 4))
+    tk.Button(info_frame, text="Kopiraj", command=lambda: _copy(supplier_var.get())).grid(row=0, column=2)
+
+    tk.Label(info_frame, text="Datum storitve:").grid(row=1, column=0, sticky="w")
+    tk.Entry(
+        info_frame,
+        textvariable=date_var,
+        state="readonly",
+        width=20,
+        readonlybackground="white",
+        fg="black",
+    ).grid(row=1, column=1, sticky="w", padx=(4, 4))
+    tk.Button(info_frame, text="Kopiraj", command=lambda: _copy(date_var.get())).grid(row=1, column=2)
+
+    tk.Label(info_frame, text="Št. računa:").grid(row=2, column=0, sticky="w")
+    tk.Entry(
+        info_frame,
+        textvariable=invoice_var,
+        state="readonly",
+        width=20,
+        readonlybackground="white",
+        fg="black",
+    ).grid(row=2, column=1, sticky="w", padx=(4, 4))
+    tk.Button(info_frame, text="Kopiraj", command=lambda: _copy(invoice_var.get())).grid(row=2, column=2)
 
     # Repeat invoice info above the main table for better visibility
     table_info_lbl = tk.Label(
         root,
         textvariable=header_var,
-        font=("Arial", 20, "bold"),
+        font=("Arial", 16, "bold"),
     )
-    table_info_lbl.pack(pady=(0, 4))
+    table_info_lbl.pack(pady=(0, 2))
     # Allow Escape to restore the original window size
     root.bind("<Escape>", lambda e: root.state("normal"))
 
@@ -909,18 +955,22 @@ def review_links(
 
     bottom = tk.Frame(root)
     bottom.pack(fill="x", padx=8, pady=6)
+
     custom = tk.Frame(bottom)
-    custom.pack(fill="x")
+    custom.pack(side="left", fill="x", expand=True)
     tk.Label(custom, text="Vpiši / izberi WSM naziv:").pack(side="left")
     entry = tk.Entry(custom)
     entry.pack(side="left", fill="x", expand=True, padx=(4, 0))
     lb = tk.Listbox(custom, height=6)
 
+    btn_frame = tk.Frame(bottom)
+    btn_frame.pack(side="right")
+
     # --- Unit change widgets ---
     unit_options = ["kos", "kg", "L"]
 
     save_btn = tk.Button(
-        bottom,
+        btn_frame,
         text="Shrani & zapri",
         width=14,
         command=lambda e=None: _save_and_close(
@@ -941,7 +991,7 @@ def review_links(
         root.quit()
 
     exit_btn = tk.Button(
-        bottom,
+        btn_frame,
         text="Izhod",
         width=14,
         command=_exit,

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -12,10 +12,14 @@ import re
 from typing import Tuple, Union, List, Dict
 
 import pandas as pd
-from wsm.ui.review_links import _load_supplier_map
-
 import logging
 log = logging.getLogger(__name__)
+
+
+def _load_supplier_map(path: Path) -> dict:
+    """Lazy import wrapper for :func:`wsm.ui.review_links._load_supplier_map`."""
+    from wsm.ui.review_links import _load_supplier_map as real
+    return real(path)
 
 # ────────────────────────── skupna orodja ───────────────────────────
 def sanitize_folder_name(name: str) -> str:
@@ -72,6 +76,27 @@ def sanitize_folder_name(name: str) -> str:
 def _clean(s: str) -> str:
     """Normalize whitespace and lowercase the string."""
     return re.sub(r"\s+", " ", s.strip().lower())
+
+
+def short_supplier_name(name: str) -> str:
+    """Return a supplier name without location or extra descriptors.
+
+    Examples
+    --------
+    >>> short_supplier_name("Podjetje d.o.o., Maribor")
+    'Podjetje d.o.o.'
+    >>> short_supplier_name("Dobavitelj d.d. Celje")
+    'Dobavitelj d.d.'
+    """
+
+    if not isinstance(name, str):
+        return name
+
+    base = name.split(",")[0]
+    m = re.search(r"(.+?(?:d\.o\.o\.|d\.d\.|s\.p\.))", base, re.I)
+    if m:
+        base = m.group(1)
+    return base.strip()
 
 # Helper to retrieve the first real supplier code from a DataFrame. ``_DOC_``
 # rows appear in some invoices due to document-level discounts and should be


### PR DESCRIPTION
## Summary
- split multi-import line in `review_links.py`
- remove unused test imports and move import to module top
- add copyable supplier info widgets in GUI
- show readonly fields with visible text and organize action buttons

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685265de711c83218f237a11d4d56c1b