### PR TITLE
Improve copy button labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
   Okno se privzeto odpre v običajni velikosti. S tipko F11 ga lahko
   ročno preklopite v celozaslonski način, iz katerega izstopite s
   tipko Esc.
-  Pri vrhu okna so prikazana polja za dobavitelja, datum storitve in 
-  številko računa. Za vsakim je gumb "Kopiraj", ki vsebino hitro prenese na odložišče.
+  Pri vrhu okna so prikazana polja za dobavitelja, datum storitve in
+  številko računa. Za vsakim je gumb ("Kopiraj dobavitelja", "Kopiraj storitev"
+  in "Kopiraj številko računa"), ki vsebino hitro prenese na odložišče.
 
 
 Če `--wsm-codes` ni podan, program poskuša prebrati `sifre_wsm.xlsx` v

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -743,7 +743,7 @@ def review_links(
         readonlybackground="white",
         fg="black",
     ).grid(row=0, column=1, sticky="w", padx=(4, 4))
-    tk.Button(info_frame, text="Kopiraj", command=lambda: _copy(supplier_var.get())).grid(row=0, column=2)
+    tk.Button(info_frame, text="Kopiraj dobavitelja", command=lambda: _copy(supplier_var.get())).grid(row=0, column=2)
 
     tk.Label(info_frame, text="Datum storitve:").grid(row=1, column=0, sticky="w")
     tk.Entry(
@@ -754,7 +754,7 @@ def review_links(
         readonlybackground="white",
         fg="black",
     ).grid(row=1, column=1, sticky="w", padx=(4, 4))
-    tk.Button(info_frame, text="Kopiraj", command=lambda: _copy(date_var.get())).grid(row=1, column=2)
+    tk.Button(info_frame, text="Kopiraj storitev", command=lambda: _copy(date_var.get())).grid(row=1, column=2)
 
     tk.Label(info_frame, text="Št. računa:").grid(row=2, column=0, sticky="w")
     tk.Entry(
@@ -765,7 +765,7 @@ def review_links(
         readonlybackground="white",
         fg="black",
     ).grid(row=2, column=1, sticky="w", padx=(4, 4))
-    tk.Button(info_frame, text="Kopiraj", command=lambda: _copy(invoice_var.get())).grid(row=2, column=2)
+    tk.Button(info_frame, text="Kopiraj številko računa", command=lambda: _copy(invoice_var.get())).grid(row=2, column=2)
 
     # Refresh header once widgets exist. ``after_idle`` ensures widgets are
     # fully initialized before values are set so the entries show up


### PR DESCRIPTION
## Summary
- rename copy buttons in review GUI for clarity
- update README to reflect new button names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68529c2aab408321be5039c038812c78