### PR TITLE
Add env var overrides for supplier paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
 
 Če `--wsm-codes` ni podan, program poskuša prebrati `sifre_wsm.xlsx` v
 korenu projekta.
+Lahko pa pot do datoteke določite tudi z okoljsko spremenljivko
+`WSM_CODES`. Podobno lahko z `WSM_SUPPLIERS` nastavite mapo s povezavami
+do dobaviteljev. GUI in ukazi CLI privzeto upoštevajo ti spremenljivki,
+če argumenti niso podani.
 
 Pri samodejnem povezovanju lahko program iz teh ročno
 shranjenih datotek sam izdela datoteko `keywords.xlsx`.


### PR DESCRIPTION
## Summary
- allow overriding default supplier and code paths via environment variables
- adjust CLI to read WSM_SUPPLIERS and WSM_CODES when options are omitted
- update GUI helper to use these environment variables
- document new variables in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a6c88c1483219caf1d230c5f075e