### PR TITLE
Add WSM_KEYWORDS env variable and optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ korenu projekta.
 Lahko pa pot do datoteke določite tudi z okoljsko spremenljivko
 `WSM_CODES`. Podobno lahko z `WSM_SUPPLIERS` nastavite mapo s povezavami
 do dobaviteljev. GUI in ukazi CLI privzeto upoštevajo ti spremenljivki,
-če argumenti niso podani.
+če argumenti niso podani. Pot do datoteke `keywords.xlsx` lahko
+nastavite z `WSM_KEYWORDS` (privzeto je `keywords.xlsx` v korenu projekta).
 
 Pri samodejnem povezovanju lahko program iz teh ročno
 shranjenih datotek sam izdela datoteko `keywords.xlsx`.

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -52,3 +52,21 @@ def test_povezi_z_wsm_autolearn(tmp_path):
     assert result.loc[0, "status"] == "KLJUCNA_BES"
     assert keywords_path.exists()
 
+
+def test_povezi_z_wsm_reads_env(monkeypatch, tmp_path):
+    links_dir = _setup_manual_links(tmp_path)
+    sifre_path = tmp_path / "sifre_wsm.xlsx"
+    pd.DataFrame({"wsm_sifra": ["100"], "wsm_naziv": ["Coca Cola"]}).to_excel(sifre_path, index=False)
+
+    env_path = tmp_path / "env_keywords.xlsx"
+    monkeypatch.setenv("WSM_KEYWORDS", str(env_path))
+
+    df_items = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP"],
+        "naziv": ["Coca Cola Zero Sugar 0.5L"],
+    })
+
+    result = povezi_z_wsm(df_items, str(sifre_path), links_dir=links_dir, supplier_code="SUP")
+    assert result.loc[0, "wsm_sifra"] == "100"
+    assert env_path.exists()
+

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from decimal import Decimal
+import os
 import re
 from typing import Tuple, Union, List, Dict
 
@@ -232,17 +233,25 @@ def load_wsm_data(
 def povezi_z_wsm(
     df_items      : pd.DataFrame,
     sifre_path    : str,
-    keywords_path : str,
-    links_dir     : Path,
-    supplier_code : str
+    keywords_path : str | None = None,
+    links_dir     : Path | None = None,
+    supplier_code : str | None = None
 ) -> pd.DataFrame:
     """
-    Poskusi vsaki vrstici v df_items pripisati WSM kodo:
-      1) če obstaja ročna povezava → status “POVEZANO”
-      2) če se v nazivu pojavi ključna beseda → status “KLJUCNA_BES”
-      3) sicer status NaN (prazno)
+    Poskusi vsaki vrstici v ``df_items`` pripisati WSM kodo:
+      1) če obstaja ročna povezava → status ``POVEZANO``
+      2) če se v nazivu pojavi ključna beseda → status ``KLJUCNA_BES``
+      3) sicer status ``NaN`` (prazno)
     Nove zadetke po ključnih besedah doda v datoteko povezav.
+
+    ``keywords_path`` je neobvezen. Če ni podan, funkcija prebere
+    okoljsko spremenljivko ``WSM_KEYWORDS`` in privzeto uporabi
+    ``keywords.xlsx``.
     """
+    if keywords_path is None:
+        keywords_path = os.getenv("WSM_KEYWORDS", "keywords.xlsx")
+    if links_dir is None or supplier_code is None:
+        raise TypeError("links_dir and supplier_code must be provided")
     kw_path = Path(keywords_path)
     if not kw_path.exists():
         extract_keywords(links_dir, kw_path)


### PR DESCRIPTION
## Summary
- add `WSM_KEYWORDS` environment variable for `keywords.xlsx`
- allow `povezi_z_wsm` to omit `keywords_path` and read the env var
- document the new variable in the README
- test that `povezi_z_wsm` reads `WSM_KEYWORDS` by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ccd9488c83219a879dfac1642fd8