### PR TITLE
Use WSM_KEYWORDS env for keyword links

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Lahko pa pot do datoteke določite tudi z okoljsko spremenljivko
 do dobaviteljev. GUI in ukazi CLI privzeto upoštevajo ti spremenljivki,
 če argumenti niso podani.
 
+Za datoteko s ključnimi besedami lahko nastavite okoljsko spremenljivko
+`WSM_KEYWORDS`, ki kaže na `kljucne_besede_wsm_kode.xlsx`. Če ni
+nastavljena, program privzeto bere to datoteko iz trenutne mape.
+
 
 Pri samodejnem povezovanju lahko program iz teh ročno
 shranjenih datotek sam izdela datoteko `kljucne_besede_wsm_kode.xlsx`.

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -37,8 +37,12 @@ def test_cli_review_uses_env_vars(monkeypatch, tmp_path):
     codes_file = tmp_path / "codes.xlsx"
     codes_file.write_text("dummy")
 
+    keywords_file = tmp_path / "kw.xlsx"
+    keywords_file.write_text("dummy")
+
     monkeypatch.setenv("WSM_SUPPLIERS", str(suppliers_dir))
     monkeypatch.setenv("WSM_CODES", str(codes_file))
+    monkeypatch.setenv("WSM_KEYWORDS", str(keywords_file))
 
     captured = {}
 
@@ -61,9 +65,14 @@ def test_cli_review_uses_env_vars(monkeypatch, tmp_path):
     def fake_review_links(df, wsm_df, links_file, total, invoice_path):
         captured["links"] = links_file
 
+    def fake_povezi(df, sifre, keywords_path=None, links_dir=None, supplier_code=None):
+        captured["kw"] = Path(keywords_path)
+        return df
+
     monkeypatch.setattr(cli, "analyze_invoice", fake_analyze)
     monkeypatch.setattr(cli.pd, "read_excel", fake_read_excel)
     monkeypatch.setattr("wsm.ui.review_links.review_links", fake_review_links)
+    monkeypatch.setattr("wsm.utils.povezi_z_wsm", fake_povezi)
     monkeypatch.setattr(cli, "get_supplier_name", lambda p: "Test Supplier")
 
     runner = CliRunner()
@@ -74,6 +83,7 @@ def test_cli_review_uses_env_vars(monkeypatch, tmp_path):
     assert captured["sup"] == str(suppliers_dir)
     assert captured["codes"] == codes_file
     assert captured["links"] == expected
+    assert captured["kw"] == keywords_file
 
 
 def test_open_invoice_gui_uses_env_vars(monkeypatch, tmp_path):
@@ -84,8 +94,12 @@ def test_open_invoice_gui_uses_env_vars(monkeypatch, tmp_path):
     codes_file = tmp_path / "codes.xlsx"
     codes_file.write_text("dummy")
 
+    keywords_file = tmp_path / "kw.xlsx"
+    keywords_file.write_text("dummy")
+
     monkeypatch.setenv("WSM_SUPPLIERS", str(suppliers_dir))
     monkeypatch.setenv("WSM_CODES", str(codes_file))
+    monkeypatch.setenv("WSM_KEYWORDS", str(keywords_file))
 
     captured = {}
 
@@ -108,9 +122,14 @@ def test_open_invoice_gui_uses_env_vars(monkeypatch, tmp_path):
     def fake_review_links(df, wsm_df, links_file, total, invoice_path):
         captured["links"] = links_file
 
+    def fake_povezi(df, sifre, keywords_path=None, links_dir=None, supplier_code=None):
+        captured["kw"] = Path(keywords_path)
+        return df
+
     monkeypatch.setattr("wsm.ui.common.analyze_invoice", fake_analyze)
     monkeypatch.setattr("wsm.ui.common.pd.read_excel", fake_read_excel)
     monkeypatch.setattr("wsm.ui.common.review_links", fake_review_links)
+    monkeypatch.setattr("wsm.utils.povezi_z_wsm", fake_povezi)
     monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Test Supplier")
 
     open_invoice_gui(invoice_path=invoice)
@@ -119,3 +138,4 @@ def test_open_invoice_gui_uses_env_vars(monkeypatch, tmp_path):
     assert captured["sup"] == suppliers_dir
     assert captured["codes"] == codes_file
     assert captured["links"] == expected
+    assert captured["kw"] == keywords_file

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -70,3 +70,20 @@ def test_povezi_z_wsm_reads_env(monkeypatch, tmp_path):
     assert result.loc[0, "wsm_sifra"] == "100"
     assert env_path.exists()
 
+
+def test_povezi_z_wsm_default_path(monkeypatch, tmp_path):
+    links_dir = _setup_manual_links(tmp_path)
+    sifre_path = tmp_path / "sifre_wsm.xlsx"
+    pd.DataFrame({"wsm_sifra": ["100"], "wsm_naziv": ["Coca Cola"]}).to_excel(sifre_path, index=False)
+
+    monkeypatch.chdir(tmp_path)
+
+    df_items = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP"],
+        "naziv": ["Coca Cola Zero Sugar 0.5L"],
+    })
+
+    result = povezi_z_wsm(df_items, str(sifre_path), links_dir=links_dir, supplier_code="SUP")
+    assert result.loc[0, "wsm_sifra"] == "100"
+    assert (tmp_path / "kljucne_besede_wsm_kode.xlsx").exists()
+

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -36,6 +36,7 @@ def open_invoice_gui(
     invoice_path: Path,
     suppliers: Path | None = None,
     wsm_codes: Path | None = None,
+    keywords: Path | None = None,
 ) -> None:
     """Parse invoice and launch the review GUI.
 
@@ -49,6 +50,8 @@ def open_invoice_gui(
         suppliers = Path(os.getenv("WSM_SUPPLIERS", "links"))
     if wsm_codes is None:
         wsm_codes = Path(os.getenv("WSM_CODES", "sifre_wsm.xlsx"))
+    if keywords is None:
+        keywords = Path(os.getenv("WSM_KEYWORDS", "kljucne_besede_wsm_kode.xlsx"))
     try:
         if invoice_path.suffix.lower() == ".xml":
             df, total, _ = analyze_invoice(str(invoice_path), str(suppliers))
@@ -93,6 +96,13 @@ def open_invoice_gui(
             wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
     else:
         wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+
+    try:
+        from wsm.utils import povezi_z_wsm
+
+        df = povezi_z_wsm(df, str(sifre_file), str(keywords), suppliers, supplier_code)
+    except Exception as exc:
+        logging.warning(f"Napaka pri samodejnem povezovanju: {exc}")
 
     review_links(df, wsm_df, links_file, total, invoice_path)
 

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -195,9 +195,9 @@ def extract_keywords(links_dir: Path, keywords_path: Path) -> pd.DataFrame:
 
 def load_wsm_data(
     sifre_path   : str,
-    keywords_path: str,
+    keywords_path: str | None,
     links_dir    : Path,
-    supplier_code: str
+    supplier_code: str,
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """
     Vrne:
@@ -206,6 +206,9 @@ def load_wsm_data(
       • links_df  – ročne povezave za dobavitelja (če obstaja datoteka)
     """
     sifre_df = pd.read_excel(sifre_path, dtype=str)
+
+    if keywords_path is None:
+        keywords_path = os.getenv("WSM_KEYWORDS", "kljucne_besede_wsm_kode.xlsx")
 
     kw_all = pd.read_excel(keywords_path, dtype=str)
     kw_all = _coerce_keyword_column(kw_all)
@@ -246,10 +249,10 @@ def povezi_z_wsm(
 
     ``keywords_path`` je neobvezen. Če ni podan, funkcija prebere
     okoljsko spremenljivko ``WSM_KEYWORDS`` in privzeto uporabi
-    ``keywords.xlsx``.
+    ``kljucne_besede_wsm_kode.xlsx``.
     """
     if keywords_path is None:
-        keywords_path = os.getenv("WSM_KEYWORDS", "keywords.xlsx")
+        keywords_path = os.getenv("WSM_KEYWORDS", "kljucne_besede_wsm_kode.xlsx")
     if links_dir is None or supplier_code is None:
         raise TypeError("links_dir and supplier_code must be provided")
     kw_path = Path(keywords_path)


### PR DESCRIPTION
## Summary
- support `WSM_KEYWORDS` environment variable for keyword file
- use variable in `povezi_z_wsm`, `load_wsm_data`, CLI review and GUI helpers
- document new environment variable
- test default and env override behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d28de8948321b856c88075c2b44a