### PR TITLE
Update keywords after linking

### DIFF
--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -87,3 +87,27 @@ def test_povezi_z_wsm_default_path(monkeypatch, tmp_path):
     assert result.loc[0, "wsm_sifra"] == "100"
     assert (tmp_path / "kljucne_besede_wsm_kode.xlsx").exists()
 
+
+def test_keywords_updated_after_new_links(tmp_path):
+    links_dir = _setup_manual_links(tmp_path)
+    sifre_path = tmp_path / "sifre_wsm.xlsx"
+    pd.DataFrame({"wsm_sifra": ["100"], "wsm_naziv": ["Coca Cola"]}).to_excel(sifre_path, index=False)
+
+    keywords_path = tmp_path / "kljucne_besede_wsm_kode.xlsx"
+
+    # initial extraction without new links
+    extract_keywords(links_dir, keywords_path)
+    initial_kw = pd.read_excel(keywords_path, dtype=str)
+    assert "zero" not in initial_kw[initial_kw["wsm_sifra"] == "100"]["keyword"].tolist()
+
+    df_items = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP"],
+        "naziv": ["Coca Cola Zero Sugar 0.5L"],
+    })
+
+    povezi_z_wsm(df_items, str(sifre_path), str(keywords_path), links_dir, "SUP")
+
+    updated_kw = pd.read_excel(keywords_path, dtype=str)
+    tokens = updated_kw[updated_kw["wsm_sifra"] == "100"]["keyword"].tolist()
+    assert "zero" in tokens
+

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -310,6 +310,7 @@ def povezi_z_wsm(
             subset=["sifra_dobavitelja", "naziv_ckey"], keep="first", inplace=True
         )
         manual_links.to_excel(links_path, index=False)
+        extract_keywords(links_dir, kw_path)
 
     return df
 


### PR DESCRIPTION
## Summary
- refresh keywords after writing new links
- test that keywords update when new links are saved

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e520c1d0832188187e78e7b033a8