### PR TITLE
Add missing WEIGHTS_PER_PIECE constants

### DIFF
--- a/wsm/constants.py
+++ b/wsm/constants.py
@@ -1,0 +1,9 @@
+"""Project-wide constants."""
+from decimal import Decimal
+
+# Mapping of supplier item codes to their weight per individual piece (in kg).
+# Add entries as needed for products where the packaging weight is constant.
+WEIGHTS_PER_PIECE: dict[str, Decimal] = {
+    # Example:
+    # "12345": Decimal("0.5"),  # 0.5 kg per piece for supplier code 12345
+}

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -55,7 +55,7 @@ def _norm_unit(
     determined from ``u`` or ``name``.  The function also accepts a
     ``code`` keyword argument which identifies the supplier item.  When
     provided and the resulting unit is ``kos``, the item code is looked
-    up in :data:`WEIGHTS_PER_PIECE` to infer the weight per piece.
+    up in :data:`wsm.constants.WEIGHTS_PER_PIECE` to infer the weight per piece.
     """
     log.debug(f"Normalizacija: q={q}, u={u}, name={name}")
     unit_map = {


### PR DESCRIPTION
## Summary
- define `WEIGHTS_PER_PIECE` in new `wsm/constants.py`
- reference the constant's module in `_norm_unit` documentation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853e62c4034832190121dea12204233