### PR TITLE
Improve keyword matching using word boundaries

### DIFF
--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -111,3 +111,20 @@ def test_keywords_updated_after_new_links(tmp_path):
     tokens = updated_kw[updated_kw["wsm_sifra"] == "100"]["keyword"].tolist()
     assert "zero" in tokens
 
+
+def test_keyword_partial_match_not_matched(tmp_path):
+    links_dir = _setup_manual_links(tmp_path)
+    sifre_path = tmp_path / "sifre_wsm.xlsx"
+    pd.DataFrame({"wsm_sifra": ["500"], "wsm_naziv": ["Eso Item"]}).to_excel(sifre_path, index=False)
+
+    keywords_path = tmp_path / "kw.xlsx"
+    pd.DataFrame({"wsm_sifra": ["500"], "keyword": ["eso"]}).to_excel(keywords_path, index=False)
+
+    df_items = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP"],
+        "naziv": ["Expreso Machine"],
+    })
+
+    result = povezi_z_wsm(df_items, str(sifre_path), str(keywords_path), links_dir, "SUP")
+    assert pd.isna(result.loc[0, "wsm_sifra"])
+

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -281,7 +281,11 @@ def povezi_z_wsm(
     if not kw_df.empty:
         for idx, row in df[mask].iterrows():
             text = row["naziv"].lower()
-            hit  = kw_df[kw_df["keyword"].str.lower().apply(lambda k: k in text)]
+            hit  = kw_df[
+                kw_df["keyword"].str.lower().apply(
+                    lambda k: bool(re.search(r"\b%s\b" % re.escape(k.lower()), text))
+                )
+            ]
             if not hit.empty:
                 wsm_code = hit.iloc[0]["wsm_sifra"]
                 df.at[idx, "wsm_sifra"] = wsm_code


### PR DESCRIPTION
## Summary
- match keywords as whole words in `povezi_z_wsm`
- test that partial matches do not trigger linking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f244df208321aad98b66c0965cf9