### PR TITLE
Enhance price watch

### DIFF
--- a/tests/test_price_history_duplicates.py
+++ b/tests/test_price_history_duplicates.py
@@ -18,4 +18,5 @@ def test_log_price_history_avoids_duplicates(tmp_path, monkeypatch):
     hist_path = hist_base.parent / 'Test' / 'price_history.xlsx'
     hist = pd.read_excel(hist_path, dtype=str)
     assert len(hist) == 1
+    assert {'code', 'name', 'cena'}.issubset(set(hist.columns))
 


### PR DESCRIPTION
## Summary
- allow log_price_history to save in supplier directory correctly
- store code and name columns for easier human reading
- update price watch UI to show item labels and last price
- verify new columns in price history tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f72551948321876169298d018374