### PR TITLE
Fix _norm_unit duplicate return

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -178,9 +178,6 @@ def _norm_unit(
     log.debug(f"Končna normalizacija: q_norm={q_norm}, base_unit={base_unit}")
     return q_norm, base_unit
 
-    log.debug(f"Končna normalizacija: q_norm={q_norm}, base_unit={base_unit}")
-    return q_norm, base_unit
-
 
 # File handling functions
 def _load_supplier_map(sup_file: Path) -> dict[str, dict]:


### PR DESCRIPTION
## Summary
- remove repeated log.debug and return statements in `_norm_unit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685504c039a0832196d0aa598546b5b2