### PR TITLE
Show error when suppliers dir missing

### DIFF
--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -30,6 +30,13 @@ def launch_price_watch(suppliers: Path | str | None = None) -> None:
             suppliers_dir,
             os.getenv("WSM_SUPPLIERS"),
         )
+        root = tk.Tk()
+        root.withdraw()
+        messagebox.showerror(
+            "Napaka", f"Mapa dobaviteljev ni najdena: {suppliers_dir}"
+        )
+        root.destroy()
+        return
 
     root = tk.Tk()
     root.title("Spremljanje cen")


### PR DESCRIPTION
## Summary
- show a messagebox error when `suppliers_dir` is missing in `launch_price_watch`
- return early to avoid starting the UI with a missing folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855054a6bd88321ba30fd8634fb553c