### PR TITLE
Remove unused import in test

### DIFF
--- a/tests/test_load_supplier_map_fallback.py
+++ b/tests/test_load_supplier_map_fallback.py
@@ -1,5 +1,4 @@
 import json
-import pandas as pd
 from pathlib import Path
 from wsm.ui.review_links import _load_supplier_map
 from wsm.utils import sanitize_folder_name


### PR DESCRIPTION
## Summary
- remove unused pandas import in fallback supplier map test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685525af7a2083218c70c3bf0e3f9296