### PR TITLE
Add VAT-based supplier lookup

### DIFF
--- a/tests/test_load_supplier_map.py
+++ b/tests/test_load_supplier_map.py
@@ -14,10 +14,10 @@ def test_load_supplier_map_from_folders(tmp_path: Path):
     df = pd.DataFrame({"sifra_dobavitelja": ["A"], "naziv": ["x"], "wsm_sifra": ["1"]})
     df.to_excel(sup_a / "KVIBO_povezane.xlsx", index=False)
 
-    # folder with supplier.json
-    sup_b = links_dir / "Acme"
+    # folder with supplier.json and VAT
+    sup_b = links_dir / "SI123"
     sup_b.mkdir()
-    info = {"sifra": "ACM", "ime": "Acme Corp"}
+    info = {"sifra": "ACM", "ime": "Acme Corp", "vat": "SI123"}
     (sup_b / "supplier.json").write_text(json.dumps(info))
 
     result = _load_supplier_map(links_dir)
@@ -25,3 +25,4 @@ def test_load_supplier_map_from_folders(tmp_path: Path):
     assert set(result) == {"KVIBO", "ACM"}
     assert result["KVIBO"]["ime"] == "Kvibo"
     assert result["ACM"]["ime"] == "Acme Corp"
+    assert result["ACM"]["vat"] == "SI123"

--- a/tests/test_supplier_edit_save.py
+++ b/tests/test_supplier_edit_save.py
@@ -26,9 +26,9 @@ def test_supplier_edit_saved_to_custom_dir(tmp_path, monkeypatch):
     wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
 
     base_dir = tmp_path / "suppliers"
-    links_dir = base_dir / "Test"
+    links_dir = base_dir / "SI999"
     links_dir.mkdir(parents=True)
-    links_file = links_dir / "SUP_Test_povezane.xlsx"
+    links_file = links_dir / "SUP_SI999_povezane.xlsx"
 
     monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
 
@@ -42,6 +42,7 @@ def test_supplier_edit_saved_to_custom_dir(tmp_path, monkeypatch):
         "SUP",
         {},
         base_dir,
+        vat="SI999",
     )
 
     info_file = links_dir / "supplier.json"
@@ -49,5 +50,6 @@ def test_supplier_edit_saved_to_custom_dir(tmp_path, monkeypatch):
     data = json.loads(info_file.read_text())
     assert data["sifra"] == "SUP"
     assert data["ime"] == "Test"
+    assert data["vat"] == "SI999"
 
 

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -124,17 +124,23 @@ def review(invoice, wsm_codes, suppliers, keywords):
     from wsm.utils import main_supplier_code
 
     supplier_code = main_supplier_code(df) or "unknown"
+    vat = None
     if invoice_path.suffix.lower() == ".xml":
+        from wsm.parsing.eslog import get_supplier_info_vat
+
         name = get_supplier_name(invoice_path) or supplier_code
+        _, _, vat_num = get_supplier_info_vat(invoice_path)
+        if vat_num:
+            vat = vat_num
     elif invoice_path.suffix.lower() == ".pdf":
         name = get_supplier_name_from_pdf(invoice_path) or supplier_code
     else:
         name = supplier_code
-    safe_name = sanitize_folder_name(name)
+    safe_id = sanitize_folder_name(vat or name)
     base = Path(suppliers_path)
-    links_dir = base / safe_name
+    links_dir = base / safe_id
     links_dir.mkdir(parents=True, exist_ok=True)
-    links_file = links_dir / f"{supplier_code}_{safe_name}_povezane.xlsx"
+    links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"
 
     if sifre_path.exists():
         try:

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -87,6 +87,25 @@ def get_supplier_name(xml_path: str | Path) -> Optional[str]:
     _, name = get_supplier_info(xml_path)
     return name or None
 
+# ────────────────────── dobavitelj: koda + ime + davčna ──────────────────────
+def get_supplier_info_vat(xml_path: str | Path) -> Tuple[str, str, str | None]:
+    """Return supplier code, name and VAT number if available."""
+    code, name = get_supplier_info(xml_path)
+    vat: str | None = None
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+        for rff in root.findall(".//e:S_RFF", NS):
+            rff_code = _text(rff.find("./e:C_C506/e:D_1153", NS))
+            if rff_code in {"VA", "AHP", "0199"}:
+                vat_val = _text(rff.find("./e:C_C506/e:D_1154", NS))
+                if vat_val:
+                    vat = vat_val
+                    break
+    except Exception:
+        vat = None
+    return code, name, vat
+
 # ─────────────────────── vsota iz glave ───────────────────────
 def extract_header_net(xml_path: Path | str) -> Decimal:
     """Vrne znesek iz MOA 389 (neto brez DDV)."""

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -76,16 +76,22 @@ def open_invoice_gui(
     from wsm.utils import main_supplier_code
 
     supplier_code = main_supplier_code(df) or "unknown"
+    vat = None
     if invoice_path.suffix.lower() == ".xml":
+        from wsm.parsing.eslog import get_supplier_info_vat
+
         name = get_supplier_name(invoice_path) or supplier_code
+        _, _, vat_num = get_supplier_info_vat(invoice_path)
+        if vat_num:
+            vat = vat_num
     elif invoice_path.suffix.lower() == ".pdf":
         name = get_supplier_name_from_pdf(invoice_path) or supplier_code
     else:
         name = supplier_code
-    safe_name = sanitize_folder_name(name)
-    links_dir = suppliers / safe_name
+    safe_id = sanitize_folder_name(vat or name)
+    links_dir = suppliers / safe_id
     links_dir.mkdir(parents=True, exist_ok=True)
-    links_file = links_dir / f"{supplier_code}_{safe_name}_povezane.xlsx"
+    links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"
 
     sifre_file = wsm_codes
     if sifre_file.exists():

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -21,8 +21,8 @@ def _load_price_histories(suppliers_dir: Path) -> dict[str, dict[str, pd.DataFra
     suppliers_map = _load_supplier_map(suppliers_dir)
     items_by_supplier: dict[str, dict[str, pd.DataFrame]] = {}
     for code, info in suppliers_map.items():
-        safe_name = sanitize_folder_name(info.get("ime", code))
-        hist_path = suppliers_dir / safe_name / "price_history.xlsx"
+        safe_id = sanitize_folder_name(info.get("vat") or info.get("ime", code))
+        hist_path = suppliers_dir / safe_id / "price_history.xlsx"
         log.debug("Checking history file for %s at %s", code, hist_path)
         if not hist_path.exists():
             log.info("price_history.xlsx ni najden: %s", hist_path)

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -221,10 +221,14 @@ def load_wsm_data(
     sup_map = _load_supplier_map(suppliers_file)
     
     supplier_info = sup_map.get(supplier_code, {})
-    supplier_name = supplier_info.get('ime', supplier_code) if isinstance(supplier_info, dict) else supplier_code
-    safe_name = sanitize_folder_name(supplier_name)
+    supplier_name = (
+        supplier_info.get("ime", supplier_code)
+        if isinstance(supplier_info, dict)
+        else supplier_code
+    )
+    safe_id = sanitize_folder_name(supplier_info.get("vat") or supplier_name)
 
-    links_path = links_dir / safe_name / f"{supplier_code}_{safe_name}_povezane.xlsx"
+    links_path = links_dir / safe_id / f"{supplier_code}_{safe_id}_povezane.xlsx"
     if links_path.exists():
         links_df = pd.read_excel(links_path, dtype=str)
     else:
@@ -302,12 +306,16 @@ def povezi_z_wsm(
         suppliers_file = links_dir
         sup_map = _load_supplier_map(suppliers_file)
         supplier_info = sup_map.get(supplier_code, {})
-        supplier_name = supplier_info.get('ime', supplier_code) if isinstance(supplier_info, dict) else supplier_code
-        safe_name = sanitize_folder_name(supplier_name)
+        supplier_name = (
+            supplier_info.get("ime", supplier_code)
+            if isinstance(supplier_info, dict)
+            else supplier_code
+        )
+        safe_id = sanitize_folder_name(supplier_info.get("vat") or supplier_name)
 
-        dst = links_dir / safe_name
+        dst = links_dir / safe_id
         dst.mkdir(parents=True, exist_ok=True)
-        links_path = dst / f"{supplier_code}_{safe_name}_povezane.xlsx"
+        links_path = dst / f"{supplier_code}_{safe_id}_povezane.xlsx"
 
         manual_links = pd.concat([manual_links, pd.DataFrame(new_links)], ignore_index=True)
         manual_links.drop_duplicates(
@@ -344,14 +352,15 @@ def log_price_history(
         lambda x: sup_map.get(str(x), {}).get("ime", str(x))
     )
     primary_code = main_supplier_code(df)
+    info = sup_map.get(primary_code, {})
     primary_name = (
         df[df["sifra_dobavitelja"] == primary_code]["supplier_name"].iloc[0]
         if primary_code
         else df["supplier_name"].iloc[0]
     )
-    safe_name = sanitize_folder_name(primary_name)
+    safe_id = sanitize_folder_name(info.get("vat") or primary_name)
 
-    history_path = suppliers_path / safe_name / "price_history.xlsx"
+    history_path = suppliers_path / safe_id / "price_history.xlsx"
     history_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Ustvari ključ iz sifra_dobavitelja in naziv


### PR DESCRIPTION
## Summary
- parse VAT info from eSLOG invoices
- store VAT in supplier.json and include it when loading
- use VAT value for folder paths in CLI/UI utilities
- keep visible supplier names unchanged
- update related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855321fb89c83218c7c59a5034b4a30