### PR TITLE
Ensure supplier folders use name

### DIFF
--- a/tests/test_load_supplier_map.py
+++ b/tests/test_load_supplier_map.py
@@ -15,7 +15,7 @@ def test_load_supplier_map_from_folders(tmp_path: Path):
     df.to_excel(sup_a / "KVIBO_povezane.xlsx", index=False)
 
     # folder with supplier.json and VAT
-    sup_b = links_dir / "SI123"
+    sup_b = links_dir / "Acme"
     sup_b.mkdir()
     info = {"sifra": "ACM", "ime": "Acme Corp", "vat": "SI123"}
     (sup_b / "supplier.json").write_text(json.dumps(info))

--- a/tests/test_supplier_edit_save.py
+++ b/tests/test_supplier_edit_save.py
@@ -26,9 +26,9 @@ def test_supplier_edit_saved_to_custom_dir(tmp_path, monkeypatch):
     wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
 
     base_dir = tmp_path / "suppliers"
-    links_dir = base_dir / "SI999"
+    links_dir = base_dir / "Test"
     links_dir.mkdir(parents=True)
-    links_file = links_dir / "SUP_SI999_povezane.xlsx"
+    links_file = links_dir / "SUP_Test_povezane.xlsx"
 
     monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
 

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -136,7 +136,7 @@ def review(invoice, wsm_codes, suppliers, keywords):
         name = get_supplier_name_from_pdf(invoice_path) or supplier_code
     else:
         name = supplier_code
-    safe_id = sanitize_folder_name(vat or name)
+    safe_id = sanitize_folder_name(name)
     base = Path(suppliers_path)
     links_dir = base / safe_id
     links_dir.mkdir(parents=True, exist_ok=True)

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -88,7 +88,7 @@ def open_invoice_gui(
         name = get_supplier_name_from_pdf(invoice_path) or supplier_code
     else:
         name = supplier_code
-    safe_id = sanitize_folder_name(vat or name)
+    safe_id = sanitize_folder_name(name)
     links_dir = suppliers / safe_id
     links_dir.mkdir(parents=True, exist_ok=True)
     links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -21,7 +21,7 @@ def _load_price_histories(suppliers_dir: Path) -> dict[str, dict[str, pd.DataFra
     suppliers_map = _load_supplier_map(suppliers_dir)
     items_by_supplier: dict[str, dict[str, pd.DataFrame]] = {}
     for code, info in suppliers_map.items():
-        safe_id = sanitize_folder_name(info.get("vat") or info.get("ime", code))
+        safe_id = sanitize_folder_name(info.get("ime", code))
         hist_path = suppliers_dir / safe_id / "price_history.xlsx"
         log.debug("Checking history file for %s at %s", code, hist_path)
         if not hist_path.exists():

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -318,7 +318,7 @@ def _write_supplier_map(sup_map: dict, sup_file: Path):
     for code, info in sup_map.items():
         from wsm.utils import sanitize_folder_name
 
-        folder = links_dir / sanitize_folder_name(info.get("vat") or info["ime"])
+        folder = links_dir / sanitize_folder_name(info["ime"])
         folder.mkdir(parents=True, exist_ok=True)
         info_path = folder / "supplier.json"
         try:

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -226,7 +226,7 @@ def load_wsm_data(
         if isinstance(supplier_info, dict)
         else supplier_code
     )
-    safe_id = sanitize_folder_name(supplier_info.get("vat") or supplier_name)
+    safe_id = sanitize_folder_name(supplier_name)
 
     links_path = links_dir / safe_id / f"{supplier_code}_{safe_id}_povezane.xlsx"
     if links_path.exists():
@@ -311,7 +311,7 @@ def povezi_z_wsm(
             if isinstance(supplier_info, dict)
             else supplier_code
         )
-        safe_id = sanitize_folder_name(supplier_info.get("vat") or supplier_name)
+        safe_id = sanitize_folder_name(supplier_name)
 
         dst = links_dir / safe_id
         dst.mkdir(parents=True, exist_ok=True)
@@ -358,7 +358,7 @@ def log_price_history(
         if primary_code
         else df["supplier_name"].iloc[0]
     )
-    safe_id = sanitize_folder_name(info.get("vat") or primary_name)
+    safe_id = sanitize_folder_name(primary_name)
 
     history_path = suppliers_path / safe_id / "price_history.xlsx"
     history_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- revert VAT-based folder naming; keep VAT in `supplier.json`
- update path generation in CLI and GUI to use the supplier name
- adjust utils and price watch to locate folders by supplier name
- fix supplier info writing logic
- update tests for new folder structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68553100ed448321b9b1679b5933a8f8