### PR TITLE
Use VAT numbers for supplier directory paths

### DIFF
--- a/tests/test_load_supplier_map.py
+++ b/tests/test_load_supplier_map.py
@@ -15,7 +15,7 @@ def test_load_supplier_map_from_folders(tmp_path: Path):
     df.to_excel(sup_a / "KVIBO_povezane.xlsx", index=False)
 
     # folder with supplier.json and VAT
-    sup_b = links_dir / "Acme"
+    sup_b = links_dir / "SI123"
     sup_b.mkdir()
     info = {"sifra": "ACM", "ime": "Acme Corp", "vat": "SI123"}
     (sup_b / "supplier.json").write_text(json.dumps(info))

--- a/tests/test_supplier_edit_save.py
+++ b/tests/test_supplier_edit_save.py
@@ -26,9 +26,9 @@ def test_supplier_edit_saved_to_custom_dir(tmp_path, monkeypatch):
     wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
 
     base_dir = tmp_path / "suppliers"
-    links_dir = base_dir / "Test"
+    links_dir = base_dir / "SI999"
     links_dir.mkdir(parents=True)
-    links_file = links_dir / "SUP_Test_povezane.xlsx"
+    links_file = links_dir / "SUP_SI999_povezane.xlsx"
 
     monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
 

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -136,7 +136,7 @@ def review(invoice, wsm_codes, suppliers, keywords):
         name = get_supplier_name_from_pdf(invoice_path) or supplier_code
     else:
         name = supplier_code
-    safe_id = sanitize_folder_name(name)
+    safe_id = sanitize_folder_name(vat or name)
     base = Path(suppliers_path)
     links_dir = base / safe_id
     links_dir.mkdir(parents=True, exist_ok=True)

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -102,6 +102,14 @@ def get_supplier_info_vat(xml_path: str | Path) -> Tuple[str, str, str | None]:
                 if vat_val:
                     vat = vat_val
                     break
+        if not vat:
+            for com in root.findall(".//e:S_COM", NS):
+                com_code = _text(com.find("./e:C_C076/e:D_3155", NS))
+                if com_code == "9949":
+                    vat_val = _text(com.find("./e:C_C076/e:D_3148", NS))
+                    if vat_val:
+                        vat = vat_val
+                        break
     except Exception:
         vat = None
     return code, name, vat

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -88,7 +88,7 @@ def open_invoice_gui(
         name = get_supplier_name_from_pdf(invoice_path) or supplier_code
     else:
         name = supplier_code
-    safe_id = sanitize_folder_name(name)
+    safe_id = sanitize_folder_name(vat or name)
     links_dir = suppliers / safe_id
     links_dir.mkdir(parents=True, exist_ok=True)
     links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -318,7 +318,7 @@ def _write_supplier_map(sup_map: dict, sup_file: Path):
     for code, info in sup_map.items():
         from wsm.utils import sanitize_folder_name
 
-        folder = links_dir / sanitize_folder_name(info["ime"])
+        folder = links_dir / sanitize_folder_name(info.get("vat") or info["ime"])
         folder.mkdir(parents=True, exist_ok=True)
         info_path = folder / "supplier.json"
         try:

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -226,7 +226,8 @@ def load_wsm_data(
         if isinstance(supplier_info, dict)
         else supplier_code
     )
-    safe_id = sanitize_folder_name(supplier_name)
+    vat_id = supplier_info.get("vat") if isinstance(supplier_info, dict) else None
+    safe_id = sanitize_folder_name(vat_id or supplier_name)
 
     links_path = links_dir / safe_id / f"{supplier_code}_{safe_id}_povezane.xlsx"
     if links_path.exists():
@@ -311,7 +312,8 @@ def povezi_z_wsm(
             if isinstance(supplier_info, dict)
             else supplier_code
         )
-        safe_id = sanitize_folder_name(supplier_name)
+        vat_id = supplier_info.get("vat") if isinstance(supplier_info, dict) else None
+        safe_id = sanitize_folder_name(vat_id or supplier_name)
 
         dst = links_dir / safe_id
         dst.mkdir(parents=True, exist_ok=True)
@@ -358,7 +360,8 @@ def log_price_history(
         if primary_code
         else df["supplier_name"].iloc[0]
     )
-    safe_id = sanitize_folder_name(primary_name)
+    vat_id = info.get("vat") if isinstance(info, dict) else None
+    safe_id = sanitize_folder_name(vat_id or primary_name)
 
     history_path = suppliers_path / safe_id / "price_history.xlsx"
     history_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- parse VAT codes from COM segments in ESLOG parsing
- write supplier info to VAT-based folder names
- prefer VAT number when determining supplier folder paths
- update CLI and GUI to use VAT folder names
- adjust tests for VAT-based folder names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685538f7a57c8321b984f402fbb63af1