### PR TITLE
Handle supplier folder rename on info change

### DIFF
--- a/tests/test_supplier_edit_save.py
+++ b/tests/test_supplier_edit_save.py
@@ -53,3 +53,54 @@ def test_supplier_edit_saved_to_custom_dir(tmp_path, monkeypatch):
     assert data["vat"] == "SI999"
 
 
+def test_supplier_folder_renamed_on_vat_change(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP"],
+        "naziv": ["Item"],
+        "kolicina": [Decimal("1")],
+        "enota": ["kg"],
+        "cena_bruto": [Decimal("5")],
+        "cena_netto": [Decimal("5")],
+        "vrednost": [Decimal("5")],
+        "rabata": [Decimal("0")],
+        "wsm_sifra": [pd.NA],
+        "dobavitelj": ["Old"],
+        "kolicina_norm": [1.0],
+        "enota_norm": ["kg"],
+    })
+
+    manual_old = pd.DataFrame(columns=["sifra_dobavitelja", "naziv", "wsm_sifra", "dobavitelj", "enota_norm"])
+    wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+
+    base_dir = tmp_path / "suppliers"
+    old_dir = base_dir / "Old"
+    old_dir.mkdir(parents=True)
+    links_file = old_dir / "SUP_Old_povezane.xlsx"
+    df.to_excel(links_file, index=False)
+
+    sup_map = {"SUP": {"ime": "Old", "vat": ""}}
+
+    monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
+
+    _save_and_close(
+        df,
+        manual_old,
+        wsm_df,
+        links_file,
+        DummyRoot(),
+        "New",
+        "SUP",
+        sup_map,
+        base_dir,
+        vat="SI111",
+    )
+
+    new_dir = base_dir / "SI111"
+    assert new_dir.exists()
+    assert not old_dir.exists()
+    new_file = new_dir / "SUP_SI111_povezane.xlsx"
+    assert new_file.exists()
+    info_file = new_dir / "supplier.json"
+    assert json.loads(info_file.read_text())["vat"] == "SI111"
+
+


### PR DESCRIPTION
## Summary
- move supplier folder when VAT/name changes
- test folder rename logic for supplier edits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68555b3d883883219db55fec2178571b