### PR TITLE
Handle supplier folder rename on info change

### DIFF
--- a/tests/test_load_supplier_map.py
+++ b/tests/test_load_supplier_map.py
@@ -26,3 +26,20 @@ def test_load_supplier_map_from_folders(tmp_path: Path):
     assert result["KVIBO"]["ime"] == "Kvibo"
     assert result["ACM"]["ime"] == "Acme Corp"
     assert result["ACM"]["vat"] == "SI123"
+
+
+def test_load_supplier_map_renames_vat_folder(tmp_path: Path):
+    links_dir = tmp_path / "links"
+    links_dir.mkdir()
+
+    old = links_dir / "Old Name"
+    old.mkdir()
+    info = {"sifra": "SUP", "ime": "Old Name", "vat": "SI555"}
+    (old / "supplier.json").write_text(json.dumps(info))
+
+    result = _load_supplier_map(links_dir)
+
+    new_folder = links_dir / "SI555"
+    assert new_folder.exists()
+    assert not old.exists()
+    assert result["SUP"]["vat"] == "SI555"

--- a/tests/test_supplier_edit_save.py
+++ b/tests/test_supplier_edit_save.py
@@ -53,3 +53,54 @@ def test_supplier_edit_saved_to_custom_dir(tmp_path, monkeypatch):
     assert data["vat"] == "SI999"
 
 
+def test_supplier_folder_renamed_on_vat_change(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP"],
+        "naziv": ["Item"],
+        "kolicina": [Decimal("1")],
+        "enota": ["kg"],
+        "cena_bruto": [Decimal("5")],
+        "cena_netto": [Decimal("5")],
+        "vrednost": [Decimal("5")],
+        "rabata": [Decimal("0")],
+        "wsm_sifra": [pd.NA],
+        "dobavitelj": ["Old"],
+        "kolicina_norm": [1.0],
+        "enota_norm": ["kg"],
+    })
+
+    manual_old = pd.DataFrame(columns=["sifra_dobavitelja", "naziv", "wsm_sifra", "dobavitelj", "enota_norm"])
+    wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])
+
+    base_dir = tmp_path / "suppliers"
+    old_dir = base_dir / "Old"
+    old_dir.mkdir(parents=True)
+    links_file = old_dir / "SUP_Old_povezane.xlsx"
+    df.to_excel(links_file, index=False)
+
+    sup_map = {"SUP": {"ime": "Old", "vat": ""}}
+
+    monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
+
+    _save_and_close(
+        df,
+        manual_old,
+        wsm_df,
+        links_file,
+        DummyRoot(),
+        "New",
+        "SUP",
+        sup_map,
+        base_dir,
+        vat="SI111",
+    )
+
+    new_dir = base_dir / "SI111"
+    assert new_dir.exists()
+    assert not old_dir.exists()
+    new_file = new_dir / "SUP_SI111_povezane.xlsx"
+    assert new_file.exists()
+    info_file = new_dir / "supplier.json"
+    assert json.loads(info_file.read_text())["vat"] == "SI111"
+
+

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -214,24 +214,48 @@ def _load_supplier_map(sup_file: Path) -> dict[str, dict]:
         if not folder.is_dir():
             continue
         info_path = folder / "supplier.json"
+        data = {}
         if info_path.exists():
             try:
                 data = json.loads(info_path.read_text())
-                sifra = str(data.get("sifra", "")).strip()
-                ime = str(data.get("ime", "")).strip() or folder.name
-                vat = str(data.get("vat") or data.get("davcna") or "").strip()
-                if sifra:
-                    sup_map[sifra] = {
-                        "ime": ime,
-                        "vat": vat,
-                    }
-                    log.debug(f"Dodan iz JSON: sifra={sifra}, ime={ime}")
-                    # uspešno prebrali podatke, nadaljuj z naslednjo mapo
-                    continue
             except Exception as e:
                 log.error(f"Napaka pri branju {info_path}: {e}")
         else:
             log.info(f"Ni datoteke supplier.json v {folder}")
+
+        sifra = str(data.get("sifra", "")).strip()
+        ime = str(data.get("ime", "")).strip() or folder.name
+        vat = str(data.get("vat") or data.get("davcna") or "").strip()
+
+        if vat:
+            from wsm.utils import sanitize_folder_name
+
+            safe_vat = sanitize_folder_name(vat)
+            if safe_vat != folder.name:
+                new_folder = links_dir / safe_vat
+                try:
+                    if not new_folder.exists():
+                        folder.rename(new_folder)
+                    else:
+                        for p in folder.iterdir():
+                            target = new_folder / p.name
+                            if not target.exists():
+                                p.rename(target)
+                        try:
+                            folder.rmdir()
+                        except OSError:
+                            pass
+                    folder = new_folder
+                    info_path = folder / "supplier.json"
+                except Exception as exc:
+                    log.warning(
+                        f"Napaka pri preimenovanju {folder} v {new_folder}: {exc}"
+                    )
+
+        if sifra:
+            sup_map[sifra] = {"ime": ime, "vat": vat}
+            log.debug(f"Dodan iz JSON: sifra={sifra}, ime={ime}")
+            continue
         # fallback when supplier.json is missing or neveljaven
         for file in folder.glob("*_povezane.xlsx"):
             code = file.stem.split("_")[0]
@@ -384,6 +408,31 @@ def _save_and_close(
     if vat and old_info.get("vat") != vat:
         new_info["vat"] = vat
         changed = True
+    from wsm.utils import sanitize_folder_name
+
+    old_safe = links_file.parent.name
+    new_safe = sanitize_folder_name(vat or supplier_name)
+    if new_safe != old_safe:
+        old_folder = links_file.parent
+        new_folder = Path(sup_file) / new_safe
+        try:
+            if not new_folder.exists():
+                old_folder.rename(new_folder)
+            else:
+                target = new_folder / f"{supplier_code}_{new_safe}_povezane.xlsx"
+                if links_file.exists():
+                    links_file.rename(target)
+                for p in old_folder.iterdir():
+                    if not (new_folder / p.name).exists():
+                        p.rename(new_folder / p.name)
+                try:
+                    old_folder.rmdir()
+                except OSError:
+                    pass
+            links_file = new_folder / f"{supplier_code}_{new_safe}_povezane.xlsx"
+        except Exception as exc:
+            log.warning(f"Napaka pri preimenovanju {old_folder} v {new_folder}: {exc}")
+
     if changed:
         sup_map[supplier_code] = new_info
         _write_supplier_map(sup_map, sup_file)


### PR DESCRIPTION
## Summary
- rename existing supplier folders to VAT paths when loading supplier map
- regression test for folder rename during map loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68555b3d883883219db55fec2178571b