### PR TITLE
Add console script entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,16 @@
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["wsm*"]
+exclude = ["wsm_vector_embedding*", "tests*"]
+
 [project]
 name = "wsm"
 version = "0.1.0"
 dependencies = ["pandas", "pdfplumber", "openpyxl"]
+
+[project.scripts]
+wsm = "wsm.cli:main"
+wsm-gui = "wsm.run:main"


### PR DESCRIPTION
## Summary
- package data discovery config for setuptools
- add `project.scripts` mapping for CLI and GUI entry points

## Testing
- `pip install -e .`
- `wsm --help | head -n 5`
- `wsm-gui --help | head -n 5`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68592d09e9cc832180089c3e29b8b1aa