### PR TITLE
Fix empty price history concat

### DIFF
--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -399,7 +399,8 @@ def log_price_history(
         if invoice_id is not None:
             mask = (old["invoice_id"] == invoice_id) & (old["key"].isin(df_hist["key"]))
             old = old[~mask]
-        df_hist = pd.concat([old, df_hist], ignore_index=True)
+        if not old.empty:
+            df_hist = pd.concat([old, df_hist], ignore_index=True)
 
     df_hist = (
         df_hist.sort_values("time", ascending=False)


### PR DESCRIPTION
## Summary
- avoid concatenating empty price history files in `log_price_history`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685933fd9d408321aff691ff5c18c3ce