### PR TITLE
Use VAT from supplier map

### DIFF
--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -74,6 +74,7 @@ def test_cli_review_uses_env_vars(monkeypatch, tmp_path):
     monkeypatch.setattr("wsm.ui.review_links.review_links", fake_review_links)
     monkeypatch.setattr("wsm.utils.povezi_z_wsm", fake_povezi)
     monkeypatch.setattr(cli, "get_supplier_name", lambda p: "Test Supplier")
+    monkeypatch.setattr(cli, "_load_supplier_map", lambda p: {})
 
     runner = CliRunner()
     result = runner.invoke(cli.main, ["review", str(invoice)])
@@ -131,6 +132,7 @@ def test_open_invoice_gui_uses_env_vars(monkeypatch, tmp_path):
     monkeypatch.setattr("wsm.ui.common.review_links", fake_review_links)
     monkeypatch.setattr("wsm.utils.povezi_z_wsm", fake_povezi)
     monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Test Supplier")
+    monkeypatch.setattr("wsm.ui.common._load_supplier_map", lambda p: {})
 
     open_invoice_gui(invoice_path=invoice)
 
@@ -139,3 +141,58 @@ def test_open_invoice_gui_uses_env_vars(monkeypatch, tmp_path):
     assert captured["codes"] == codes_file
     assert captured["links"] == expected
     assert captured["kw"] == keywords_file
+
+
+def test_cli_review_prefers_vat_from_map(monkeypatch, tmp_path):
+    invoice = tmp_path / "inv.xml"
+    invoice.write_text("<xml/>")
+
+    suppliers_dir = tmp_path / "links_env"
+    codes_file = tmp_path / "codes.xlsx"
+    codes_file.write_text("dummy")
+
+    keywords_file = tmp_path / "kw.xlsx"
+    keywords_file.write_text("dummy")
+
+    monkeypatch.setenv("WSM_SUPPLIERS", str(suppliers_dir))
+    monkeypatch.setenv("WSM_CODES", str(codes_file))
+    monkeypatch.setenv("WSM_KEYWORDS", str(keywords_file))
+
+    captured = {}
+
+    def fake_analyze(inv, suppliers_file):
+        captured["sup"] = suppliers_file
+        df = pd.DataFrame({
+            "sifra_dobavitelja": ["SUP"],
+            "naziv": ["Item"],
+            "kolicina": [Decimal("1")],
+            "enota": ["kos"],
+            "vrednost": [Decimal("1")],
+            "rabata": [Decimal("0")],
+        })
+        return df, Decimal("1"), True
+
+    def fake_read_excel(path, dtype=None):
+        captured["codes"] = Path(path)
+        return pd.DataFrame()
+
+    def fake_review_links(df, wsm_df, links_file, total, invoice_path):
+        captured["links"] = links_file
+
+    def fake_povezi(df, sifre, keywords_path=None, links_dir=None, supplier_code=None):
+        captured["kw"] = Path(keywords_path)
+        return df
+
+    monkeypatch.setattr(cli, "analyze_invoice", fake_analyze)
+    monkeypatch.setattr(cli.pd, "read_excel", fake_read_excel)
+    monkeypatch.setattr("wsm.ui.review_links.review_links", fake_review_links)
+    monkeypatch.setattr("wsm.utils.povezi_z_wsm", fake_povezi)
+    monkeypatch.setattr(cli, "get_supplier_name", lambda p: "Test Supplier")
+    monkeypatch.setattr(cli, "_load_supplier_map", lambda p: {"SUP": {"ime": "Test Supplier", "vat": "SI777"}})
+
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["review", str(invoice)])
+    assert result.exit_code == 0
+
+    expected = suppliers_dir / "SI777" / "SUP_SI777_povezane.xlsx"
+    assert captured["links"] == expected

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -14,7 +14,7 @@ from tkinter import filedialog, messagebox
 from wsm.analyze import analyze_invoice
 from wsm.parsing.pdf import parse_pdf, get_supplier_name_from_pdf
 from wsm.parsing.eslog import get_supplier_name
-from wsm.utils import sanitize_folder_name
+from wsm.utils import sanitize_folder_name, _load_supplier_map
 from wsm.ui.review_links import review_links
 
 logging.basicConfig(level=logging.INFO)
@@ -76,6 +76,8 @@ def open_invoice_gui(
     from wsm.utils import main_supplier_code
 
     supplier_code = main_supplier_code(df) or "unknown"
+    sup_map = _load_supplier_map(Path(suppliers))
+    map_vat = sup_map.get(supplier_code, {}).get("vat") if sup_map else None
     vat = None
     if invoice_path.suffix.lower() == ".xml":
         from wsm.parsing.eslog import get_supplier_info_vat
@@ -88,6 +90,8 @@ def open_invoice_gui(
         name = get_supplier_name_from_pdf(invoice_path) or supplier_code
     else:
         name = supplier_code
+    if not vat and map_vat:
+        vat = map_vat
     safe_id = sanitize_folder_name(vat or name)
     links_dir = suppliers / safe_id
     links_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- load supplier map in CLI and GUI when opening invoices
- fall back to map VAT if invoice VAT is missing
- extend tests to cover VAT-based folder selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594b5b88688321be8ada4762a574aa