### PR TITLE
Update README manual linking docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,12 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
    python -m wsm.cli review <invoice.xml>
    ```
   (po želji dodajte `--wsm-codes pot/do/sifre_wsm.xlsx`)
-  Program odpre grafični vmesnik, kjer povezave shranjujete v podmapo
-  `links/<ime_dobavitelja>/`. Posodobljene tabele najdete v datotekah
-  `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
+   Program odpre grafični vmesnik, kjer povezave shranjujete v podmapo
+   `links/<davcna_stevilka>/` (oziroma `links/<ime_dobavitelja>`,
+   če davčna številka ni znana). Posodobljene tabele najdete v datotekah
+   `<koda>_<ime>_povezane.xlsx` in `price_history.xlsx`.
+   Če davčna številka ni navedena na računu, jo lahko program prebere iz
+   obstoječe datoteke `supplier.json` v ustrezni mapi povezav.
   Okno se privzeto odpre v običajni velikosti. S tipko F11 ga lahko
   ročno preklopite v celozaslonski način, iz katerega izstopite s
   tipko Esc.


### PR DESCRIPTION
## Summary
- document that manual linking uses `links/<davcna_stevilka>/` and falls back to the supplier name
- mention that the VAT ID can be read from an existing `supplier.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a42896a00832188d5f0b59294c058