### PR TITLE
Fix supplier folder creation

### DIFF
--- a/wsm/analyze.py
+++ b/wsm/analyze.py
@@ -4,7 +4,8 @@ from decimal import Decimal
 import pandas as pd
 
 from wsm.parsing.eslog import parse_eslog_invoice
-from wsm.ui.review_links import _norm_unit, _load_supplier_map
+from wsm.ui.review_links import _norm_unit
+from wsm.supplier_store import load_suppliers as _load_supplier_map
 from wsm.parsing.eslog import extract_header_net
 from wsm.parsing.money import detect_round_step, round_to_step
 

--- a/wsm/supplier_store.py
+++ b/wsm/supplier_store.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import logging
+import pandas as pd
+
+from .utils import sanitize_folder_name
+
+log = logging.getLogger(__name__)
+
+
+def load_suppliers(sup_file: Path) -> dict[str, dict]:
+    """Load supplier info from per-supplier JSON files or a legacy Excel."""
+    log.debug("Branje datoteke ali mape dobaviteljev: %s", sup_file)
+    sup_map: dict[str, dict] = {}
+
+    if not sup_file.exists():
+        log.info("Mapa ali datoteka dobaviteljev %s ne obstaja", sup_file)
+        return sup_map
+
+    if sup_file.is_file():
+        try:
+            df_sup = pd.read_excel(sup_file, dtype=str)
+            log.info("\u0160tevilo prebranih dobaviteljev iz %s: %s", sup_file, len(df_sup))
+            for _, row in df_sup.iterrows():
+                sifra = str(row["sifra"]).strip()
+                ime = str(row["ime"]).strip()
+                vat = str(row.get("vat") or row.get("davcna") or "").strip()
+                sup_map[sifra] = {"ime": ime or sifra, "vat": vat}
+                log.debug("Dodan v sup_map: sifra=%s, ime=%s", sifra, ime)
+            return sup_map
+        except Exception as e:
+            log.error("Napaka pri branju suppliers.xlsx: %s", e)
+            return {}
+
+    links_dir = sup_file if sup_file.is_dir() else sup_file.parent
+    log.info("Pregledujem mapo dobaviteljev: %s", links_dir)
+    for folder in links_dir.iterdir():
+        if not folder.is_dir():
+            continue
+        info_path = folder / "supplier.json"
+        data = {}
+        if info_path.exists():
+            try:
+                data = json.loads(info_path.read_text())
+            except Exception as e:
+                log.error("Napaka pri branju %s: %s", info_path, e)
+        sifra = str(data.get("sifra", "")).strip()
+        ime = str(data.get("ime", "")).strip() or folder.name
+        vat = str(data.get("vat") or data.get("davcna") or "").strip()
+        if vat:
+            safe_vat = sanitize_folder_name(vat)
+            if safe_vat != folder.name:
+                new_folder = links_dir / safe_vat
+                try:
+                    if not new_folder.exists():
+                        folder.rename(new_folder)
+                    else:
+                        for p in folder.iterdir():
+                            target = new_folder / p.name
+                            if not target.exists():
+                                p.rename(target)
+                        try:
+                            folder.rmdir()
+                        except OSError:
+                            pass
+                    folder = new_folder
+                    info_path = folder / "supplier.json"
+                except Exception as exc:
+                    log.warning("Napaka pri preimenovanju %s v %s: %s", folder, new_folder, exc)
+        if sifra:
+            sup_map[sifra] = {"ime": ime, "vat": vat}
+            log.debug("Dodan iz JSON: sifra=%s, ime=%s", sifra, ime)
+            continue
+        for file in folder.glob("*_povezane.xlsx"):
+            code = file.stem.split("_")[0]
+            if not code:
+                continue
+            if code not in sup_map:
+                sup_map[code] = {"ime": folder.name, "vat": ""}
+                log.debug("Dodan iz mape: sifra=%s, ime=%s", code, folder.name)
+            break
+        hist_path = folder / "price_history.xlsx"
+        if hist_path.exists():
+            try:
+                df_hist = pd.read_excel(hist_path)
+                if "code" in df_hist.columns:
+                    code = str(df_hist["code"].dropna().astype(str).iloc[0])
+                elif "key" in df_hist.columns:
+                    code = str(df_hist["key"].dropna().astype(str).iloc[0]).split("_")[0]
+                else:
+                    code = None
+            except Exception as exc:
+                log.error("Napaka pri branju %s: %s", hist_path, exc)
+                code = None
+            if code and code not in sup_map:
+                sup_map[code] = {"ime": folder.name, "vat": ""}
+                log.debug("Dodan iz price_history: sifra=%s, ime=%s", code, folder.name)
+        if folder.name and folder.name not in {info.get("ime") for info in sup_map.values()}:
+            code = sanitize_folder_name(folder.name)
+            if code not in sup_map:
+                sup_map[code] = {"ime": folder.name, "vat": ""}
+                log.debug("Dodan iz imena mape: sifra=%s, ime=%s", code, folder.name)
+    log.info("Najdeni dobavitelji: %s", list(sup_map.keys()))
+    return sup_map
+
+
+def save_supplier(sup_map: dict, sup_file: Path) -> None:
+    """Write supplier info to JSON files or legacy Excel."""
+    log.debug("Pisanje podatkov dobaviteljev v %s", sup_file)
+    if sup_file.suffix == ".xlsx" or sup_file.is_file():
+        sup_file.parent.mkdir(parents=True, exist_ok=True)
+        df = pd.DataFrame(
+            [{"sifra": k, "ime": v["ime"], "vat": v.get("vat", "")} for k, v in sup_map.items()]
+        )
+        df.to_excel(sup_file, index=False)
+        log.info("Datoteka uspe\u0161no zapisana: %s", sup_file)
+        return
+
+    is_dir_path = sup_file.is_dir() or sup_file.suffix == ""
+    if is_dir_path:
+        if not sup_file.exists():
+            sup_file.mkdir(parents=True, exist_ok=True)
+        links_dir = sup_file
+    else:
+        links_dir = sup_file.parent
+
+    for code, info in sup_map.items():
+        folder = links_dir / sanitize_folder_name(info.get("vat") or info["ime"])
+        folder.mkdir(parents=True, exist_ok=True)
+        info_path = folder / "supplier.json"
+        try:
+            info_path.write_text(
+                json.dumps({"sifra": code, "ime": info["ime"], "vat": info.get("vat")}, ensure_ascii=False)
+            )
+            log.debug("Zapisano %s", info_path)
+        except Exception as exc:
+            log.error("Napaka pri zapisu %s: %s", info_path, exc)
+
+

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -12,7 +12,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-from wsm.ui.review_links import _load_supplier_map
+from wsm.supplier_store import load_suppliers as _load_supplier_map
 from wsm.utils import sanitize_folder_name
 
 

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -18,8 +18,8 @@ log = logging.getLogger(__name__)
 
 
 def _load_supplier_map(path: Path) -> dict:
-    """Lazy import wrapper for :func:`wsm.ui.review_links._load_supplier_map`."""
-    from wsm.ui.review_links import _load_supplier_map as real
+    """Lazy import wrapper for :func:`wsm.supplier_store.load_suppliers`."""
+    from wsm.supplier_store import load_suppliers as real
     return real(path)
 
 # ────────────────────────── skupna orodja ───────────────────────────


### PR DESCRIPTION
## Summary
- create `supplier_store` module with helpers for loading and saving supplier metadata
- switch other modules to use `supplier_store`
- remove automatic hash codes for empty supplier entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a45dd3c10832186af85d8d4f68d9b