### PR TITLE
Handle empty sanitize_folder_name

### DIFF
--- a/tests/test_sanitize_folder_name.py
+++ b/tests/test_sanitize_folder_name.py
@@ -18,3 +18,7 @@ def test_reserved_name_modified():
 
 def test_control_chars_replaced():
     assert sanitize_folder_name("bad\x05name") == "bad_name"
+
+
+def test_empty_returns_unknown():
+    assert sanitize_folder_name("") == "unknown"

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -29,7 +29,8 @@ def sanitize_folder_name(name: str) -> str:
     Prepovedane znake zamenja z ``_`` in odstrani končne presledke ali pike.
     Odstrani tudi kontrolne znake (ASCII < 32). Poleg tega prepozna
     rezervirana imena v Windows (npr. ``CON``, ``PRN``) in jim doda ``_`` na
-    konec, da se izogne napakam pri ustvarjanju map.
+    konec, da se izogne napakam pri ustvarjanju map.  Če je po čiščenju
+    rezultat prazen, vrne ``"unknown"``.
     """
 
     if not isinstance(name, str):
@@ -70,6 +71,9 @@ def sanitize_folder_name(name: str) -> str:
     if cleaned.upper() in reserved:
         cleaned += "_"
 
+
+    if cleaned == "":
+        return "unknown"
 
     return cleaned
 


### PR DESCRIPTION
## Summary
- ensure sanitize_folder_name never returns an empty string
- clarify behavior in docstring
- test new default value for empty input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ced05473c8321843ea4c71fb1cba2