### PR TITLE
Move logging setup to runtime

### DIFF
--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -4,6 +4,7 @@ import pandas as pd
 import os
 from pathlib import Path
 from decimal import Decimal
+import logging
 
 from wsm.parsing.eslog import parse_invoice, validate_invoice, get_supplier_name
 from wsm.parsing.pdf import parse_pdf, get_supplier_name_from_pdf
@@ -14,6 +15,7 @@ from wsm.analyze import analyze_invoice
 @click.group()
 def main():
     """WSM – CLI za validacijo in pregled e-računov."""
+    logging.basicConfig(level=logging.INFO)
     pass
 
 @main.command()

--- a/wsm/run.py
+++ b/wsm/run.py
@@ -7,10 +7,9 @@ import sys
 from wsm.cli import main as cli_main
 from wsm.ui.main_menu import launch_main_menu
 
-logging.basicConfig(level=logging.INFO)
-
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     if len(sys.argv) > 1:
         cli_main()
     else:

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -17,8 +17,6 @@ from wsm.parsing.eslog import get_supplier_name
 from wsm.utils import sanitize_folder_name, _load_supplier_map
 from wsm.ui.review_links import review_links
 
-logging.basicConfig(level=logging.INFO)
-
 
 def select_invoice() -> Path | None:
     """Open a file dialog and return the chosen path."""


### PR DESCRIPTION
## Summary
- stop configuring logging during import
- configure logging in CLI and GUI launchers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ceebd3694832184e2ecce0cca011f