### PR TITLE
Fix handling of empty price history files

### DIFF
--- a/tests/test_load_supplier_map_history.py
+++ b/tests/test_load_supplier_map_history.py
@@ -20,3 +20,17 @@ def test_load_supplier_map_from_history(tmp_path: Path) -> None:
 
     assert "H1" in result
     assert result["H1"]["ime"] == "HistOnly"
+
+
+def test_load_supplier_map_skips_empty_history(tmp_path: Path) -> None:
+    links_dir = tmp_path / "links"
+    links_dir.mkdir()
+    hist_folder = links_dir / "EmptyHist"
+    hist_folder.mkdir()
+    pd.DataFrame(columns=["code", "name", "cena", "time"]).to_excel(
+        hist_folder / "price_history.xlsx", index=False
+    )
+
+    result = _load_supplier_map(links_dir)
+
+    assert result == {}

--- a/wsm/supplier_store.py
+++ b/wsm/supplier_store.py
@@ -85,10 +85,15 @@ def load_suppliers(sup_file: Path) -> dict[str, dict]:
         if hist_path.exists():
             try:
                 df_hist = pd.read_excel(hist_path)
+                if df_hist.empty:
+                    log.debug("Prazna datoteka zgodovine cen: %s", hist_path)
+                    continue
                 if "code" in df_hist.columns:
-                    code = str(df_hist["code"].dropna().astype(str).iloc[0])
+                    codes = df_hist["code"].dropna().astype(str)
+                    code = str(codes.iloc[0]) if not codes.empty else None
                 elif "key" in df_hist.columns:
-                    code = str(df_hist["key"].dropna().astype(str).iloc[0]).split("_")[0]
+                    keys = df_hist["key"].dropna().astype(str)
+                    code = str(keys.iloc[0]).split("_")[0] if not keys.empty else None
                 else:
                     code = None
             except Exception as exc:


### PR DESCRIPTION
## Summary
- handle empty price history files when loading suppliers
- skip folders whose `price_history.xlsx` is empty
- add regression test for empty history files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf2c215f48321aa23c354876fed19