### PR TITLE
Fix folder reuse for renamed suppliers

### DIFF
--- a/tests/test_use_existing_folder.py
+++ b/tests/test_use_existing_folder.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from decimal import Decimal
+from pathlib import Path
+from wsm.ui.common import open_invoice_gui
+
+
+def test_open_invoice_gui_uses_existing_folder(monkeypatch, tmp_path):
+    invoice = tmp_path / "inv.xml"
+    invoice.write_text("<xml/>")
+
+    suppliers_dir = tmp_path / "links"
+    old_dir = suppliers_dir / "unknown"
+    old_dir.mkdir(parents=True)
+    (old_dir / "SUP_unknown_povezane.xlsx").write_text("dummy")
+
+    captured = {}
+
+    def fake_analyze(inv, suppliers_file):
+        captured["sup"] = Path(suppliers_file)
+        df = pd.DataFrame(
+            {
+                "sifra_dobavitelja": ["SUP"],
+                "naziv": ["Item"],
+                "kolicina": [Decimal("1")],
+                "enota": ["kos"],
+                "vrednost": [Decimal("1")],
+                "rabata": [Decimal("0")],
+            }
+        )
+        return df, Decimal("1"), True
+
+    monkeypatch.setattr("wsm.ui.common.analyze_invoice", fake_analyze)
+    monkeypatch.setattr("wsm.ui.common.pd.read_excel", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr("wsm.ui.common.review_links", lambda df, wdf, lf, total, ip: captured.update({"links": lf}))
+    monkeypatch.setattr("wsm.utils.povezi_z_wsm", lambda df, *a, **k: df)
+    monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Unknown")
+    monkeypatch.setattr("wsm.parsing.eslog.get_supplier_info_vat", lambda p: ("", "", "SI111"))
+    monkeypatch.setattr("wsm.ui.common._load_supplier_map", lambda p: {"SUP": {"ime": "unknown", "vat": ""}})
+
+    open_invoice_gui(invoice_path=invoice, suppliers=suppliers_dir)
+
+    expected = old_dir / "SUP_unknown_povezane.xlsx"
+    assert captured["links"] == expected

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -142,11 +142,21 @@ def review(invoice, wsm_codes, suppliers, keywords):
         name = supplier_code
     if not vat and map_vat:
         vat = map_vat
+
     safe_id = sanitize_folder_name(vat or name)
     base = Path(suppliers_path)
-    links_dir = base / safe_id
-    links_dir.mkdir(parents=True, exist_ok=True)
-    links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"
+
+    # Če obstaja stara mapa (npr. "unknown") za isto sifro, jo uporabimo,
+    # da se ob shranjevanju prenesejo vse datoteke.
+    old_info = sup_map.get(supplier_code, {})
+    old_folder = sanitize_folder_name(old_info.get("vat") or old_info.get("ime", ""))
+    if old_folder and old_folder != safe_id and (base / old_folder).exists():
+        links_dir = base / old_folder
+        links_file = links_dir / f"{supplier_code}_{old_folder}_povezane.xlsx"
+    else:
+        links_dir = base / safe_id
+        links_dir.mkdir(parents=True, exist_ok=True)
+        links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"
 
     if sifre_path.exists():
         try:

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -90,10 +90,20 @@ def open_invoice_gui(
         name = supplier_code
     if not vat and map_vat:
         vat = map_vat
+
     safe_id = sanitize_folder_name(vat or name)
-    links_dir = suppliers / safe_id
-    links_dir.mkdir(parents=True, exist_ok=True)
-    links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"
+
+    # Če že obstaja mapa za tega dobavitelja (npr. "unknown"), jo najprej
+    # uporabimo, da se datoteke ob shranjevanju pravilno preimenujejo.
+    old_info = sup_map.get(supplier_code, {})
+    old_folder = sanitize_folder_name(old_info.get("vat") or old_info.get("ime", ""))
+    if old_folder and old_folder != safe_id and (suppliers / old_folder).exists():
+        links_dir = suppliers / old_folder
+        links_file = links_dir / f"{supplier_code}_{old_folder}_povezane.xlsx"
+    else:
+        links_dir = suppliers / safe_id
+        links_dir.mkdir(parents=True, exist_ok=True)
+        links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"
 
     sifre_file = wsm_codes
     if sifre_file.exists():


### PR DESCRIPTION
## Summary
- keep old supplier folder when VAT later becomes known
- ensure CLI and GUI reuse existing folders so rename logic runs
- cover use of existing folder with regression test

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce9ab94008321b4de04576866e0fe