### PR TITLE
Fix folder lookup logic and add VAT folder test

### DIFF
--- a/tests/test_use_existing_folder.py
+++ b/tests/test_use_existing_folder.py
@@ -41,3 +41,46 @@ def test_open_invoice_gui_uses_existing_folder(monkeypatch, tmp_path):
 
     expected = old_dir / "SUP_unknown_povezane.xlsx"
     assert captured["links"] == expected
+
+
+def test_open_invoice_gui_prefers_vat_folder(monkeypatch, tmp_path):
+    invoice = tmp_path / "inv.xml"
+    invoice.write_text("<xml/>")
+
+    suppliers_dir = tmp_path / "links"
+
+    captured = {}
+
+    def fake_analyze(inv, suppliers_file):
+        captured["sup"] = Path(suppliers_file)
+        df = pd.DataFrame(
+            {
+                "sifra_dobavitelja": ["SUP"],
+                "naziv": ["Item"],
+                "kolicina": [Decimal("1")],
+                "enota": ["kos"],
+                "vrednost": [Decimal("1")],
+                "rabata": [Decimal("0")],
+            }
+        )
+        return df, Decimal("1"), True
+
+    monkeypatch.setattr("wsm.ui.common.analyze_invoice", fake_analyze)
+    monkeypatch.setattr("wsm.ui.common.pd.read_excel", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(
+        "wsm.ui.common.review_links",
+        lambda df, wdf, lf, total, ip: captured.update({"links": lf}),
+    )
+    monkeypatch.setattr("wsm.utils.povezi_z_wsm", lambda df, *a, **k: df)
+    monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Unknown")
+    monkeypatch.setattr(
+        "wsm.parsing.eslog.get_supplier_info_vat", lambda p: ("", "", "SI111")
+    )
+    monkeypatch.setattr("wsm.ui.common._load_supplier_map", lambda p: {})
+
+    open_invoice_gui(invoice_path=invoice, suppliers=suppliers_dir)
+
+    expected_dir = suppliers_dir / "SI111"
+    expected = expected_dir / "SUP_SI111_povezane.xlsx"
+    assert captured["links"] == expected
+    assert expected_dir.exists()

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -148,9 +148,13 @@ def review(invoice, wsm_codes, suppliers, keywords):
 
     # Če obstaja stara mapa (npr. "unknown") za isto sifro, jo uporabimo,
     # da se ob shranjevanju prenesejo vse datoteke.
-    old_info = sup_map.get(supplier_code, {})
-    old_folder = sanitize_folder_name(old_info.get("vat") or old_info.get("ime", ""))
-    if old_folder and old_folder != safe_id and (base / old_folder).exists():
+    old_info = sup_map.get(supplier_code)
+    old_folder = (
+        sanitize_folder_name(old_info.get("vat") or old_info.get("ime", ""))
+        if old_info
+        else ""
+    )
+    if old_info and old_folder != safe_id and (base / old_folder).exists():
         links_dir = base / old_folder
         links_file = links_dir / f"{supplier_code}_{old_folder}_povezane.xlsx"
     else:

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -95,9 +95,13 @@ def open_invoice_gui(
 
     # Če že obstaja mapa za tega dobavitelja (npr. "unknown"), jo najprej
     # uporabimo, da se datoteke ob shranjevanju pravilno preimenujejo.
-    old_info = sup_map.get(supplier_code, {})
-    old_folder = sanitize_folder_name(old_info.get("vat") or old_info.get("ime", ""))
-    if old_folder and old_folder != safe_id and (suppliers / old_folder).exists():
+    old_info = sup_map.get(supplier_code)
+    old_folder = (
+        sanitize_folder_name(old_info.get("vat") or old_info.get("ime", ""))
+        if old_info
+        else ""
+    )
+    if old_info and old_folder != safe_id and (suppliers / old_folder).exists():
         links_dir = suppliers / old_folder
         links_file = links_dir / f"{supplier_code}_{old_folder}_povezane.xlsx"
     else:


### PR DESCRIPTION
## Summary
- handle missing supplier data when choosing links folder
- handle missing supplier data in CLI
- test that VAT folder is used when supplier map is empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d173878bc832198aa0e34bfa793b3