### PR TITLE
Remove redundant pass in review_links

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -214,7 +214,6 @@ def _save_and_close(
         log.debug(
             f"Primer vrstic s prazno sifra_dobavitelja: {df[empty_sifra][['naziv', 'sifra_dobavitelja']].head().to_dict()}"
         )
-        pass
 
     # Posodobi zemljevid dobaviteljev, če se je ime ali nastavitev spremenila
     old_info = sup_map.get(supplier_code, {})


### PR DESCRIPTION
## Summary
- clean up `_save_and_close` by removing a no-op `pass` after logging empty `sifra_dobavitelja`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d17cf2b00832191321fcf6f86d44b