### PR TITLE
Handle blanks in supplier code extraction

### DIFF
--- a/tests/test_main_supplier_code.py
+++ b/tests/test_main_supplier_code.py
@@ -2,6 +2,8 @@ import json
 from decimal import Decimal
 
 from wsm import analyze
+from wsm.utils import main_supplier_code
+import pandas as pd
 
 DOC_XML = (
     "<Invoice xmlns='urn:eslog:2.00'>"
@@ -47,3 +49,8 @@ def test_analyze_ignores_doc_row_for_supplier(tmp_path):
     assert row["kolicina"] == Decimal("2.5")
     assert total == Decimal("9")
     assert ok
+
+
+def test_main_supplier_code_skips_blank_and_nan():
+    df = pd.DataFrame({"sifra_dobavitelja": ["", pd.NA, "_DOC_", "A1"]})
+    assert main_supplier_code(df) == "A1"

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -107,14 +107,16 @@ def short_supplier_name(name: str) -> str:
 # rows appear in some invoices due to document-level discounts and should be
 # ignored when determining the main supplier.
 def main_supplier_code(df: pd.DataFrame) -> str:
-    """Return the first ``sifra_dobavitelja`` value that isn't ``"_DOC_"``."""
+    """Return the first ``sifra_dobavitelja`` value that isn't ``"_DOC_"`` or blank."""
     if df.empty or "sifra_dobavitelja" not in df.columns:
         return ""
 
     for code in df["sifra_dobavitelja"]:
-        if str(code) != "_DOC_":
-            return str(code)
-    return str(df["sifra_dobavitelja"].iloc[0])
+        if pd.isna(code) or str(code).strip() == "" or str(code) == "_DOC_":
+            continue
+        return str(code)
+
+    return ""
 
 # ────────────────────────── združevanje postavk ─────────────────────
 def zdruzi_artikle(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- skip `_DOC_`, NaN and empty cells when determining the main supplier code
- fall back to empty string when no valid supplier code exists
- test main_supplier_code skips blanks and NaN values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d248b43c88321b0b546cb0593e52d