### PR TITLE
Update supplier info saving order

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -215,15 +215,16 @@ def _save_and_close(
             f"Primer vrstic s prazno sifra_dobavitelja: {df[empty_sifra][['naziv', 'sifra_dobavitelja']].head().to_dict()}"
         )
 
-    # Posodobi zemljevid dobaviteljev, če se je ime ali nastavitev spremenila
-    old_info = sup_map.get(supplier_code, {})
-    new_info = old_info.copy()
+    # -------------------------------------------------------------
+    # posodobi zapise, da ALWAYS vsebujejo vat + ime
+    # -------------------------------------------------------------
+    new_info = sup_map.setdefault(supplier_code, {}).copy()
     changed = False
-    if supplier_name and old_info.get("ime") != supplier_name:
-        new_info["ime"] = supplier_name
-        changed = True
-    if vat and old_info.get("vat") != vat:
+    if vat and new_info.get("vat") != vat:
         new_info["vat"] = vat
+        changed = True
+    if supplier_name and new_info.get("ime") != supplier_name:
+        new_info["ime"] = supplier_name
         changed = True
     from wsm.utils import sanitize_folder_name
 
@@ -253,6 +254,7 @@ def _save_and_close(
                 f"Napaka pri preimenovanju {old_folder} v {new_folder}: {exc}"
             )
 
+    # V datoteko zapiši le, če smo posodobili ime ali VAT
     if changed:
         sup_map[supplier_code] = new_info
         _write_supplier_map(sup_map, sup_file)
@@ -358,6 +360,9 @@ def _save_and_close(
                 log.warning(f"Napaka pri izračunu hash: {exc}")
 
     try:
+        # -------------------------------------------------------------
+        # log_price_history pokličemo ZADNJI, ko je supplier.json že OK
+        # -------------------------------------------------------------
         from wsm.utils import log_price_history
 
         log_price_history(


### PR DESCRIPTION
## Summary
- ensure supplier data is written only when changed
- clarify order of logging price history

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d39f7226c83219cd826d8df893d21