### PR TITLE
Fix price history loading by VAT

### DIFF
--- a/tests/test_price_watch.py
+++ b/tests/test_price_watch.py
@@ -41,3 +41,25 @@ def test_load_price_histories_missing_file(tmp_path):
     items = _load_price_histories(links)
     assert items == {}
 
+
+def test_load_price_histories_vat_dir(tmp_path):
+    links = tmp_path / "links"
+    sup = links / "SI123"
+    sup.mkdir(parents=True)
+    (sup / "supplier.json").write_text(
+        json.dumps({"sifra": "SUP", "ime": "Supplier", "vat": "SI123"})
+    )
+
+    df = pd.DataFrame(
+        {
+            "key": ["SUP_ItemA"],
+            "cena": [1],
+            "time": [pd.Timestamp("2023-01-01")],
+        }
+    )
+    df.to_excel(sup / "price_history.xlsx", index=False)
+
+    items = _load_price_histories(links)
+    assert set(items.keys()) == {"SUP"}
+    assert set(items["SUP"].keys()) == {"SUP - ItemA"}
+

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -21,7 +21,7 @@ def _load_price_histories(suppliers_dir: Path) -> dict[str, dict[str, pd.DataFra
     suppliers_map = _load_supplier_map(suppliers_dir)
     items_by_supplier: dict[str, dict[str, pd.DataFrame]] = {}
     for code, info in suppliers_map.items():
-        safe_id = sanitize_folder_name(info.get("ime", code))
+        safe_id = sanitize_folder_name(info.get("vat") or info.get("ime", code))
         hist_path = suppliers_dir / safe_id / "price_history.xlsx"
         log.debug("Checking history file for %s at %s", code, hist_path)
         if not hist_path.exists():


### PR DESCRIPTION
## Summary
- use VAT when locating price history directories
- test VAT-based directory loading

## Testing
- `pytest -q`
- `pytest -q tests/test_price_watch.py::test_load_price_histories_vat_dir -q`


------
https://chatgpt.com/codex/tasks/task_e_685e4907f7208321863a941e49344a0e