### PR TITLE
Fix supplier code fallback to VAT

### DIFF
--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -90,6 +90,9 @@ def open_invoice_gui(
         name = supplier_code
     if not vat and map_vat:
         vat = map_vat
+    # Če je koda še "unknown" in VAT obstaja, uporabi kar davčno številko
+    if supplier_code == "unknown" and vat:
+        supplier_code = vat
 
     safe_id = sanitize_folder_name(vat or name)
 


### PR DESCRIPTION
## Summary
- update `open_invoice_gui` to prefer VAT number when supplier code is unknown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e4b1cdd6c832181f2b455a851def2