### PR TITLE
Fix links filename when folder matches supplier code

### DIFF
--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -110,7 +110,10 @@ def open_invoice_gui(
     else:
         links_dir = suppliers / safe_id
         links_dir.mkdir(parents=True, exist_ok=True)
-        links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"
+        if supplier_code == safe_id:
+            links_file = links_dir / f"{supplier_code}_povezane.xlsx"
+        else:
+            links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"
 
     sifre_file = wsm_codes
     if sifre_file.exists():

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -249,11 +249,20 @@ def _save_and_close(
                         dest = dest.with_stem(dest.stem + "_old")
                     p.rename(dest)
                 shutil.rmtree(old_folder, ignore_errors=True)
-            links_file = new_folder / f"{supplier_code}_{new_safe}_povezane.xlsx"
+            if supplier_code == new_safe:
+                links_file = new_folder / f"{supplier_code}_povezane.xlsx"
+            else:
+                links_file = new_folder / f"{supplier_code}_{new_safe}_povezane.xlsx"
         except Exception as exc:
             log.warning(
                 f"Napaka pri preimenovanju {old_folder} v {new_folder}: {exc}"
             )
+    else:
+        new_folder = Path(sup_file) / new_safe
+        if supplier_code == new_safe:
+            links_file = new_folder / f"{supplier_code}_povezane.xlsx"
+        else:
+            links_file = new_folder / f"{supplier_code}_{new_safe}_povezane.xlsx"
 
     # Zapiši supplier.json, če smo posodobili podatke ali je to prvi vnos
     if changed or supplier_code not in sup_map:


### PR DESCRIPTION
## Summary
- avoid repeating supplier code twice when generating `links_file`
- ensure rename logic in `_save_and_close` uses the same check

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e4cfee1c48321adc3aa277ee73d38