### PR TITLE
Fix case-insensitive supplier folder check

### DIFF
--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -110,7 +110,7 @@ def open_invoice_gui(
     else:
         links_dir = suppliers / safe_id
         links_dir.mkdir(parents=True, exist_ok=True)
-        if supplier_code == safe_id:
+        if supplier_code.casefold() == safe_id.casefold():
             links_file = links_dir / f"{supplier_code}_povezane.xlsx"
         else:
             links_file = links_dir / f"{supplier_code}_{safe_id}_povezane.xlsx"

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -249,7 +249,7 @@ def _save_and_close(
                         dest = dest.with_stem(dest.stem + "_old")
                     p.rename(dest)
                 shutil.rmtree(old_folder, ignore_errors=True)
-            if supplier_code == new_safe:
+            if supplier_code.casefold() == new_safe.casefold():
                 links_file = new_folder / f"{supplier_code}_povezane.xlsx"
             else:
                 links_file = new_folder / f"{supplier_code}_{new_safe}_povezane.xlsx"
@@ -259,7 +259,7 @@ def _save_and_close(
             )
     else:
         new_folder = Path(sup_file) / new_safe
-        if supplier_code == new_safe:
+        if supplier_code.casefold() == new_safe.casefold():
             links_file = new_folder / f"{supplier_code}_povezane.xlsx"
         else:
             links_file = new_folder / f"{supplier_code}_{new_safe}_povezane.xlsx"


### PR DESCRIPTION
## Summary
- use `casefold()` when checking if supplier code matches sanitized folder name
- ensure `_save_and_close` handles folder comparisons without case sensitivity

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e519d65b88321a766f6d08401fe97