### PR TITLE
Improve folder move handling

### DIFF
--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -234,9 +234,11 @@ def _save_and_close(
     if new_safe != old_safe:
         old_folder = links_file.parent
         new_folder = Path(sup_file) / new_safe
+        moved = False
         try:
             if not new_folder.exists():
-                old_folder.rename(new_folder)
+                shutil.move(str(old_folder), str(new_folder))
+                moved = True
             else:
                 target = new_folder / f"{supplier_code}_{new_safe}_povezane.xlsx"
                 if links_file.exists():
@@ -247,16 +249,34 @@ def _save_and_close(
                     dest = new_folder / p.name
                     if dest.exists():
                         dest = dest.with_stem(dest.stem + "_old")
-                    p.rename(dest)
+                    shutil.move(str(p), str(dest))
                 shutil.rmtree(old_folder, ignore_errors=True)
-            if supplier_code.casefold() == new_safe.casefold():
-                links_file = new_folder / f"{supplier_code}_povezane.xlsx"
-            else:
-                links_file = new_folder / f"{supplier_code}_{new_safe}_povezane.xlsx"
+                moved = True
         except Exception as exc:
             log.warning(
                 f"Napaka pri preimenovanju {old_folder} v {new_folder}: {exc}"
             )
+            try:
+                new_folder.mkdir(exist_ok=True)
+                for p in old_folder.iterdir():
+                    dest = new_folder / p.name
+                    if dest.exists():
+                        dest = dest.with_stem(dest.stem + "_old")
+                    shutil.move(str(p), str(dest))
+                shutil.rmtree(old_folder, ignore_errors=True)
+                moved = True
+            except Exception as exc2:
+                log.warning(
+                    f"Napaka pri prenosu vsebine {old_folder} v {new_folder}: {exc2}"
+                )
+        if moved:
+            if supplier_code.casefold() == new_safe.casefold():
+                links_file = new_folder / f"{supplier_code}_povezane.xlsx"
+            else:
+                links_file = new_folder / f"{supplier_code}_{new_safe}_povezane.xlsx"
+            unk_folder = Path(sup_file) / "unknown"
+            if unk_folder.exists():
+                shutil.rmtree(unk_folder, ignore_errors=True)
     else:
         new_folder = Path(sup_file) / new_safe
         if supplier_code.casefold() == new_safe.casefold():


### PR DESCRIPTION
## Summary
- use `shutil.move` instead of `Path.rename` when moving supplier folders
- fall back to per-file moves if the move fails
- update `links_file` paths and remove `unknown` folder on success

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e6d76e7b88321aadc6d9c880c9252