### PR TITLE
Enhance VAT handling in log_price_history

### DIFF
--- a/tests/test_price_history_duplicates.py
+++ b/tests/test_price_history_duplicates.py
@@ -20,3 +20,20 @@ def test_log_price_history_avoids_duplicates(tmp_path, monkeypatch):
     assert len(hist) == 1
     assert {'code', 'name', 'cena'}.issubset(set(hist.columns))
 
+
+def test_log_price_history_folder_vat(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        'sifra_dobavitelja': ['SUP'],
+        'naziv': ['Artikel'],
+        'cena_bruto': [Decimal('10')],
+    })
+    links_dir = tmp_path / 'links'
+    history_file = links_dir / 'SI999' / 'SUP_SI999_povezane.xlsx'
+    history_file.parent.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(utils, '_load_supplier_map', lambda path: {'SUP': {'ime': 'Test', 'vat': ''}})
+    utils.log_price_history(df, history_file, suppliers_dir=links_dir)
+    hist_path = links_dir / 'SI999' / 'price_history.xlsx'
+    hist = pd.read_excel(hist_path, dtype=str)
+    assert not hist.empty
+    assert {'code', 'name', 'cena'}.issubset(set(hist.columns))

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -368,7 +368,14 @@ def log_price_history(
         else df["supplier_name"].iloc[0]
     )
     vat_id = info.get("vat") if isinstance(info, dict) else None
+    if not vat_id:
+        folder_name = Path(history_file).parent.name
+        if folder_name.startswith("SI") and folder_name[2:].isdigit():
+            vat_id = folder_name
+
     safe_id = sanitize_folder_name(vat_id or primary_name)
+    if safe_id == "unknown" and vat_id:
+        safe_id = sanitize_folder_name(vat_id)
 
     history_path = suppliers_path / safe_id / "price_history.xlsx"
     history_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- handle VAT derived from folder name when supplier map lacks VAT in `log_price_history`
- add regression test to ensure folder VAT is used

## Testing
- `pytest -q tests/test_price_history_duplicates.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e79d96c348321ae89760902d97888