### PR TITLE
Fix VAT extraction for seller

### DIFF
--- a/tests/test_supplier_vat.py
+++ b/tests/test_supplier_vat.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+from wsm.parsing.eslog import get_supplier_info_vat
+
+
+def test_get_supplier_info_vat_prefers_seller():
+    xml = Path("tests/PR5918-Slika2.XML")
+    _, _, vat = get_supplier_info_vat(xml)
+    assert vat == "SI29746507"


### PR DESCRIPTION
## Summary
- ensure VAT number extraction searches within the seller group
- add regression test for supplier VAT parsing

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e802d49588321a44f2d9b62da15f3