### PR TITLE
Normalize supplier codes for manual links

### DIFF
--- a/tests/test_blank_code_reload.py
+++ b/tests/test_blank_code_reload.py
@@ -1,0 +1,42 @@
+import pandas as pd
+from decimal import Decimal
+from wsm.ui.review_links import _save_and_close
+from wsm.utils import _clean
+
+class DummyRoot:
+    def quit(self):
+        pass
+
+def test_blank_supplier_code_retains_mapping(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        "sifra_dobavitelja": [pd.NA],
+        "naziv": ["Item"],
+        "kolicina": [Decimal("1")],
+        "enota": ["kg"],
+        "cena_bruto": [Decimal("5")],
+        "cena_netto": [Decimal("5")],
+        "vrednost": [Decimal("5")],
+        "rabata": [Decimal("0")],
+        "wsm_sifra": ["A1"],
+        "dobavitelj": ["Test"],
+        "kolicina_norm": [1.0],
+        "enota_norm": ["kg"],
+    })
+    manual_old = pd.DataFrame(columns=["sifra_dobavitelja", "naziv", "wsm_sifra", "dobavitelj", "enota_norm"])
+    wsm_df = pd.DataFrame({"wsm_sifra": ["A1"], "wsm_naziv": ["Art"]})
+    base_dir = tmp_path / "suppliers"
+    links_dir = base_dir / "Test"
+    links_dir.mkdir(parents=True)
+    links_file = links_dir / "SUP_Test_povezane.xlsx"
+    monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
+    _save_and_close(df, manual_old, wsm_df, links_file, DummyRoot(), "Test", "SUP", {}, base_dir)
+    manual_new = pd.read_excel(links_file, dtype=str)
+    manual_new["sifra_dobavitelja"] = manual_new["sifra_dobavitelja"].fillna("").astype(str)
+    assert manual_new["sifra_dobavitelja"].iloc[0] == ""
+    manual_new["naziv_ckey"] = manual_new["naziv"].map(_clean)
+    lookup = manual_new.set_index(["sifra_dobavitelja", "naziv_ckey"])["wsm_sifra"].to_dict()
+    df2 = pd.DataFrame({"sifra_dobavitelja": [pd.NA], "naziv": ["Item"]})
+    df2["sifra_dobavitelja"] = df2["sifra_dobavitelja"].fillna("").astype(str)
+    df2["naziv_ckey"] = df2["naziv"].map(_clean)
+    df2["wsm_sifra"] = df2.apply(lambda r: lookup.get((r["sifra_dobavitelja"], r["naziv_ckey"])), axis=1)
+    assert df2["wsm_sifra"].iloc[0] == "A1"

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -208,7 +208,8 @@ def _save_and_close(
     )
 
     # Preverimo prazne sifra_dobavitelja
-    empty_sifra = df["sifra_dobavitelja"].isna() | (df["sifra_dobavitelja"] == "")
+    df["sifra_dobavitelja"] = df["sifra_dobavitelja"].fillna("").astype(str)
+    empty_sifra = df["sifra_dobavitelja"] == ""
     if empty_sifra.any():
         log.warning(
             f"Prazne vrednosti v sifra_dobavitelja za {empty_sifra.sum()} vrstic"
@@ -331,6 +332,7 @@ def _save_and_close(
         log.info("Manual_old je prazen, ustvarjam nov DataFrame")
 
     # Ustvari df_links z istim indeksom
+    df["sifra_dobavitelja"] = df["sifra_dobavitelja"].fillna("").astype(str)
     df["naziv_ckey"] = df["naziv"].map(_clean)
     df_links = df.set_index(["sifra_dobavitelja", "naziv_ckey"])[
         ["naziv", "wsm_sifra", "dobavitelj", "enota_norm"]
@@ -549,9 +551,8 @@ def review_links(
         log.info("Processing complete")
         log.info(f"Število prebranih povezav iz {links_file}: {len(manual_old)}")
         log.debug(f"Primer povezav iz {links_file}: {manual_old.head().to_dict()}")
-        empty_sifra_old = manual_old["sifra_dobavitelja"].isna() | (
-            manual_old["sifra_dobavitelja"] == ""
-        )
+        manual_old["sifra_dobavitelja"] = manual_old["sifra_dobavitelja"].fillna("").astype(str)
+        empty_sifra_old = manual_old["sifra_dobavitelja"].eq("")
         if empty_sifra_old.any():
             log.warning(
                 f"Prazne vrednosti v sifra_dobavitelja v manual_old za {empty_sifra_old.sum()} vrstic"
@@ -588,8 +589,9 @@ def review_links(
     df["dobavitelj"] = supplier_name
     log.debug(f"Supplier name nastavljen na: {supplier_name}")
 
-    # Generate sifra_dobavitelja for empty cases before lookup
-    empty_sifra = df["sifra_dobavitelja"].isna() | (df["sifra_dobavitelja"] == "")
+    # Normalize codes before lookup
+    df["sifra_dobavitelja"] = df["sifra_dobavitelja"].fillna("").astype(str)
+    empty_sifra = df["sifra_dobavitelja"] == ""
     if empty_sifra.any():
         log.warning(
             f"Prazne vrednosti v sifra_dobavitelja za {empty_sifra.sum()} vrstic v df"


### PR DESCRIPTION
## Summary
- normalize `sifra_dobavitelja` when loading and saving manual links
- ensure saved links keep mapping for rows without supplier codes
- add regression test for blank supplier code

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e88f2a3e88321a99c5721b76cd435