### PR TITLE
Add price difference warnings

### DIFF
--- a/tests/test_price_warning.py
+++ b/tests/test_price_warning.py
@@ -1,0 +1,29 @@
+from decimal import Decimal
+from wsm.ui.review_links import _apply_price_warning
+
+class DummyTree:
+    def __init__(self):
+        self.tags = {}
+    def item(self, iid, **kw):
+        if kw:
+            if 'tags' in kw:
+                self.tags[iid] = kw['tags']
+        return {'tags': self.tags.get(iid)}
+
+def test_apply_price_warning_none():
+    tree = DummyTree()
+    tooltip = _apply_price_warning(tree, '1', Decimal('1'), None)
+    assert tree.tags.get('1') == ()
+    assert tooltip is None
+
+def test_apply_price_warning_within_threshold():
+    tree = DummyTree()
+    tooltip = _apply_price_warning(tree, '1', Decimal('10.4'), Decimal('10'), threshold=Decimal('5'))
+    assert tree.tags.get('1') == ()
+    assert tooltip is None
+
+def test_apply_price_warning_exceeds_threshold():
+    tree = DummyTree()
+    tooltip = _apply_price_warning(tree, '1', Decimal('11'), Decimal('10'), threshold=Decimal('5'))
+    assert tree.tags.get('1') == ('price_warn',)
+    assert "Prejšnja cena" in tooltip


### PR DESCRIPTION
## Summary
- highlight invoice rows when price change exceeds threshold
- show tooltip with last price details
- configure warning threshold via env
- add tests for `_apply_price_warning`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e934a55908321ba0681d5ef5d75f2