### PR TITLE
Handle invalid time values in price watch

### DIFF
--- a/tests/test_price_watch.py
+++ b/tests/test_price_watch.py
@@ -37,6 +37,29 @@ def test_load_price_histories(tmp_path):
     assert set(items["S2"].keys()) == {"S2 - ItemB"}
 
 
+def test_load_price_histories_non_datetime(tmp_path):
+    clear_price_cache()
+    links = tmp_path / "links"
+    s1 = links / "Sup1"
+    s1.mkdir(parents=True)
+
+    (s1 / "supplier.json").write_text(json.dumps({"sifra": "S1", "ime": "Sup1"}))
+
+    df = pd.DataFrame(
+        {
+            "key": ["S1_ItemA", "S1_ItemA"],
+            "cena": [1, 2],
+            "time": [pd.Timestamp("2023-01-01"), "not-a-date"],
+        }
+    )
+    df.to_excel(s1 / "price_history.xlsx", index=False)
+
+    items = _load_price_histories(links)
+    item_df = items["S1"]["S1 - ItemA"]
+    assert len(item_df) == 1
+    assert item_df["time"].iloc[0] == pd.Timestamp("2023-01-01")
+
+
 def test_load_price_histories_missing_file(tmp_path):
     clear_price_cache()
     links = tmp_path / "links"

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -41,6 +41,12 @@ def _load_price_histories(suppliers_dir: Path | str) -> dict[str, dict[str, pd.D
                 df["code"] = parts[0]
             if "name" not in df.columns:
                 df["name"] = parts[1].fillna("")
+
+        # Convert time to datetime and drop rows that fail conversion
+        if "time" in df.columns:
+            df["time"] = pd.to_datetime(df["time"], errors="coerce")
+            df = df.dropna(subset=["time"])
+
         df["label"] = df["code"].astype(str) + " - " + df["name"].astype(str)
         for label in df["label"].unique():
             sub = df[df["label"] == label].sort_values("time")


### PR DESCRIPTION
## Summary
- ensure price history loads convert 'time' column to datetime
- drop rows with invalid time values before sorting
- test that non-datetime values are removed during load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686247571aac8321b9a21e9698b09c49