### PR TITLE
Add click dependency and include matplotlib for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = ["wsm_vector_embedding*", "tests*"]
 [project]
 name = "wsm"
 version = "0.1.0"
-dependencies = ["pandas", "pdfplumber", "openpyxl"]
+dependencies = ["pandas", "pdfplumber", "openpyxl", "click"]
 
 [project.optional-dependencies]
 pyqt = ["PyQt5>=5.15"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest
 pytest-cov
+matplotlib


### PR DESCRIPTION
## Summary
- add click as a runtime dependency in `pyproject.toml`
- include `matplotlib` in dev requirements for running tests

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686258b434148321b837fe4fc9027418