### PR TITLE
Update PriceWatch to Toplevel

### DIFF
--- a/wsm/ui/main_menu.py
+++ b/wsm/ui/main_menu.py
@@ -23,7 +23,7 @@ def launch_main_menu() -> None:
 
     def _watch_prices() -> None:
         root.withdraw()
-        launch_price_watch()
+        launch_price_watch(root)
         root.deiconify()
 
     btn_invoice = tk.Button(root, text="Vnesi račun", width=20, command=_enter_invoice)

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -59,11 +59,11 @@ def clear_price_cache() -> None:
     _load_price_histories.cache_clear()
 
 
-class PriceWatch(tk.Tk):
+class PriceWatch(tk.Toplevel):
     """Window for browsing historic prices."""
 
-    def __init__(self, suppliers: Path | str | None = None) -> None:
-        super().__init__()
+    def __init__(self, master: tk.Misc | None = None, suppliers: Path | str | None = None) -> None:
+        super().__init__(master)
         self.title("Spremljanje cen")
         self.geometry("600x400")
 
@@ -244,8 +244,8 @@ class PriceWatch(tk.Tk):
         top.bind("<Escape>", lambda e: top.destroy())
 
 
-def launch_price_watch(suppliers: Path | str | None = None) -> None:
+def launch_price_watch(master: tk.Misc, suppliers: Path | str | None = None) -> None:
     """Launch the price watch window."""
 
-    PriceWatch(suppliers).mainloop()
+    PriceWatch(master, suppliers).mainloop()
 


### PR DESCRIPTION
## Summary
- make `PriceWatch` inherit from `tk.Toplevel`
- allow passing a master/root widget when creating `PriceWatch`
- update `launch_price_watch` and main menu to use the root

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625d4844e08321a4fdaf17af9558a9