### PR TITLE
Update price history schema and helpers

### DIFF
--- a/tests/test_price_history_duplicates.py
+++ b/tests/test_price_history_duplicates.py
@@ -8,7 +8,9 @@ def test_log_price_history_avoids_duplicates(tmp_path, monkeypatch):
     df = pd.DataFrame({
         'sifra_dobavitelja': ['SUP'],
         'naziv': ['Artikel'],
-        'cena_bruto': [Decimal('10')],
+        'cena_netto': [Decimal('10')],
+        'kolicina_norm': [1],
+        'enota_norm': ['kg'],
     })
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(utils, '_load_supplier_map', lambda path: {'SUP': {'ime': 'Test', }})
@@ -18,14 +20,16 @@ def test_log_price_history_avoids_duplicates(tmp_path, monkeypatch):
     hist_path = hist_base.parent / 'Test' / 'price_history.xlsx'
     hist = pd.read_excel(hist_path, dtype=str)
     assert len(hist) == 1
-    assert {'code', 'name', 'cena'}.issubset(set(hist.columns))
+    assert {'code', 'name', 'line_netto', 'unit_price', 'enota_norm'}.issubset(set(hist.columns))
 
 
 def test_log_price_history_folder_vat(tmp_path, monkeypatch):
     df = pd.DataFrame({
         'sifra_dobavitelja': ['SUP'],
         'naziv': ['Artikel'],
-        'cena_bruto': [Decimal('10')],
+        'cena_netto': [Decimal('10')],
+        'kolicina_norm': [2],
+        'enota_norm': ['kg'],
     })
     links_dir = tmp_path / 'links'
     history_file = links_dir / 'SI999' / 'SUP_SI999_povezane.xlsx'
@@ -36,4 +40,4 @@ def test_log_price_history_folder_vat(tmp_path, monkeypatch):
     hist_path = links_dir / 'SI999' / 'price_history.xlsx'
     hist = pd.read_excel(hist_path, dtype=str)
     assert not hist.empty
-    assert {'code', 'name', 'cena'}.issubset(set(hist.columns))
+    assert {'code', 'name', 'line_netto', 'unit_price', 'enota_norm'}.issubset(set(hist.columns))

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -41,6 +41,13 @@ def _load_price_histories(suppliers_dir: Path | str) -> dict[str, dict[str, pd.D
                 df["code"] = parts[0]
             if "name" not in df.columns:
                 df["name"] = parts[1].fillna("")
+        if "line_netto" not in df.columns and "cena" in df.columns:
+            df.rename(columns={"cena": "line_netto"}, inplace=True)
+        if "unit_price" not in df.columns:
+            df["unit_price"] = pd.NA
+        if "enota_norm" not in df.columns:
+            df["enota_norm"] = pd.NA
+        df["cena"] = df["unit_price"].fillna(df["line_netto"])
 
         # Convert time to datetime and drop rows that fail conversion
         if "time" in df.columns:


### PR DESCRIPTION
## Summary
- track netto line price and compute unit price when logging history
- keep backwards compatibility when reading old history files
- adjust last price loader and price watch to handle new columns
- update price history duplicate test to new schema

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626b602a8c8321ad0447458f3ad762