### PR TITLE
Enhance price watch for unit prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ stalno maso pakiranja, jo dodajte v ta slovar.
 
    V zgornjem delu okna je iskalnik za hitro filtriranje dobaviteljev. Spodaj
    se nahaja dodatno polje za iskanje po nazivih artiklov. Rezultati so
-   prikazani v tabeli s stolpci "Artikel", "Zadnja cena", "Zadnji datum",
-   "Min" in "Max". Po posameznem stolpcu lahko razvrstite s klikom na glavo.
+   prikazani v tabeli s stolpci "Artikel", "Neto cena", "€/kg|€/L",
+   "Zadnji datum", "Min" in "Max". Po posameznem stolpcu lahko razvrstite
+   s klikom na glavo.
    Dvojni klik na vrstico odpre graf gibanja cen iz `price_history.xlsx`.
 
 7. Analizo in združevanje postavk lahko izvedete z:

--- a/tests/test_price_watch.py
+++ b/tests/test_price_watch.py
@@ -35,6 +35,8 @@ def test_load_price_histories(tmp_path):
     assert set(items.keys()) == {"S1", "S2"}
     assert set(items["S1"].keys()) == {"S1 - ItemA"}
     assert set(items["S2"].keys()) == {"S2 - ItemB"}
+    df_loaded = items["S1"]["S1 - ItemA"]
+    assert {"line_netto", "unit_price", "enota_norm"}.issubset(df_loaded.columns)
 
 
 def test_load_price_histories_non_datetime(tmp_path):
@@ -102,7 +104,7 @@ def test_show_graph_sets_xticks(monkeypatch):
                 pd.Timestamp("2023-01-02"),
                 pd.Timestamp("2023-01-03"),
             ],
-            "cena": [1, 2, 3],
+            "unit_price": [1, 2, 3],
         }
     )
 
@@ -231,7 +233,7 @@ def test_refresh_table_empty(monkeypatch):
         def insert(self, parent, index, values):
             self.inserted.append(values)
 
-    df = pd.DataFrame({"cena": [1], "time": [pd.Timestamp("2023-01-01")]})
+    df = pd.DataFrame({"line_netto": [1], "time": [pd.Timestamp("2023-01-01")]})
 
     pw = PriceWatch.__new__(PriceWatch)
     pw.tree = DummyTree()
@@ -255,7 +257,7 @@ def test_show_graph_with_real_matplotlib(monkeypatch):
     df = pd.DataFrame(
         {
             "time": [pd.Timestamp("2023-01-01"), pd.Timestamp("2023-01-02")],
-            "cena": [1, 2],
+            "unit_price": [1, 2],
         }
     )
 


### PR DESCRIPTION
## Summary
- read `line_netto`, `unit_price` and `enota_norm` columns from price history files
- extend price table with columns for `line_netto` and `unit_price`
- compute statistics using `unit_price` when available
- adjust graph plotting logic to use `unit_price` if present
- document updated table layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626f7a50b083219b68f5120cab27d3