### PR TITLE
Update tests for new price history columns

### DIFF
--- a/tests/test_last_price.py
+++ b/tests/test_last_price.py
@@ -39,6 +39,35 @@ def test_load_last_price_multiple_suppliers(tmp_path):
         "key": ["A_Item"],
         "code": ["A"],
         "name": ["Item"],
+        "line_netto": [1],
+        "unit_price": [pd.NA],
+        "time": [pd.Timestamp("2023-01-01")],
+    })
+    df2 = pd.DataFrame({
+        "key": ["A_Item"],
+        "code": ["A"],
+        "name": ["Item"],
+        "line_netto": [2],
+        "unit_price": [pd.NA],
+        "time": [pd.Timestamp("2023-02-01")],
+    })
+    df1.to_excel(s1 / "price_history.xlsx", index=False)
+    df2.to_excel(s2 / "price_history.xlsx", index=False)
+    price = load_last_price("A - Item", links)
+    assert price == Decimal("2")
+
+
+def test_load_last_price_multiple_suppliers_legacy(tmp_path):
+    """Legacy files with column 'cena' are still supported."""
+    links = tmp_path / "links"
+    s1 = links / "S1"
+    s2 = links / "S2"
+    s1.mkdir(parents=True)
+    s2.mkdir(parents=True)
+    df1 = pd.DataFrame({
+        "key": ["A_Item"],
+        "code": ["A"],
+        "name": ["Item"],
         "cena": [1],
         "time": [pd.Timestamp("2023-01-01")],
     })

--- a/tests/test_last_price_confirm.py
+++ b/tests/test_last_price_confirm.py
@@ -33,7 +33,8 @@ def test_load_last_price_single_supplier(tmp_path):
         "key": ["A_Item", "A_Item"],
         "code": ["A", "A"],
         "name": ["Item", "Item"],
-        "cena": [1, 2],
+        "line_netto": [1, 2],
+        "unit_price": [pd.NA, pd.NA],
         "time": [pd.Timestamp("2023-01-01"), pd.Timestamp("2023-02-01")],
     })
     df.to_excel(sup / "price_history.xlsx", index=False)


### PR DESCRIPTION
## Summary
- switch price history tests to new column names `line_netto` and `unit_price`
- keep compatibility checks for legacy `cena` column
- verify price watch table shows the new columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627209abfc8321a6bc043d363af76a