### PR TITLE
Clarify net price history in Price Watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ stalno maso pakiranja, jo dodajte v ta slovar.
    "Zadnji datum", "Min" in "Max". Po posameznem stolpcu lahko razvrstite
    s klikom na glavo.
    Dvojni klik na vrstico odpre graf gibanja cen iz `price_history.xlsx`.
+   Zgodovina se beleži v **neto** vrednostih brez DDV. Pri artiklih, kjer je
+   enota `kg` ali `L`, se cena shrani tudi kot cena na kilogram oziroma liter
+   in je prikazana v stolpcu "€/kg|€/L". Graf pri dvokliku uporabi to
+   vrednost, če je na voljo.
 
 7. Analizo in združevanje postavk lahko izvedete z:
    ```bash


### PR DESCRIPTION
## Summary
- document that price history is stored as net values
- note €/kg|€/L column for weighted or liquid items
- explain that graphs use unit price when available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686273e5b3e48321ab9922fc09008cf9