### PR TITLE
Fix price watch last date for non-contiguous index

### DIFF
--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -198,7 +198,7 @@ class PriceWatch(tk.Toplevel):
                     "label": label,
                     "line_netto": float(last_line.iloc[-1]) if not last_line.empty else None,
                     "unit_price": float(last_unit.iloc[-1]) if not last_unit.empty else None,
-                    "last_dt": pd.to_datetime(df["time"].iloc[last_idx]),
+                    "last_dt": pd.to_datetime(df.loc[last_idx, "time"]),
                     "min": float(stats_series.min()),
                     "max": float(stats_series.max()),
                     "df": df,


### PR DESCRIPTION
## Summary
- ensure last date lookup uses label-based index
- test refresh table with non-contiguous index

## Testing
- `pytest tests/test_price_watch.py::test_refresh_table_with_non_contiguous_index -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68627605511c83218dc19fe87d1ba8eb