### PR TITLE
Implement weight table and remove VAT heuristic

### DIFF
--- a/tests/test_analyze_groupby.py
+++ b/tests/test_analyze_groupby.py
@@ -50,7 +50,7 @@ def test_grouping_by_code_and_discount(monkeypatch):
     # Patch parse_eslog_invoice to return our DataFrame
     monkeypatch.setattr(analyze, 'parse_eslog_invoice', lambda path, sup: data)
     # Identity normalization
-    monkeypatch.setattr(analyze, '_norm_unit', lambda q, u, n, vat=None: (q, u))
+    monkeypatch.setattr(analyze, '_norm_unit', lambda q, u, n, vat=None, code=None: (q, u))
     # Header total equals sum of values
     monkeypatch.setattr(analyze, 'extract_header_net', lambda path: Decimal('30'))
 

--- a/tests/test_norm_unit.py
+++ b/tests/test_norm_unit.py
@@ -3,19 +3,25 @@ from wsm.ui.review.helpers import _norm_unit
 
 
 def test_norm_unit_mg_unit():
-    q, unit = _norm_unit(Decimal('500'), 'mg', 'Vitamin C', Decimal('22'))
+    q, unit = _norm_unit(Decimal('500'), 'mg', 'Vitamin C', Decimal('22'), None)
     assert unit == 'kg'
     assert q == Decimal('0.0005')
 
 
 def test_norm_unit_mg_in_name_with_kos():
-    q, unit = _norm_unit(Decimal('1'), 'kos', 'Tabletka 250 mg', Decimal('9.5'))
+    q, unit = _norm_unit(Decimal('1'), 'kos', 'Tabletka 250 mg', Decimal('9.5'), None)
     assert unit == 'kg'
     assert q == Decimal('0.00025')
 
 
 def test_norm_unit_vat_fallback():
-    q, unit = _norm_unit(Decimal('36'), 'H87', 'KREMA rast. za kuhanje  1/1', Decimal('9.5'))
-    assert unit == 'kg'
+    q, unit = _norm_unit(Decimal('36'), 'H87', 'KREMA rast. za kuhanje  1/1', Decimal('9.5'), None)
+    assert unit == 'kos'
     assert q == Decimal('36')
+
+
+def test_norm_unit_weight_table():
+    q, unit = _norm_unit(Decimal('1'), 'H87', 'cevapcici 480g kos', Decimal('9.5'), '95308')
+    assert unit == 'kg'
+    assert q == Decimal('0.48')
 

--- a/weights_per_piece.csv
+++ b/weights_per_piece.csv
@@ -1,0 +1,4 @@
+sifra_dobavitelja,naziv_ckey,kg_per_piece
+95308,cevapcici 480g kos,0.48
+95829,piskancje koske vp,0.78
+94016,pršut gastro narezek,0.86

--- a/wsm/analyze.py
+++ b/wsm/analyze.py
@@ -22,7 +22,13 @@ def analyze_invoice(xml_path: str, suppliers_file: str | None = None) -> tuple[p
 
     # normalize units
     df[['kolicina', 'enota']] = [
-        _norm_unit(row['kolicina'], row['enota'], row['naziv'], row['ddv_stopnja'])
+        _norm_unit(
+            row['kolicina'],
+            row['enota'],
+            row['naziv'],
+            row['ddv_stopnja'],
+            row.get('sifra_artikla')
+        )
         for _, row in df.iterrows()
     ]
 

--- a/wsm/constants.py
+++ b/wsm/constants.py
@@ -1,9 +1,24 @@
 """Project-wide constants."""
 from decimal import Decimal
+from pathlib import Path
+import csv
 
 # Mapping of supplier item codes to their weight per individual piece (in kg).
 # Add entries as needed for products where the packaging weight is constant.
-WEIGHTS_PER_PIECE: dict[str, Decimal] = {
-    # Example:
-    # "12345": Decimal("0.5"),  # 0.5 kg per piece for supplier code 12345
-}
+WEIGHTS_PER_PIECE: dict[tuple[str, str], Decimal] = {}
+
+csv_path = Path(__file__).resolve().parent / ".." / "weights_per_piece.csv"
+csv_path = csv_path.resolve()
+if csv_path.exists():
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            code = (row.get("sifra_dobavitelja") or "").strip()
+            name = (row.get("naziv_ckey") or "").strip().lower()
+            weight = row.get("kg_per_piece")
+            try:
+                weight_dec = Decimal(str(weight))
+            except Exception:
+                continue
+            if code and name:
+                WEIGHTS_PER_PIECE[(code, name)] = weight_dec

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -240,10 +240,11 @@ def parse_eslog_invoice(
                 qual = _text(pia.find("./e:C_C212/e:D_7143", NS))
                 code = _text(pia.find("./e:C_C212/e:D_7140", NS))
                 digits = re.sub(r"\D+", "", code)
-                if qual == "SA" and digits:
+                if qual in {"SA", "SRV"} and digits and not art_code:
                     art_code = digits
-                    break
-                if not art_code and digits:
+                    if qual == "SA":
+                        break
+                elif not art_code and digits:
                     art_code = digits
             if not art_code:
                 art_code = lin_digits

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -136,17 +136,20 @@ class PriceWatch(tk.Toplevel):
             "min": "Min",
             "max": "Max",
         }
+        numeric_cols = {"line_netto", "unit_price", "min", "max"}
         for col in columns:
             self.tree.heading(col, text=headings[col], command=lambda c=col: self._sort_by(c))
             width = 220 if col == "label" else 90
             anchor = tk.W if col == "label" else tk.E
-            self.tree.column(col, width=width, anchor=anchor)
+            fmt = "%.2f" if col in numeric_cols else ""
+            self.tree.column(col, width=width, anchor=anchor, format=fmt)
 
         scrollbar = ttk.Scrollbar(self, orient="vertical", command=self.tree.yview)
         self.tree.configure(yscroll=scrollbar.set)
         scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
         self.tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.tree.bind("<Double-1>", self._on_double_click)
+        self.tree.bind("<BackSpace>", lambda e: self.destroy())
 
     def _build_back_button(self) -> None:
         ttk.Button(self, text="Nazaj", command=self.destroy).pack(pady=5)

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -248,9 +248,13 @@ def review_links(
     df["total_net"] = df["vrednost"]
     df["kolicina_norm"], df["enota_norm"] = zip(
         *[
-            _norm_unit(Decimal(str(q)), u, n, vat)
-            for q, u, n, vat in zip(
-                df["kolicina"], df["enota"], df["naziv"], df["ddv_stopnja"]
+            _norm_unit(Decimal(str(q)), u, n, vat, code)
+            for q, u, n, vat, code in zip(
+                df["kolicina"],
+                df["enota"],
+                df["naziv"],
+                df["ddv_stopnja"],
+                df.get("sifra_artikla")
             )
         ]
     )

--- a/wsm/ui_qt/review_links_qt.py
+++ b/wsm/ui_qt/review_links_qt.py
@@ -109,8 +109,14 @@ def review_links_qt(
     df["total_net"] = df["vrednost"]
     df["kolicina_norm"], df["enota_norm"] = zip(
         *[
-            _norm_unit(Decimal(str(q)), u, n, vat)
-            for q, u, n, vat in zip(df["kolicina"], df["enota"], df["naziv"], df["ddv_stopnja"])
+            _norm_unit(Decimal(str(q)), u, n, vat, code)
+            for q, u, n, vat, code in zip(
+                df["kolicina"],
+                df["enota"],
+                df["naziv"],
+                df["ddv_stopnja"],
+                df.get("sifra_artikla")
+            )
         ]
     )
     df["kolicina_norm"] = df["kolicina_norm"].astype(float)


### PR DESCRIPTION
## Summary
- support additional qualifier `SRV` when reading PIA codes
- remove 9.5 % VAT fallback in `_norm_unit`
- use `weights_per_piece.csv` to normalize piece units
- extend `_norm_unit` with optional item code parameter
- format numeric columns in **Price Watch** and add Backspace shortcut
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627fcd998c832191b80e30ce7d773b