### PR TITLE
Fix Treeview option causing crash

### DIFF
--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -136,13 +136,11 @@ class PriceWatch(tk.Toplevel):
             "min": "Min",
             "max": "Max",
         }
-        numeric_cols = {"line_netto", "unit_price", "min", "max"}
         for col in columns:
             self.tree.heading(col, text=headings[col], command=lambda c=col: self._sort_by(c))
             width = 220 if col == "label" else 90
             anchor = tk.W if col == "label" else tk.E
-            fmt = "%.2f" if col in numeric_cols else ""
-            self.tree.column(col, width=width, anchor=anchor, format=fmt)
+            self.tree.column(col, width=width, anchor=anchor)
 
         scrollbar = ttk.Scrollbar(self, orient="vertical", command=self.tree.yview)
         self.tree.configure(yscroll=scrollbar.set)


### PR DESCRIPTION
## Summary
- remove unsupported `format` argument when creating Treeview columns

## Testing
- `pytest tests/test_price_watch.py::test_refresh_table_with_data -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68628515a00c83218e4dec9dcf21b78e