### PR TITLE
Use invoice date for price history

### DIFF
--- a/tests/test_price_history_service_date.py
+++ b/tests/test_price_history_service_date.py
@@ -1,0 +1,47 @@
+import json
+import pandas as pd
+from decimal import Decimal
+
+from wsm import utils
+from wsm.ui.price_watch import _load_price_histories, clear_price_cache
+
+
+def test_log_price_history_uses_service_date(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        'sifra_dobavitelja': ['SUP'],
+        'naziv': ['Artikel'],
+        'cena_netto': [Decimal('10')],
+        'kolicina_norm': [1],
+        'enota_norm': ['kg'],
+    })
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(utils, '_load_supplier_map', lambda path: {'SUP': {'ime': 'Test'}})
+    base = tmp_path / 'base.xlsx'
+    utils.log_price_history(df, base, suppliers_dir=tmp_path, service_date='2023-01-01')
+    hist_path = base.parent / 'Test' / 'price_history.xlsx'
+    hist = pd.read_excel(hist_path)
+    assert pd.to_datetime(hist['time']).iloc[0] == pd.Timestamp('2023-01-01')
+    assert hist['service_date'].iloc[0] == '2023-01-01'
+
+
+def test_load_price_histories_prefers_service_date(tmp_path, monkeypatch):
+    clear_price_cache()
+    links = tmp_path / 'links'
+    sup = links / 'Sup'
+    sup.mkdir(parents=True)
+    (sup / 'supplier.json').write_text(json.dumps({'sifra': 'SUP', 'ime': 'Sup'}))
+    df = pd.DataFrame({
+        'key': ['SUP_Item'],
+        'line_netto': [1],
+        'unit_price': [pd.NA],
+        'enota_norm': ['kg'],
+        'time': ['2023-02-01'],
+        'service_date': ['2023-01-15'],
+    })
+    df.to_excel(sup / 'price_history.xlsx', index=False)
+    monkeypatch.setattr('wsm.ui.price_watch._load_supplier_map', lambda path: {'SUP': {'ime': 'Sup'}})
+    items = _load_price_histories(links)
+    item_df = items['SUP']['SUP - Item']
+    assert pd.to_datetime(item_df['time']).iloc[0] == pd.Timestamp('2023-01-15')
+
+

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -51,10 +51,13 @@ def _load_price_histories(suppliers_dir: Path | str) -> dict[str, dict[str, pd.D
         df["unit_price"] = pd.to_numeric(df.get("unit_price"), errors="coerce")
         df["cena"] = df["unit_price"].fillna(df["line_netto"])
 
-        # Convert time to datetime and drop rows that fail conversion
-        if "time" in df.columns:
+        # Use service_date when available for the timeline
+        if "service_date" in df.columns:
+            df["service_date"] = pd.to_datetime(df["service_date"], errors="coerce")
+            df["time"] = df["service_date"].combine_first(pd.to_datetime(df.get("time"), errors="coerce"))
+        elif "time" in df.columns:
             df["time"] = pd.to_datetime(df["time"], errors="coerce")
-            df = df.dropna(subset=["time"])
+        df = df.dropna(subset=["time"])
 
         df["label"] = df["code"].astype(str) + " - " + df["name"].astype(str)
         for label in df["label"].unique():

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -415,7 +415,14 @@ def log_price_history(
         axis=1,
     )
     df_hist.drop(columns=["kolicina_norm"], inplace=True)
-    df_hist["time"] = pd.Timestamp.now()
+    if service_date:
+        try:
+            dt = pd.to_datetime(service_date)
+        except Exception:
+            dt = pd.Timestamp.now()
+        df_hist["time"] = dt
+    else:
+        df_hist["time"] = pd.Timestamp.now()
     df_hist["service_date"] = service_date
     df_hist["invoice_id"] = invoice_id
 


### PR DESCRIPTION
## Summary
- record the invoice service date as the timestamp in `log_price_history`
- prefer the stored service date when loading price history in `PriceWatch`
- cover these behaviors with new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628694b278832185ed8e3510ad6862