### PR TITLE
Fix VAT normalization for kg/L

### DIFF
--- a/tests/test_norm_unit.py
+++ b/tests/test_norm_unit.py
@@ -14,10 +14,16 @@ def test_norm_unit_mg_in_name_with_kos():
     assert q == Decimal('0.00025')
 
 
-def test_norm_unit_vat_fallback():
+def test_norm_unit_vat_fraction_to_liter():
     q, unit = _norm_unit(Decimal('36'), 'H87', 'KREMA rast. za kuhanje  1/1', Decimal('9.5'), None)
-    assert unit == 'kos'
+    assert unit == 'L'
     assert q == Decimal('36')
+
+
+def test_norm_unit_vat_default_kg():
+    q, unit = _norm_unit(Decimal('2'), 'H87', 'Artikel brez mere', Decimal('9.5'), None)
+    assert unit == 'kg'
+    assert q == Decimal('2')
 
 
 def test_norm_unit_weight_table():


### PR DESCRIPTION
## Summary
- improve `_norm_unit` fallback when invoice has VAT 9.5%
- detect `1/1` style volume indication and convert to liters
- return kilograms by default for such VAT when no info
- expand tests for the new behaviour

## Testing
- `pytest tests/test_norm_unit.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628a4a49a48321b431ba7cc8b36106