### PR TITLE
Fix unit_price calculation from total_net

### DIFF
--- a/tests/test_duplicate_invoice_warning.py
+++ b/tests/test_duplicate_invoice_warning.py
@@ -18,6 +18,7 @@ def _sample_df():
             "cena_bruto": [Decimal("5")],
             "cena_netto": [Decimal("5")],
             "vrednost": [Decimal("5")],
+            "total_net": [Decimal("5")],
             "rabata": [Decimal("0")],
             "wsm_sifra": [pd.NA],
             "dobavitelj": ["Test"],

--- a/tests/test_price_history_duplicates.py
+++ b/tests/test_price_history_duplicates.py
@@ -9,6 +9,7 @@ def test_log_price_history_avoids_duplicates(tmp_path, monkeypatch):
         'sifra_dobavitelja': ['SUP'],
         'naziv': ['Artikel'],
         'cena_netto': [Decimal('10')],
+        'total_net': [Decimal('10')],
         'kolicina_norm': [1],
         'enota_norm': ['kg'],
     })
@@ -28,6 +29,7 @@ def test_log_price_history_folder_vat(tmp_path, monkeypatch):
         'sifra_dobavitelja': ['SUP'],
         'naziv': ['Artikel'],
         'cena_netto': [Decimal('10')],
+        'total_net': [Decimal('20')],
         'kolicina_norm': [2],
         'enota_norm': ['kg'],
     })

--- a/tests/test_price_history_service_date.py
+++ b/tests/test_price_history_service_date.py
@@ -11,6 +11,7 @@ def test_log_price_history_uses_service_date(tmp_path, monkeypatch):
         'sifra_dobavitelja': ['SUP'],
         'naziv': ['Artikel'],
         'cena_netto': [Decimal('10')],
+        'total_net': [Decimal('10')],
         'kolicina_norm': [1],
         'enota_norm': ['kg'],
     })

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -392,6 +392,7 @@ def log_price_history(
             "sifra_dobavitelja",
             "naziv",
             "cena_netto",
+            "total_net",
             "kolicina_norm",
             "enota_norm",
         ]
@@ -407,13 +408,13 @@ def log_price_history(
     )
     df_hist["unit_price"] = df_hist.apply(
         lambda r: (
-            Decimal(str(r["line_netto"]))
-            / Decimal(str(r["kolicina_norm"]))
+            Decimal(str(r["total_net"])) / Decimal(str(r["kolicina_norm"]))
             if r["enota_norm"] in ("kg", "L") and r["kolicina_norm"]
             else pd.NA
         ),
         axis=1,
     )
+    df_hist.drop(columns=["total_net"], inplace=True)
     df_hist.drop(columns=["kolicina_norm"], inplace=True)
     if service_date:
         try:


### PR DESCRIPTION
## Summary
- compute unit_price in price history from total_net
- adjust tests to include total_net
- add total_net to duplicate invoice sample

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68629157d5ec83218f93ce7e07a518a0