### PR TITLE
Fix VAT 9.5 unit fallback

### DIFF
--- a/tests/test_norm_unit.py
+++ b/tests/test_norm_unit.py
@@ -22,7 +22,7 @@ def test_norm_unit_vat_fraction_to_liter():
 
 def test_norm_unit_vat_default_kg():
     q, unit = _norm_unit(Decimal('2'), 'H87', 'Artikel brez mere', Decimal('9.5'), None)
-    assert unit == 'kos'
+    assert unit == 'kg'
     assert q == Decimal('2')
 
 

--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -178,10 +178,8 @@ def _norm_unit(
                 f"Fractional volume detected: {val}/1 -> using {val} L"
             )
             return q_norm * val, "L"
-        log.debug(
-            "VAT rate 9.5% with piece unit but no weight/volume info -> keeping 'kos'"
-        )
-        return q_norm, base_unit
+        log.debug("VAT rate 9.5% detected -> using 'kg' as fallback unit")
+        base_unit = "kg"
 
     log.debug(f"Končna normalizacija: q_norm={q_norm}, base_unit={base_unit}")
     return q_norm, base_unit


### PR DESCRIPTION
## Summary
- normalize piece units to kg when VAT rate is 9.5 and no other info
- adjust unit test expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686384fb28fc832184ef97dd623d9da4