### PR TITLE
Handle fractional piece quantities

### DIFF
--- a/tests/test_main_supplier_code.py
+++ b/tests/test_main_supplier_code.py
@@ -45,7 +45,7 @@ def test_analyze_ignores_doc_row_for_supplier(tmp_path):
 
     df, total, ok = analyze.analyze_invoice(xml_path, str(links))
     row = df[df["sifra_dobavitelja"] == "SUP"].iloc[0]
-    assert row["enota"] == "kos"
+    assert row["enota"] == "kg"
     assert row["kolicina"] == Decimal("2.5")
     assert total == Decimal("9")
     assert ok

--- a/tests/test_norm_unit.py
+++ b/tests/test_norm_unit.py
@@ -31,3 +31,15 @@ def test_norm_unit_weight_table():
     assert unit == 'kg'
     assert q == Decimal('0.48')
 
+
+def test_norm_unit_fractional_kos_default_kg():
+    q, unit = _norm_unit(Decimal('4.2'), 'H87', 'Artikel brez mere', Decimal('22'), None)
+    assert unit == 'kg'
+    assert q == Decimal('4.2')
+
+
+def test_norm_unit_fractional_kos_to_liter():
+    q, unit = _norm_unit(Decimal('4.2'), 'H87', 'Sok 500 ml', Decimal('22'), None)
+    assert unit == 'L'
+    assert q == Decimal('2.1')
+


### PR DESCRIPTION
## Summary
- interpret fractional 'kos' quantities as weight or volume
- keep behavior for integer counts
- add regression tests for fractional piece handling
- adjust supplier code tests for new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863bcc489208321a0c553e3375a7105