### PR TITLE
Fix PriceWatch closing behavior

### DIFF
--- a/tests/test_price_watch.py
+++ b/tests/test_price_watch.py
@@ -414,3 +414,22 @@ def test_show_graph_with_real_matplotlib(monkeypatch):
     assert ax.get_xlabel() == "Datum"
     assert ax.get_ylabel() == "Cena"
 
+
+def test_close_calls_destroy_and_quit():
+    calls = []
+
+    pw = PriceWatch.__new__(PriceWatch)
+
+    def fake_destroy():
+        calls.append("destroy")
+
+    def fake_quit():
+        calls.append("quit")
+
+    pw.destroy = fake_destroy
+    pw.quit = fake_quit
+
+    PriceWatch._close(pw)
+
+    assert calls == ["destroy", "quit"]
+

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -85,7 +85,7 @@ class PriceWatch(tk.Toplevel):
             messagebox.showerror(
                 "Napaka", f"Mapa dobaviteljev ni najdena: {self.suppliers_dir}"
             )
-            self.destroy()
+            self._close()
             return
 
         self.suppliers_map = _load_supplier_map(self.suppliers_dir)
@@ -101,8 +101,17 @@ class PriceWatch(tk.Toplevel):
         self._build_article_table()
         self._build_back_button()
 
-        self.bind("<Escape>", lambda e: self.destroy())
+        self.bind("<Escape>", lambda e: self._close())
         self._refresh_table()
+
+    # ------------------------------------------------------------------
+    def _close(self) -> None:
+        """Destroy the window and quit its event loop."""
+        try:
+            self.destroy()
+        finally:
+            if getattr(self, "quit", None):
+                self.quit()
 
     # ------------------------------------------------------------------
     def _build_supplier_search(self) -> None:
@@ -150,10 +159,10 @@ class PriceWatch(tk.Toplevel):
         scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
         self.tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.tree.bind("<Double-1>", self._on_double_click)
-        self.tree.bind("<BackSpace>", lambda e: self.destroy())
+        self.tree.bind("<BackSpace>", lambda e: self._close())
 
     def _build_back_button(self) -> None:
-        ttk.Button(self, text="Nazaj", command=self.destroy).pack(pady=5)
+        ttk.Button(self, text="Nazaj", command=self._close).pack(pady=5)
 
     # ------------------------------------------------------------------
     def _update_supplier_list(self) -> None:


### PR DESCRIPTION
## Summary
- add `_close()` helper to `PriceWatch` to quit nested event loop
- use `_close()` when suppliers folder is missing or when Escape/Back/Nazaj are triggered
- test `_close()` ensures both `destroy()` and `quit()` are called

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c92a63588321964e4cd03ccb6890