### PR TITLE
Add missing graph dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
    pip install -r requirements.txt
    ```
    Med glavnimi odvisnostmi so `pandas`, `pdfplumber` in `openpyxl`.
+   Za prikaz grafov cen morate namestiti tudi `matplotlib` in `mplcursors`:
+   ```bash
+   pip install 'wsm[plot]'
+   ```
    Za PyQt različico GUI lahko namestite tudi `PyQt5` preko
    ```bash
    pip install 'wsm[pyqt]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = ["pandas", "pdfplumber", "openpyxl", "click"]
 
 [project.optional-dependencies]
 pyqt = ["PyQt5>=5.15"]
+plot = ["matplotlib", "mplcursors"]
 
 [project.scripts]
 wsm = "wsm.cli:main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 pytest
 pytest-cov
 matplotlib
+mplcursors

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ openpyxl
 click
 # Optional: install PyQt5 to use the alternative Qt GUI
 PyQt5; extra == "pyqt"
+matplotlib
+mplcursors


### PR DESCRIPTION
## Summary
- include `matplotlib` and `mplcursors` in the main requirements
- ensure dev requirements install `mplcursors`
- expose them as an optional "plot" extra
- mention the optional install in the README

## Testing
- `pip install matplotlib mplcursors`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: Too early to create variable: no default root window)*

------
https://chatgpt.com/codex/tasks/task_e_6863da8b23548321a684a999995627c9