### PR TITLE
Drop unused price graph toggle

### DIFF
--- a/tests/test_price_watch.py
+++ b/tests/test_price_watch.py
@@ -232,29 +232,8 @@ def test_show_graph_sets_xticks(monkeypatch):
 
         def pack(self, *a, **k):
             pass
-    import builtins
-    toggle_capture = {}
-    builtins.toggle_capture = toggle_capture
-    monkeypatch.setattr("wsm.ui.price_watch.toggle_capture", toggle_capture)
-
-    class FakeVar:
-        def __init__(self, value=False):
-            builtins.toggle_capture["var"] = self
-
-        def get(self):
-            return False
-
-    class FakeCheck:
-        def __init__(self, master=None, text=None, variable=None, command=None):
-            builtins.toggle_capture["variable"] = variable
-
-        def pack(self, *a, **k):
-            builtins.toggle_capture["packed"] = True
-
     monkeypatch.setattr("wsm.ui.price_watch.tk.Toplevel", FakeTop)
     monkeypatch.setattr("wsm.ui.price_watch.ttk.Button", FakeButton)
-    monkeypatch.setattr("wsm.ui.price_watch.tk.BooleanVar", FakeVar)
-    monkeypatch.setattr("wsm.ui.price_watch.ttk.Checkbutton", FakeCheck)
     monkeypatch.setattr("wsm.ui.price_watch.tk.BOTH", "both", raising=False)
     monkeypatch.setattr("wsm.ui.price_watch.messagebox.showerror", lambda *a, **k: None)
 
@@ -269,8 +248,6 @@ def test_show_graph_sets_xticks(monkeypatch):
         df["unit_price"].min() - expected_pad,
         df["unit_price"].max() + expected_pad,
     )
-    assert toggle_capture.get("variable") is toggle_capture.get("var")
-    assert toggle_capture.get("packed") in (True, False)
 
 
 def test_show_graph_single_value(monkeypatch):
@@ -394,29 +371,8 @@ def test_show_graph_single_value(monkeypatch):
 
         def pack(self, *a, **k):
             pass
-    import builtins
-    toggle_capture = {}
-    builtins.toggle_capture = toggle_capture
-    monkeypatch.setattr("wsm.ui.price_watch.toggle_capture", toggle_capture)
-
-    class FakeVar:
-        def __init__(self, value=False):
-            builtins.toggle_capture["var"] = self
-
-        def get(self):
-            return False
-
-    class FakeCheck:
-        def __init__(self, master=None, text=None, variable=None, command=None):
-            builtins.toggle_capture["variable"] = variable
-
-        def pack(self, *a, **k):
-            builtins.toggle_capture["packed"] = True
-
     monkeypatch.setattr("wsm.ui.price_watch.tk.Toplevel", FakeTop)
     monkeypatch.setattr("wsm.ui.price_watch.ttk.Button", FakeButton)
-    monkeypatch.setattr("wsm.ui.price_watch.tk.BooleanVar", FakeVar)
-    monkeypatch.setattr("wsm.ui.price_watch.ttk.Checkbutton", FakeCheck)
     monkeypatch.setattr("wsm.ui.price_watch.tk.BOTH", "both", raising=False)
     monkeypatch.setattr("wsm.ui.price_watch.messagebox.showerror", lambda *a, **k: None)
 
@@ -428,8 +384,6 @@ def test_show_graph_single_value(monkeypatch):
     if pad == 0:
         pad = 0.10
     assert ax.ylim == (float(df["unit_price"].iloc[0]) - pad, float(df["unit_price"].iloc[0]) + pad)
-    assert toggle_capture.get("variable") is toggle_capture.get("var")
-    assert toggle_capture.get("packed") in (True, False)
 
 
 def test_refresh_table_empty(monkeypatch):
@@ -617,48 +571,7 @@ def test_show_graph_with_real_matplotlib(monkeypatch):
 
         def pack(self, *a, **k):
             pass
-    import builtins
-    toggle_capture = {}
-    builtins.toggle_capture = toggle_capture
-    monkeypatch.setattr("wsm.ui.price_watch.toggle_capture", toggle_capture)
-
-    class FakeVar:
-        def __init__(self, value=False):
-            builtins.toggle_capture["var"] = self
-
-        def get(self):
-            return False
-
-    class FakeCheck:
-        def __init__(self, master=None, text=None, variable=None, command=None):
-            builtins.toggle_capture["variable"] = variable
-
-        def pack(self, *a, **k):
-            builtins.toggle_capture["packed"] = True
-
-    toggle_capture = {}
-    builtins.toggle_capture = toggle_capture
-    monkeypatch.setattr("wsm.ui.price_watch.toggle_capture", toggle_capture)
-
-    class FakeVar:
-        def __init__(self, value=False):
-            builtins.toggle_capture["var"] = self
-
-        def get(self):
-            return False
-
-    class FakeCheck:
-        def __init__(self, master=None, text=None, variable=None, command=None):
-            builtins.toggle_capture["variable"] = variable
-
-        def pack(self, *a, **k):
-            builtins.toggle_capture["packed"] = True
-
     cursor_info = {}
-    import builtins
-    toggle_capture = {}
-    builtins.toggle_capture = toggle_capture
-    monkeypatch.setattr("wsm.ui.price_watch.toggle_capture", toggle_capture)
 
     class FakeCursor:
         def connect(self, event, func):
@@ -675,8 +588,6 @@ def test_show_graph_with_real_matplotlib(monkeypatch):
     )
     monkeypatch.setattr("wsm.ui.price_watch.tk.Toplevel", FakeTop)
     monkeypatch.setattr("wsm.ui.price_watch.ttk.Button", FakeButton)
-    monkeypatch.setattr("wsm.ui.price_watch.tk.BooleanVar", FakeVar)
-    monkeypatch.setattr("wsm.ui.price_watch.ttk.Checkbutton", FakeCheck)
     monkeypatch.setattr("wsm.ui.price_watch.tk.BOTH", "both", raising=False)
     monkeypatch.setattr("wsm.ui.price_watch.messagebox.showerror", lambda *a, **k: None)
     monkeypatch.setitem(sys.modules, "mplcursors", types.SimpleNamespace(cursor=fake_cursor))
@@ -800,8 +711,6 @@ def test_show_graph_skips_zero_prices(monkeypatch):
     ydata = list(line.get_ydata())
     assert 0 not in ydata
     assert len(ydata) == 2
-    assert toggle_capture.get("variable") is toggle_capture.get("var")
-    assert toggle_capture.get("packed") in (True, False)
 
 
 def test_close_calls_destroy_and_quit():

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -17,10 +17,6 @@ from wsm.supplier_store import load_suppliers as _load_supplier_map
 from wsm.utils import sanitize_folder_name
 from functools import lru_cache
 
-# Used in tests to verify that the toggle checkbutton was created.
-toggle_capture: dict[str, object] = {}
-import builtins
-builtins.toggle_capture = toggle_capture
 
 
 @lru_cache(maxsize=None)
@@ -329,29 +325,6 @@ class PriceWatch(tk.Toplevel):
         canvas.draw()
         canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
 
-        widget_parent = top
-        root_ok = tk._default_root is not None or hasattr(top, "tk")
-        if not root_ok:
-            # Attempt to create a root if none exists; may fail on headless systems
-            try:  # pragma: no cover - depends on Tk availability
-                root = tk.Tk()
-                root.withdraw()
-                if not hasattr(top, "tk"):
-                    top.tk = root.tk
-                widget_parent = root
-                root_ok = True
-            except Exception as exc:  # noqa: BLE001 - just log failure
-                log.warning("Failed to create Tk root: %s", exc)
-
-        if root_ok:
-            pct_var = tk.BooleanVar(value=False)
-            ttk.Checkbutton(widget_parent, text="%", variable=pct_var).pack(pady=5)
-            toggle_capture["var"] = pct_var
-            toggle_capture["variable"] = pct_var
-            toggle_capture["packed"] = True
-        else:
-            # Headless fallback: no toggle widget available
-            toggle_capture["packed"] = False
         ttk.Button(top, text="Zapri", command=top.destroy).pack(pady=5)
         top.bind("<Escape>", lambda e: top.destroy())
 


### PR DESCRIPTION
## Summary
- remove `toggle_capture` helper and related checkbox logic
- update tests that referenced the removed toggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f9c78d388321a61e42beac1eb5c0