### PR TITLE
Fix tooltip formatting for graph points

### DIFF
--- a/tests/test_price_watch.py
+++ b/tests/test_price_watch.py
@@ -622,7 +622,7 @@ def test_show_graph_with_real_matplotlib(monkeypatch):
             target=(mdates.date2num(first_x), first_y), annotation=Ann()
         )
     )
-    assert ann_text and "2023-01-01" in ann_text[0]
+    assert ann_text and ann_text[0] == "1.00 €\n2023-01-01"
 
 
 def test_show_graph_skips_zero_prices(monkeypatch):

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 from wsm.supplier_store import load_suppliers as _load_supplier_map
 from wsm.utils import sanitize_folder_name
 from functools import lru_cache
+from typing import Any
 
 
 
@@ -286,12 +287,17 @@ class PriceWatch(tk.Toplevel):
 
         ax.plot(df_plot["date"], df_plot["price"], marker="o")
         cursor = mplcursors.cursor(ax.get_lines(), hover=True)
-        cursor.connect(
-            "add",
-            lambda sel: sel.annotation.set_text(
-                f"{sel.target[1]:.2f}\n{mdates.num2date(sel.target[0]).strftime('%Y-%m-%d')}"
-            ),
-        )
+
+        def _fmt(sel: Any) -> None:
+            try:
+                dt = mdates.num2date(sel.target[0])
+            except Exception:
+                dt = pd.to_datetime(sel.target[0])
+            sel.annotation.set_text(
+                f"{sel.target[1]:.2f} €\n{dt.strftime('%Y-%m-%d')}"
+            )
+
+        cursor.connect("add", _fmt)
         locator = mdates.DayLocator()
         ax.xaxis.set_major_locator(locator)
         ax.xaxis.set_major_formatter(mdates.DateFormatter("%d-%b"))


### PR DESCRIPTION
## Summary
- ensure tooltip handler uses euro symbol and handles grouped date values
- update test for formatted tooltip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864fbc18fd08321aa6d0278b01ea761