### PR TITLE
Update README instructions for price watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
    pip install -r requirements.txt
    ```
    Med glavnimi odvisnostmi so `pandas`, `pdfplumber` in `openpyxl`.
-   Za prikaz grafov cen morate namestiti tudi `matplotlib` in `mplcursors`:
+   Za grafični vmesnik **Price Watch** potrebujete tudi `matplotlib` in `mplcursors`:
    ```bash
    pip install 'wsm[plot]'
    ```
@@ -145,7 +145,9 @@ stalno maso pakiranja, jo dodajte v ta slovar.
 
 ### Poganjanje testov
 
-Pred zagonom `pytest` zato namestite pakete iz `requirements.txt` in, če obstaja, še `requirements-dev.txt`:
+Pred zagonom `pytest` namestite pakete iz `requirements.txt` in, če obstaja,
+še `requirements-dev.txt`. Slednji vključuje `matplotlib` in `mplcursors`,
+ki sta potrebna za teste **Price Watch**:
 
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- clarify that matplotlib and mplcursors are needed for the price-watch GUI
- mention these packages when describing how to run tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ff7f5c8083219a542fb41b22d3c1