### PR TITLE
Add PRICE_DIFF_THRESHOLD constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ ki avtomatizira vnos in obdelavo računov ter povezovanje s šiframi izdelkov.
   prostora, da se ločijo od tabele.
   Ob potrditvi vrstice program primerja ceno s prejšnjimi zapisi v
   `price_history.xlsx`. Če je odstopanje večje od nastavljenega praga
-  (privzeto 5&nbsp;% oz. vrednost spremenljivke `WSM_PRICE_WARN_PCT`), se
+  (privzeto 1&nbsp;% oz. vrednost spremenljivke `WSM_PRICE_WARN_PCT`), se
   vrstica obarva oranžno in prikaže se namig z zadnjo ceno ter razliko v
   odstotkih.
   Parameter `--price-warn-pct` omogoča začasno nastavitev drugega praga.

--- a/wsm/constants.py
+++ b/wsm/constants.py
@@ -3,6 +3,9 @@ from decimal import Decimal
 from pathlib import Path
 import csv
 
+# Threshold for price change warnings (percent).
+PRICE_DIFF_THRESHOLD = Decimal("1.0")
+
 # Mapping of supplier item codes to their weight per individual piece (in kg).
 # Add entries as needed for products where the packaging weight is constant.
 WEIGHTS_PER_PIECE: dict[tuple[str, str], Decimal] = {}

--- a/wsm/ui/review/__init__.py
+++ b/wsm/ui/review/__init__.py
@@ -1,4 +1,5 @@
-from .helpers import _fmt, _norm_unit, PRICE_DIFF_THRESHOLD
+from wsm.constants import PRICE_DIFF_THRESHOLD
+from .helpers import _fmt, _norm_unit
 from .gui import review_links, _apply_price_warning, log
 from .io import _save_and_close, _load_supplier_map, _write_supplier_map
 

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -18,7 +18,8 @@ from tkinter import ttk, messagebox
 
 from wsm.parsing.money import detect_round_step
 from wsm.utils import short_supplier_name, _clean
-from .helpers import _fmt, _norm_unit, PRICE_DIFF_THRESHOLD
+from wsm.constants import PRICE_DIFF_THRESHOLD
+from .helpers import _fmt, _norm_unit
 from .io import _save_and_close, _load_supplier_map, _write_supplier_map
 
 # Logger setup

--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -7,14 +7,17 @@ import re
 from decimal import Decimal
 from typing import Tuple
 
-from wsm.constants import WEIGHTS_PER_PIECE
+from wsm.constants import WEIGHTS_PER_PIECE, PRICE_DIFF_THRESHOLD as DEFAULT_PRICE_DIFF_THRESHOLD
 
 import pandas as pd
 
 log = logging.getLogger(__name__)
 
 # Threshold for price change warnings in percent used by GUI
-PRICE_DIFF_THRESHOLD = Decimal(os.getenv("WSM_PRICE_WARN_PCT", "5"))
+_env_threshold = os.getenv("WSM_PRICE_WARN_PCT")
+PRICE_DIFF_THRESHOLD = (
+    Decimal(_env_threshold) if _env_threshold is not None else DEFAULT_PRICE_DIFF_THRESHOLD
+)
 
 
 def _fmt(v) -> str:

--- a/wsm/ui/review_links.py
+++ b/wsm/ui/review_links.py
@@ -1,7 +1,8 @@
 """Backward compatibility module for review utilities."""
 from __future__ import annotations
 
-from .review.helpers import _fmt, _norm_unit, PRICE_DIFF_THRESHOLD
+from wsm.constants import PRICE_DIFF_THRESHOLD
+from .review.helpers import _fmt, _norm_unit
 from .review.gui import review_links, _apply_price_warning
 from .review.io import _save_and_close, _load_supplier_map, _write_supplier_map
 

--- a/wsm/ui_qt/review_links_qt.py
+++ b/wsm/ui_qt/review_links_qt.py
@@ -21,7 +21,8 @@ try:
 except Exception as exc:  # pragma: no cover - optional dependency
     raise ImportError("PyQt5 is required for the Qt GUI") from exc
 
-from wsm.ui.review.helpers import _fmt, _norm_unit, PRICE_DIFF_THRESHOLD
+from wsm.constants import PRICE_DIFF_THRESHOLD
+from wsm.ui.review.helpers import _fmt, _norm_unit
 from wsm.ui.review.io import _save_and_close, _load_supplier_map
 from wsm.parsing.money import detect_round_step
 from wsm.utils import short_supplier_name


### PR DESCRIPTION
## Summary
- establish `PRICE_DIFF_THRESHOLD` in `wsm.constants`
- use this constant in UI modules
- document new default threshold in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650f83d1988321ae476402bff6155f