### PR TITLE
Improve price watch diff display

### DIFF
--- a/tests/test_price_watch.py
+++ b/tests/test_price_watch.py
@@ -431,6 +431,10 @@ def test_refresh_table_empty(monkeypatch):
 
 
 def test_refresh_table_with_data(monkeypatch):
+    monkeypatch.setattr(
+        "wsm.ui.price_watch.messagebox.showinfo",
+        lambda *a, **k: None,
+    )
     class DummyVar:
         def __init__(self, value=""):
             self.val = value
@@ -477,6 +481,10 @@ def test_refresh_table_with_data(monkeypatch):
 
 
 def test_refresh_table_with_non_contiguous_index(monkeypatch):
+    monkeypatch.setattr(
+        "wsm.ui.price_watch.messagebox.showinfo",
+        lambda *a, **k: None,
+    )
     class DummyVar:
         def __init__(self, value=""):
             self.val = value


### PR DESCRIPTION
## Summary
- color-code price differences with `_color_for_diff`
- tag tree rows with computed colors and alert on large changes
- skip GUI alerts during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865148b3040832195da4989366d8347