### PR TITLE
Round price watch table values to two decimals

### DIFF
--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -281,18 +281,18 @@ class PriceWatch(tk.Toplevel):
                     try:
                         messagebox.showinfo(
                             "Price change",
-                            f"{price_val} ({r['diff_pct']:.2f} %)",
+                            f"{price_val:.2f} ({r['diff_pct']:.2f} %)",
                         )
                     except Exception:  # pragma: no cover - optional GUI
                         pass
             vals = (
                 r["label"],
-                "" if r["line_netto"] is None else f"{r['line_netto']}",
-                "" if r["unit_price"] is None else f"{r['unit_price']}",
+                "" if r["line_netto"] is None else f"{r['line_netto']:.2f}",
+                "" if r["unit_price"] is None else f"{r['unit_price']:.2f}",
                 r["last_dt"].strftime("%Y-%m-%d"),
                 "" if r["diff_pct"] is None else f"{r['diff_pct']:.2f}",
-                f"{r['min']}",
-                f"{r['max']}",
+                f"{r['min']:.2f}",
+                f"{r['max']:.2f}",
             )
             kwargs = {"tags": (tag,)} if tag else {}
             try:


### PR DESCRIPTION
## Summary
- round prices shown in the `PriceWatch` table and popup messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686516b42f648321a395070d1b22474c