### PR TITLE
Add weeks filter to Price Watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ stalno maso pakiranja, jo dodajte v ta slovar.
    vmesnik pa lahko po potrebi zaženete tudi neposredno s funkcijo
    `launch_price_watch`.
 
-   V zgornjem delu okna je iskalnik za hitro filtriranje dobaviteljev. Spodaj
-   se nahaja dodatno polje za iskanje po nazivih artiklov. Rezultati so
+   V zgornjem delu okna je iskalnik za hitro filtriranje dobaviteljev. Ob njem
+   je še polje za izbiro števila tednov (privzeto 10), ki določa, koliko
+   zgodovine se upošteva pri izračunu spremembe cene. Spodaj se nahaja
+   dodatno polje za iskanje po nazivih artiklov. Rezultati so
    prikazani v tabeli s stolpci "Artikel", "Neto cena", "€/kg|€/L",
    "Zadnji datum", "Min" in "Max". Po posameznem stolpcu lahko razvrstite
    s klikom na glavo.

--- a/tests/test_price_watch.py
+++ b/tests/test_price_watch.py
@@ -531,6 +531,120 @@ def test_refresh_table_with_non_contiguous_index(monkeypatch):
     assert float(row[2]) == 0.6
 
 
+def test_refresh_table_weeks_filter(monkeypatch):
+    monkeypatch.setattr(
+        "wsm.ui.price_watch.messagebox.showinfo",
+        lambda *a, **k: None,
+    )
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.val = value
+
+        def get(self):
+            return self.val
+
+    class DummyTree:
+        def __init__(self):
+            self.inserted = []
+
+        def get_children(self):
+            return []
+
+        def delete(self, *a):
+            pass
+
+        def insert(self, parent, index, values):
+            self.inserted.append(values)
+
+    now = pd.Timestamp("2023-01-31")
+    monkeypatch.setattr(pd.Timestamp, "now", classmethod(lambda cls, tz=None: now))
+
+    df = pd.DataFrame(
+        {
+            "line_netto": [1, 2, 3],
+            "unit_price": [pd.NA, pd.NA, pd.NA],
+            "time": [
+                now - pd.Timedelta(weeks=2),
+                now - pd.Timedelta(weeks=1),
+                now,
+            ],
+        }
+    )
+
+    pw = PriceWatch.__new__(PriceWatch)
+    pw.tree = DummyTree()
+    pw.supplier_codes = {"S1 - Sup": "S1"}
+    pw.sup_var = DummyVar("S1 - Sup")
+    pw.search_var = DummyVar("")
+    pw.weeks_var = DummyVar("2")
+    pw.items_by_supplier = {"S1": {"Item": df}}
+    pw._sort_col = None
+    pw._sort_reverse = False
+
+    pw._refresh_table()
+
+    row = pw.tree.inserted[0]
+    assert float(row[4]) == 200.0
+
+
+def test_refresh_table_weeks_filter_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "wsm.ui.price_watch.messagebox.showinfo",
+        lambda *a, **k: None,
+    )
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.val = value
+
+        def get(self):
+            return self.val
+
+    class DummyTree:
+        def __init__(self):
+            self.inserted = []
+
+        def get_children(self):
+            return []
+
+        def delete(self, *a):
+            pass
+
+        def insert(self, parent, index, values):
+            self.inserted.append(values)
+
+    now = pd.Timestamp("2023-01-31")
+    monkeypatch.setattr(pd.Timestamp, "now", classmethod(lambda cls, tz=None: now))
+
+    df = pd.DataFrame(
+        {
+            "line_netto": [1, 2, 4],
+            "unit_price": [pd.NA, pd.NA, pd.NA],
+            "time": [
+                now - pd.Timedelta(weeks=10),
+                now - pd.Timedelta(weeks=5),
+                now,
+            ],
+        }
+    )
+
+    pw = PriceWatch.__new__(PriceWatch)
+    pw.tree = DummyTree()
+    pw.supplier_codes = {"S1 - Sup": "S1"}
+    pw.sup_var = DummyVar("S1 - Sup")
+    pw.search_var = DummyVar("")
+    pw.weeks_var = DummyVar("1")
+    pw.items_by_supplier = {"S1": {"Item": df}}
+    pw._sort_col = None
+    pw._sort_reverse = False
+
+    pw._refresh_table()
+
+    row = pw.tree.inserted[0]
+    assert float(row[4]) == 300.0
+
+
 def test_show_graph_with_real_matplotlib(monkeypatch):
     import matplotlib
     import matplotlib.dates as mdates


### PR DESCRIPTION
## Summary
- add weeks range selection in Price Watch GUI
- compute diff percentage based on selected weeks and plot matching range
- document weeks filter in README
- test weeks filtering logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651a43c2888321be0a66ea98271a7e