### PR TITLE
Format numbers in price watch table

### DIFF
--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -306,12 +306,12 @@ class PriceWatch(tk.Toplevel):
                         pass
             vals = (
                 r["label"],
-                "" if r["line_netto"] is None else f"{r['line_netto']}",
-                "" if r["unit_price"] is None else f"{r['unit_price']}",
+                "" if r["line_netto"] is None else f"{r['line_netto']:.2f}",
+                "" if r["unit_price"] is None else f"{r['unit_price']:.2f}",
                 r["last_dt"].strftime("%Y-%m-%d"),
                 "" if r["diff_pct"] is None else f"{r['diff_pct']:.2f}",
-                f"{r['min']}",
-                f"{r['max']}",
+                f"{r['min']:.2f}",
+                f"{r['max']:.2f}",
             )
             kwargs = {"tags": (tag,)} if tag else {}
             try:


### PR DESCRIPTION
## Summary
- display numerical values in `_refresh_table` with two decimal places

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686520d821148321b01638d583ead839