### PR TITLE
Auto-refresh price watch on weeks change

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ stalno maso pakiranja, jo dodajte v ta slovar.
    V zgornjem delu okna je iskalnik za hitro filtriranje dobaviteljev. Ob njem
    je še polje za izbiro števila tednov (privzeto 2), ki določa, koliko
    zgodovine se upošteva pri izračunu spremembe cene. Spodaj se nahaja
-   dodatno polje za iskanje po nazivih artiklov. Filter se uporabi po kliku na
-   gumb "Potrdi". Rezultati so
+   dodatno polje za iskanje po nazivih artiklov. Tabela se ob spremembi
+   števila tednov osveži samodejno, filter pa lahko po želji potrdite tudi
+   z gumbom "Potrdi". Rezultati so
    prikazani v tabeli s stolpci "Artikel", "Neto cena", "€/kg|€/L",
    "Zadnji datum", "Min" in "Max". Po posameznem stolpcu lahko razvrstite
    s klikom na glavo.

--- a/wsm/ui/price_watch.py
+++ b/wsm/ui/price_watch.py
@@ -143,6 +143,8 @@ class PriceWatch(tk.Toplevel):
         self.weeks_var = tk.StringVar(value="2")
         spin = ttk.Spinbox(frame, from_=1, to=520, textvariable=self.weeks_var, width=5)
         spin.pack(side=tk.LEFT, padx=5)
+        spin.configure(command=self._refresh_table)
+        spin.bind("<KeyRelease>", lambda e: self._refresh_table())
         ttk.Button(frame, text="Potrdi", command=self._refresh_table).pack(side=tk.LEFT, padx=5)
 
         self.sup_var = tk.StringVar()


### PR DESCRIPTION
## Summary
- refresh the price watch table when changing the week range
- mention automatic refresh in the docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686526b2a15483219409cd9ea9e051bd