### PR TITLE
Add start date filter to Price Watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ stalno maso pakiranja, jo dodajte v ta slovar.
    `launch_price_watch`.
 
    V zgornjem delu okna je iskalnik za hitro filtriranje dobaviteljev. Ob njem
-   je še polje za izbiro števila tednov (privzeto 2), ki določa, koliko
-   zgodovine se upošteva pri izračunu spremembe cene. Spodaj se nahaja
-   dodatno polje za iskanje po nazivih artiklov. Tabela se ob spremembi
-   števila tednov osveži samodejno, filter pa lahko po želji potrdite tudi
+   je še polje za izbiro števila tednov (privzeto 30) in koledar za izbiro
+   začetnega datuma. Če je nameščen paket `tkcalendar`, se privzeta vrednost
+   koledarja nastavi na prvi dan trenutnega leta. Spodaj se nahaja dodatno
+   polje za iskanje po nazivih artiklov. Tabela se ob spremembi
+   števila tednov ali datuma osveži samodejno, filter pa lahko po želji potrdite tudi
    z gumbom "Potrdi". Rezultati so
    prikazani v tabeli s stolpci "Artikel", "Neto cena", "€/kg|€/L",
    "Zadnji datum", "Min" in "Max". Po posameznem stolpcu lahko razvrstite


### PR DESCRIPTION
## Summary
- default to 30 weeks when showing historical prices
- allow selecting a start date via `tkcalendar.DateEntry`
- compute stats from chosen date or week range
- document calendar selector in README
- test that start date filtering works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686624f9a96c832195dfcceb9e8a3393