### PR TITLE
Handle 100% discount lines

### DIFF
--- a/tests/test_ignore_gratis_lines.py
+++ b/tests/test_ignore_gratis_lines.py
@@ -1,0 +1,49 @@
+from decimal import Decimal
+import pandas as pd
+from wsm import analyze
+
+
+def test_gratis_lines_are_removed(monkeypatch):
+    data = pd.DataFrame([
+        {
+            'sifra_dobavitelja': 'SUP',
+            'naziv': 'Kava',
+            'kolicina': Decimal('24'),
+            'enota': 'kos',
+            'cena_bruto': Decimal('0'),
+            'cena_netto': Decimal('0'),
+            'rabata': Decimal('0'),
+            'rabata_pct': Decimal('0'),
+            'vrednost': Decimal('48'),
+            'sifra_artikla': '111',
+            'ddv_stopnja': Decimal('22'),
+        },
+        {
+            'sifra_dobavitelja': 'SUP',
+            'naziv': 'Kava',
+            'kolicina': Decimal('6'),
+            'enota': 'kos',
+            'cena_bruto': Decimal('0'),
+            'cena_netto': Decimal('0'),
+            'rabata': Decimal('12'),
+            'rabata_pct': Decimal('100'),
+            'vrednost': Decimal('0'),
+            'sifra_artikla': '111',
+            'ddv_stopnja': Decimal('22'),
+        },
+    ])
+
+    monkeypatch.setattr(analyze, 'parse_eslog_invoice', lambda path, sup: data)
+    monkeypatch.setattr(analyze, '_norm_unit', lambda q, u, n, vat=None, code=None: (q, u))
+    monkeypatch.setattr(analyze, 'extract_header_net', lambda path: Decimal('48'))
+
+    df, total, ok = analyze.analyze_invoice('dummy.xml')
+
+    assert total == Decimal('48')
+    assert ok
+    rows = df[df['sifra_artikla'] == '111']
+    assert len(rows) == 1
+    row = rows.iloc[0]
+    assert row['kolicina'] == Decimal('24')
+    assert row['vrednost'] == Decimal('48')
+

--- a/wsm/analyze.py
+++ b/wsm/analyze.py
@@ -37,6 +37,11 @@ def analyze_invoice(xml_path: str, suppliers_file: str | None = None) -> tuple[p
     df_main = df[~doc_mask].copy()
     df_doc = df[doc_mask].copy()
 
+    # Remove "gratis" lines with 100 % discount or zero net value
+    df_main = df_main[~(
+        (df_main['vrednost'] == 0) | (df_main['rabata_pct'] >= Decimal('100'))
+    )].copy()
+
     grouped = (
         df_main
         .groupby(['sifra_artikla', 'rabata_pct'], dropna=False, as_index=False)


### PR DESCRIPTION
## Summary
- remove invoice lines that have zero net amount or 100% discount
- test that gratis lines are ignored

## Testing
- `pytest tests/test_ignore_gratis_lines.py::test_gratis_lines_are_removed -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662b4f194083219c90c0e9a483de1b