### PR TITLE
Add bonus code handling for gratis lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ Za datoteko s ključnimi besedami lahko nastavite okoljsko spremenljivko
 `WSM_KEYWORDS`, ki kaže na `kljucne_besede_wsm_kode.xlsx`. Če ni
 nastavljena, program privzeto bere to datoteko iz trenutne mape.
 
+Če v `povezi_z_wsm` želite samodejno označiti brezplačne ("gratis")
+postavke s posebno WSM kodo, nastavite okoljsko spremenljivko
+`WSM_BONUS_CODE` na želeno kodo. Vrstice, kjer je stolpec `is_gratis`
+`True`, bodo tako dobile to kodo in status `BONUS`.
+
 
 Pri samodejnem povezovanju lahko program iz teh ročno
 shranjenih datotek sam izdela datoteko `kljucne_besede_wsm_kode.xlsx`.

--- a/tests/test_bonus_code.py
+++ b/tests/test_bonus_code.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from pathlib import Path
+import json
+from wsm.utils import povezi_z_wsm
+
+
+def _setup_env(tmp_path: Path) -> Path:
+    links_dir = tmp_path / "links" / "Test"
+    links_dir.mkdir(parents=True)
+    # empty manual links
+    pd.DataFrame(columns=["sifra_dobavitelja", "naziv", "naziv_ckey", "wsm_sifra"]).to_excel(
+        links_dir / "SUP_Test_povezane.xlsx", index=False
+    )
+    (links_dir / "supplier.json").write_text(json.dumps({"sifra": "SUP", "ime": "Test"}))
+    return tmp_path / "links"
+
+
+def test_bonus_code_applied(monkeypatch, tmp_path):
+    links_dir = _setup_env(tmp_path)
+    sifre = tmp_path / "sifre.xlsx"
+    pd.DataFrame({"wsm_sifra": ["1"], "wsm_naziv": ["Dummy"]}).to_excel(sifre, index=False)
+    keywords = tmp_path / "kw.xlsx"
+    pd.DataFrame(columns=["wsm_sifra", "keyword"]).to_excel(keywords, index=False)
+
+    df_items = pd.DataFrame({
+        "sifra_dobavitelja": ["SUP"],
+        "naziv": ["Gratis"],
+        "is_gratis": [True],
+    })
+
+    monkeypatch.setenv("WSM_BONUS_CODE", "BON")
+
+    result = povezi_z_wsm(df_items, str(sifre), str(keywords), links_dir, "SUP")
+
+    assert result.loc[0, "wsm_sifra"] == "BON"
+    assert result.loc[0, "status"] == "BONUS"
+

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -190,7 +190,24 @@ def review(invoice, wsm_codes, suppliers, keywords, price_warn_pct, use_pyqt):
 
     try:
         from wsm.utils import povezi_z_wsm
-        df = povezi_z_wsm(df, str(sifre_path), str(keywords_path), Path(suppliers_path), supplier_code)
+        bonus_code = os.getenv("WSM_BONUS_CODE")
+        if bonus_code:
+            df = povezi_z_wsm(
+                df,
+                str(sifre_path),
+                str(keywords_path),
+                Path(suppliers_path),
+                supplier_code,
+                bonus_code=bonus_code,
+            )
+        else:
+            df = povezi_z_wsm(
+                df,
+                str(sifre_path),
+                str(keywords_path),
+                Path(suppliers_path),
+                supplier_code,
+            )
     except Exception as exc:
         click.echo(f"[NAPAKA] Samodejno povezovanje ni uspelo: {exc}")
 

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -128,7 +128,24 @@ def open_invoice_gui(
     try:
         from wsm.utils import povezi_z_wsm
 
-        df = povezi_z_wsm(df, str(sifre_file), str(keywords), suppliers, supplier_code)
+        bonus_code = os.getenv("WSM_BONUS_CODE")
+        if bonus_code:
+            df = povezi_z_wsm(
+                df,
+                str(sifre_file),
+                str(keywords),
+                suppliers,
+                supplier_code,
+                bonus_code=bonus_code,
+            )
+        else:
+            df = povezi_z_wsm(
+                df,
+                str(sifre_file),
+                str(keywords),
+                suppliers,
+                supplier_code,
+            )
     except Exception as exc:
         logging.warning(f"Napaka pri samodejnem povezovanju: {exc}")
 

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -246,11 +246,12 @@ def load_wsm_data(
 
 # ────────────────────────── samodejno povezovanje ───────────────────
 def povezi_z_wsm(
-    df_items      : pd.DataFrame,
-    sifre_path    : str,
-    keywords_path : str | None = None,
-    links_dir     : Path | None = None,
-    supplier_code : str | None = None
+    df_items: pd.DataFrame,
+    sifre_path: str,
+    keywords_path: str | None = None,
+    links_dir: Path | None = None,
+    supplier_code: str | None = None,
+    bonus_code: str | None = None,
 ) -> pd.DataFrame:
     """
     Poskusi vsaki vrstici v ``df_items`` pripisati WSM kodo:
@@ -265,6 +266,8 @@ def povezi_z_wsm(
     """
     if keywords_path is None:
         keywords_path = os.getenv("WSM_KEYWORDS", "kljucne_besede_wsm_kode.xlsx")
+    if bonus_code is None:
+        bonus_code = os.getenv("WSM_BONUS_CODE")
     if links_dir is None or supplier_code is None:
         raise TypeError("links_dir and supplier_code must be provided")
     kw_path = Path(keywords_path)
@@ -287,6 +290,11 @@ def povezi_z_wsm(
         on=["sifra_dobavitelja", "naziv_ckey"], how="left"
     )
     df["status"] = df["wsm_sifra"].notna().map({True: "POVEZANO", False: pd.NA})
+
+    if bonus_code and "is_gratis" in df.columns:
+        bonus_mask = df["status"].isna() & df["is_gratis"]
+        df.loc[bonus_mask, "wsm_sifra"] = bonus_code
+        df.loc[bonus_mask, "status"] = "BONUS"
 
     new_links: List[Dict] = []
     mask = df["status"].isna()


### PR DESCRIPTION
## Summary
- support optional `bonus_code` for `povezi_z_wsm`
- allow CLI and UI to forward `WSM_BONUS_CODE`
- document `WSM_BONUS_CODE` environment variable
- add regression test for gratis bonus code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68664f9650608321ae5a24f4013356f5