### PR TITLE
Fix gratis tagging when items lack tags

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -495,7 +495,7 @@ def review_links(
         )
         df.at[i, "warning"] = tooltip
         if "is_gratis" in row and row["is_gratis"]:
-            current_tags = tree.item(str(i), "tags")
+            current_tags = tree.item(str(i)).get("tags", ())
             tree.item(str(i), tags=current_tags + ("gratis",))
     tree.focus("0")
     tree.selection_set("0")
@@ -886,7 +886,7 @@ def review_links(
 
         _show_tooltip(sel_i, tooltip)
         if "is_gratis" in df.columns and df.at[idx, "is_gratis"]:
-            current_tags = tree.item(sel_i, "tags")
+            current_tags = tree.item(sel_i).get("tags", ())
             if "gratis" not in current_tags:
                 tree.item(sel_i, tags=current_tags + ("gratis",))
 


### PR DESCRIPTION
## Summary
- avoid TypeError when appending the `gratis` tag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68666b4709788321b715b17ec16ffc89