### PR TITLE
Enable editing of WSM code in Qt model

### DIFF
--- a/tests/test_qt_dataframe_model.py
+++ b/tests/test_qt_dataframe_model.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from PyQt5 import QtCore
+from wsm.ui_qt import DataFrameModel
+
+
+def test_wsm_sifra_editable_based_on_status():
+    df = pd.DataFrame({
+        "wsm_sifra": ["111", "", "222"],
+        "status": ["POVEZANO", "BONUS", pd.NA],
+        "other": [1, 2, 3],
+    })
+    model = DataFrameModel(df)
+    col = df.columns.get_loc("wsm_sifra")
+
+    editable0 = model.flags(model.index(0, col)) & QtCore.Qt.ItemIsEditable
+    editable1 = model.flags(model.index(1, col)) & QtCore.Qt.ItemIsEditable
+    editable2 = model.flags(model.index(2, col)) & QtCore.Qt.ItemIsEditable
+
+    assert not editable0
+    assert editable1
+    assert editable2
+
+    # other column should never be editable
+    other_col = df.columns.get_loc("other")
+    assert not (model.flags(model.index(1, other_col)) & QtCore.Qt.ItemIsEditable)

--- a/wsm/ui_qt/__init__.py
+++ b/wsm/ui_qt/__init__.py
@@ -1,0 +1,1 @@
+from .model import DataFrameModel

--- a/wsm/ui_qt/model.py
+++ b/wsm/ui_qt/model.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from PyQt5 import QtCore
+import pandas as pd
+
+
+class DataFrameModel(QtCore.QAbstractTableModel):
+    """Simple Qt table model backed by a pandas DataFrame."""
+
+    def __init__(self, df: pd.DataFrame):
+        super().__init__()
+        self._df = df
+
+    def rowCount(self, parent: QtCore.QModelIndex | QtCore.QModelIndex = QtCore.QModelIndex()) -> int:  # type: ignore[override]
+        return len(self._df)
+
+    def columnCount(self, parent: QtCore.QModelIndex | QtCore.QModelIndex = QtCore.QModelIndex()) -> int:  # type: ignore[override]
+        return len(self._df.columns)
+
+    def data(self, index: QtCore.QModelIndex, role: int = QtCore.Qt.DisplayRole):  # type: ignore[override]
+        if not index.isValid():
+            return None
+        value = self._df.iat[index.row(), index.column()]
+        if role in (QtCore.Qt.DisplayRole, QtCore.Qt.EditRole):
+            if pd.isna(value):
+                return ""
+            return str(value)
+        return None
+
+    def setData(self, index: QtCore.QModelIndex, value, role: int = QtCore.Qt.EditRole):  # type: ignore[override]
+        if role != QtCore.Qt.EditRole or not index.isValid():
+            return False
+        column = self._df.columns[index.column()]
+        self._df.at[index.row(), column] = value
+        self.dataChanged.emit(index, index, [QtCore.Qt.DisplayRole, QtCore.Qt.EditRole])
+        return True
+
+    def headerData(self, section: int, orientation: QtCore.Qt.Orientation, role: int = QtCore.Qt.DisplayRole):  # type: ignore[override]
+        if role != QtCore.Qt.DisplayRole:
+            return None
+        if orientation == QtCore.Qt.Horizontal:
+            return str(self._df.columns[section])
+        return str(section)
+
+    def flags(self, index: QtCore.QModelIndex):  # type: ignore[override]
+        if not index.isValid():
+            return QtCore.Qt.NoItemFlags
+        base = QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
+        column_name = self._df.columns[index.column()]
+        if column_name == "wsm_sifra":
+            status = None
+            if "status" in self._df.columns:
+                status = self._df.at[index.row(), "status"]
+            if pd.isna(status) or status != "POVEZANO":
+                return base | QtCore.Qt.ItemIsEditable
+        return base


### PR DESCRIPTION
## Summary
- add `DataFrameModel` for Qt views
- expose `DataFrameModel` in `ui_qt` package
- allow editing of `wsm_sifra` unless row status is `POVEZANO`
- test editable behaviour for BONUS and blank rows

## Testing
- `pytest tests/test_qt_dataframe_model.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68677843323c832190c9e3189e14bba6