### PR TITLE
Fix gratis tag update

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -496,6 +496,8 @@ def review_links(
         df.at[i, "warning"] = tooltip
         if "is_gratis" in row and row["is_gratis"]:
             current_tags = tree.item(str(i)).get("tags", ())
+            if not isinstance(current_tags, tuple):
+                current_tags = (current_tags,) if current_tags else ()
             tree.item(str(i), tags=current_tags + ("gratis",))
     tree.focus("0")
     tree.selection_set("0")
@@ -887,8 +889,9 @@ def review_links(
         _show_tooltip(sel_i, tooltip)
         if "is_gratis" in df.columns and df.at[idx, "is_gratis"]:
             current_tags = tree.item(sel_i).get("tags", ())
-            if "gratis" not in current_tags:
-                tree.item(sel_i, tags=current_tags + ("gratis",))
+            if not isinstance(current_tags, tuple):
+                current_tags = (current_tags,) if current_tags else ()
+            tree.item(sel_i, tags=current_tags + ("gratis",))
 
         new_vals = [
             (


### PR DESCRIPTION
## Summary
- ensure gratis tag logic handles `Treeview` tags that are not tuples

## Testing
- `pytest -q`
- `python -m wsm.cli review tests/minimal_doc_discount.xml --wsm-codes sifre_wsm.xlsx --keywords kljucne_besede_wsm_kode.xlsx --suppliers links` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68678253d96c83218a79252bf1657fa0