### PR TITLE
Fix tag config usage

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -453,9 +453,9 @@ def review_links(
     ]
     tree = ttk.Treeview(frame, columns=cols, show="headings", height=tree_height)
     tree.tag_configure("price_warn", background="orange")
-    tree.tag_config("gratis", background="#ffe6cc")  # oranžna
-    tree.tag_config("linked", background="#ffe6cc")
-    tree.tag_config("suggestion", background="#ffe6cc")
+    tree.tag_configure("gratis", background="#ffe6cc")  # oranžna
+    tree.tag_configure("linked", background="#ffe6cc")
+    tree.tag_configure("suggestion", background="#ffe6cc")
     vsb = ttk.Scrollbar(frame, orient="vertical", command=tree.yview)
     tree.configure(yscrollcommand=vsb.set)
     vsb.pack(side="right", fill="y")


### PR DESCRIPTION
## Summary
- use `tag_configure` for all row highlighting in review links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867aec4fa648321925b96b427915112