### PR TITLE
Update autofix tag style

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -456,7 +456,7 @@ def review_links(
     tree.tag_configure("gratis", background="#ffe6cc")  # oranžna
     tree.tag_configure("linked", background="#ffe6cc")
     tree.tag_configure("suggestion", background="#ffe6cc")
-    tree.tag_configure("autofix", background="#eeeeee")
+    tree.tag_configure("autofix", background="#eeeeee", foreground="#333")
     vsb = ttk.Scrollbar(frame, orient="vertical", command=tree.yview)
     tree.configure(yscrollcommand=vsb.set)
     vsb.pack(side="right", fill="y")


### PR DESCRIPTION
## Summary
- adjust autofix tree tag to use dark text color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867cc7638a48321ab2caff627ec1c67