### PR TITLE
Handle MOA 176 discounts

### DIFF
--- a/tests/test_parse_eslog_document_discount.py
+++ b/tests/test_parse_eslog_document_discount.py
@@ -117,3 +117,15 @@ def test_line_and_doc_discount_total_matches_header():
     header_total = extract_header_net(xml_path)
 
     assert (line_total + doc_value).quantize(Decimal("0.01")) == header_total
+
+
+def test_parse_eslog_invoice_handles_moa_176():
+    """Invoices with document discount code 176 should yield a _DOC_ row."""
+    xml_path = Path("tests/PR5690-Slika1.XML")
+    expected_discount = _compute_doc_discount(xml_path)
+
+    df = parse_eslog_invoice(xml_path, {})
+    doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
+
+    assert doc_row["vrednost"] == -expected_discount
+    assert doc_row["rabata_pct"] == Decimal("100.00")

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -44,7 +44,7 @@ NS = {"e": "urn:eslog:2.00"}
 # Common document discount codes.  Extend this list or pass a custom
 # sequence to ``parse_eslog_invoice`` if your suppliers use different
 # identifiers.
-DEFAULT_DOC_DISCOUNT_CODES = ["204", "260", "131", "128"]
+DEFAULT_DOC_DISCOUNT_CODES = ["204", "260", "131", "128", "176"]
 
 # ────────────────────── dobavitelj: koda + ime ──────────────────────
 def get_supplier_info(xml_path: str | Path) -> Tuple[str, str]:


### PR DESCRIPTION
## Summary
- include discount code 176 by default
- ensure invoices containing MOA 176 create a `_DOC_` row
- adapt analyze tests for the new discount code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d66a21248321b03248ea340aeb4f