### PR TITLE
Return discount_total from parse_invoice

### DIFF
--- a/tests/test_allowance_204.py
+++ b/tests/test_allowance_204.py
@@ -1,0 +1,10 @@
+from decimal import Decimal
+from pathlib import Path
+from wsm.parsing.eslog import parse_invoice
+
+
+def test_document_moa_204_discount():
+    xml_path = Path("tests/minimal_doc_discount.xml")
+    df, header_total, discount_total = parse_invoice(xml_path)
+    assert header_total == Decimal("7.00")
+    assert discount_total == Decimal("1.00")

--- a/tests/test_decimal_precision.py
+++ b/tests/test_decimal_precision.py
@@ -20,6 +20,7 @@ def test_parse_invoice_high_precision_values():
         "  </LineItems>"
         "</Invoice>"
     )
-    df, header_total = parse_invoice(xml)
+    df, header_total, discount_total = parse_invoice(xml)
     assert header_total == Decimal("132.00")
+    assert discount_total == Decimal("0")
     assert sum(df["izracunana_vrednost"]) == Decimal("132.00")

--- a/tests/test_missing_unit.py
+++ b/tests/test_missing_unit.py
@@ -12,5 +12,5 @@ def test_missing_unit_defaults_to_kos(tmp_path):
         <Cena>7.2</Cena>
       </Postavka>
     </Racun>""")
-    df, _ = parse_invoice(xml)
+    df, _, _ = parse_invoice(xml)
     assert df.loc[0, "enota"] == "kos"

--- a/tests/test_validate_invoice.py
+++ b/tests/test_validate_invoice.py
@@ -57,8 +57,9 @@ def test_parse_invoice_minimal():
         "</Invoice>"
     )
     # V tem primeru je vsota vrstic (50 + 100) = 150, glava = 150
-    df, header_total = parse_invoice(xml)
+    df, header_total, discount_total = parse_invoice(xml)
     assert header_total == Decimal("150.00")
+    assert discount_total == Decimal("0")
     # Seštevek izračunanih vrstic:
     assert sum(df["izracunana_vrednost"]) == Decimal("150.00")
 
@@ -92,8 +93,9 @@ def test_parse_invoice_with_line_and_doc_discount():
     # Ker vsota vrstic (280.00) + doc discount (50.00) = 330.00, kar se ne ujema z
     # glavo (300.00), parse_invoice vrne `header_total` po odštetem popustu (250.00)
     # in DataFrame z `izracunana_vrednost`.
-    df, header_total = parse_invoice(xml)
+    df, header_total, discount_total = parse_invoice(xml)
     assert header_total == Decimal("250.00")
+    assert discount_total == Decimal("50.00")
     # Skupaj izračunanih vrstic:
     assert sum(df["izracunana_vrednost"]) == Decimal("280.00")
     # Potrdimo, da extract_total_amount vrne 250 (300 - 50):

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -40,15 +40,15 @@ def validate(invoices):
 
 def _validate_file(file_path: Path):
     """
-    Poskrbi za validacijo posamezne datoteke: 
-    - parse_invoice -> DataFrame in glava
+    Poskrbi za validacijo posamezne datoteke:
+    - parse_invoice -> DataFrame, glava, dokumentarni popust
     - validate_invoice -> True/False
     - Izpiše [OK], [NESKLADJE] ali [NAPAKA PARSANJA]
     """
     filename = file_path.name
     try:
-        # parse_invoice vrača točno dva rezultata: (df, header_total)
-        df, header_total = parse_invoice(str(file_path))
+        # parse_invoice vrne tri rezultate: (df, header_total, discount_total)
+        df, header_total, _ = parse_invoice(str(file_path))
     except Exception as e:
         click.echo(f"[NAPAKA PARSANJA] {filename}: {e}")
         return
@@ -215,7 +215,7 @@ def review(invoice, wsm_codes, suppliers, keywords, price_warn_pct, use_pyqt):
 @click.argument("invoice", type=click.Path(exists=True))
 def round_debug(invoice):
     """Prikaži podrobnosti o seštevanju vrstic in zaokroževanju."""
-    df, header_total = parse_invoice(invoice)
+    df, header_total, _ = parse_invoice(invoice)
     col = "izracunana_vrednost" if "izracunana_vrednost" in df.columns else "vrednost"
     line_sum_dec = Decimal(str(df.get(col, pd.Series(dtype=float)).sum()))
     step = detect_round_step(header_total, line_sum_dec)


### PR DESCRIPTION
## Summary
- expose document allowance along with header total in `parse_invoice`
- adapt CLI to work with the new return value
- update tests for the new `(df, header_total, discount_total)` tuple
- test document level MOA 204 discount detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d9417ca483219b7c02133aeacf99