### PR TITLE
Handle more MOA codes in totals

### DIFF
--- a/tests/test_extract_total_amount_moa.py
+++ b/tests/test_extract_total_amount_moa.py
@@ -31,3 +31,23 @@ def test_extract_total_amount_moa_with_discount():
     )
     root = ET.fromstring(xml)
     assert extract_total_amount(root) == Decimal("170.00")
+
+
+def test_extract_total_amount_moa_with_discount_260_500():
+    xml = (
+        "<Invoice>"
+        "  <M_INVOIC>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>200</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>260</D_5025><D_5004>20</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>500</D_5025><D_5004>0.05</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    root = ET.fromstring(xml)
+    assert extract_total_amount(root) == Decimal("179.95")

--- a/tests/test_parse_eslog_document_discount.py
+++ b/tests/test_parse_eslog_document_discount.py
@@ -129,3 +129,30 @@ def test_parse_eslog_invoice_handles_moa_176():
 
     assert doc_row["vrednost"] == -expected_discount
     assert doc_row["rabata_pct"] == Decimal("100.00")
+
+
+def test_parse_eslog_invoice_handles_moa_500(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>0001</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>500</D_5025><D_5004>0.05</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    xml_path = tmp_path / "disc500.xml"
+    xml_path.write_text(xml)
+
+    df = parse_eslog_invoice(xml_path, {})
+    doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
+
+    assert doc_row["vrednost"] == Decimal("-0.05")
+    assert doc_row["rabata_pct"] == Decimal("100.00")

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -44,7 +44,7 @@ NS = {"e": "urn:eslog:2.00"}
 # Common document discount codes.  Extend this list or pass a custom
 # sequence to ``parse_eslog_invoice`` if your suppliers use different
 # identifiers.
-DEFAULT_DOC_DISCOUNT_CODES = ["204", "260", "131", "128", "176"]
+DEFAULT_DOC_DISCOUNT_CODES = ["204", "260", "131", "128", "176", "500"]
 
 # ────────────────────── dobavitelj: koda + ime ──────────────────────
 def get_supplier_info(xml_path: str | Path) -> Tuple[str, str]:

--- a/wsm/parsing/money.py
+++ b/wsm/parsing/money.py
@@ -62,7 +62,7 @@ def extract_total_amount(xml_root: ET.Element) -> Decimal:
     discount = (
         Decimal(discount_str.replace(",", "."))
         if discount_str not in (None, "")
-        else _find_moa_values({"176", "204"})
+        else _find_moa_values({"176", "204", "260", "500"})
     )
 
     return (base - discount).quantize(Decimal("0.01"))


### PR DESCRIPTION
## Summary
- support MOA codes 260 and 500 when reading document discounts
- include code 500 in default discount codes list
- cover new codes in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867db1c48a083219532c9a34852d927