### PR TITLE
Improve supplier folder handling

### DIFF
--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -10,6 +10,7 @@ from wsm.parsing.eslog import parse_invoice, validate_invoice, get_supplier_name
 from wsm.parsing.pdf import parse_pdf, get_supplier_name_from_pdf
 from wsm.parsing.money import detect_round_step, round_to_step
 from wsm.utils import sanitize_folder_name, _load_supplier_map
+from wsm.supplier_store import _norm_vat
 from wsm.analyze import analyze_invoice
 
 @click.group()
@@ -160,18 +161,20 @@ def review(invoice, wsm_codes, suppliers, keywords, price_warn_pct, use_pyqt):
 
     base = Path(suppliers_path)
 
-    # ───── enotna mapa: supplier_code > VAT > fallback ─────
     info = sup_map.get(supplier_code, {})
-    vat_id = info.get("vat") if isinstance(info, dict) else None
+    vat_id = vat or (info.get("vat") if isinstance(info, dict) else None)
+    vat_norm = _norm_vat(vat_id or "")
+    vat_safe = sanitize_folder_name(vat_norm) if vat_norm else None
+    code_safe = sanitize_folder_name(supplier_code)
 
-    cand_paths = [
-        base / sanitize_folder_name(supplier_code),
-        base / sanitize_folder_name(vat_id) if vat_id else None,
-    ]
-    links_dir = next(
-        (p for p in cand_paths if p and p.exists()),
-        cand_paths[1] or cand_paths[0],
-    )
+    cand_paths = []
+    if vat_safe:
+        cand_paths.append(base / vat_safe)
+    if code_safe != vat_safe:
+        cand_paths.append(base / code_safe)
+    cand_paths.append(base / "unknown")
+
+    links_dir = next((p for p in cand_paths if p.exists()), cand_paths[0])
 
     links_dir.mkdir(parents=True, exist_ok=True)
     if (links_dir / f"{supplier_code}_povezane.xlsx").exists():

--- a/wsm/supplier_store.py
+++ b/wsm/supplier_store.py
@@ -12,6 +12,16 @@ from .utils import sanitize_folder_name
 log = logging.getLogger(__name__)
 
 
+def _norm_vat(s: str) -> str:
+    """Return digits-only VAT number without a leading ``SI``."""
+    if not isinstance(s, str):
+        return ""
+    s = s.strip()
+    if s.upper().startswith("SI"):
+        s = s[2:]
+    return "".join(ch for ch in s if ch.isdigit())
+
+
 @lru_cache(maxsize=None)
 def load_suppliers(sup_file: Path | str) -> dict[str, dict]:
     """Load supplier info from per-supplier JSON files or a legacy Excel."""
@@ -30,7 +40,7 @@ def load_suppliers(sup_file: Path | str) -> dict[str, dict]:
             for _, row in df_sup.iterrows():
                 sifra = str(row["sifra"]).strip()
                 ime = str(row["ime"]).strip()
-                vat = str(row.get("vat") or row.get("davcna") or "").strip()
+                vat = _norm_vat(str(row.get("vat") or row.get("davcna") or ""))
                 sup_map[sifra] = {"ime": ime or sifra, "vat": vat}
                 log.debug("Dodan v sup_map: sifra=%s, ime=%s", sifra, ime)
             return sup_map
@@ -52,7 +62,9 @@ def load_suppliers(sup_file: Path | str) -> dict[str, dict]:
                 log.error("Napaka pri branju %s: %s", info_path, e)
         sifra = str(data.get("sifra", "")).strip()
         ime = str(data.get("ime", "")).strip() or folder.name
-        vat = str(data.get("vat") or data.get("davcna") or "").strip()
+        vat = _norm_vat(str(data.get("vat") or data.get("davcna") or ""))
+        if not vat:
+            vat = _norm_vat(folder.name)
         if vat:
             safe_vat = sanitize_folder_name(vat)
             if safe_vat != folder.name:
@@ -73,10 +85,11 @@ def load_suppliers(sup_file: Path | str) -> dict[str, dict]:
                             except OSError:
                                 pass
                     else:
-                        for p in folder.iterdir():
-                            target = new_folder / p.name
-                            if not target.exists():
-                                p.rename(target)
+                        for p in folder.glob("*.xls*"):
+                            dest = new_folder / p.name
+                            if dest.exists():
+                                dest = dest.with_stem(dest.stem + "_old")
+                            shutil.move(str(p), str(dest))
                         try:
                             folder.rmdir()
                         except OSError:
@@ -119,10 +132,15 @@ def load_suppliers(sup_file: Path | str) -> dict[str, dict]:
                 sup_map[code] = {"ime": folder.name, "vat": ""}
                 log.debug("Dodan iz price_history: sifra=%s, ime=%s", code, folder.name)
         if folder.name and folder.name not in {info.get("ime") for info in sup_map.values()}:
-            code = sanitize_folder_name(folder.name)
-            if code not in sup_map:
-                sup_map[code] = {"ime": folder.name, "vat": ""}
-                log.debug("Dodan iz imena mape: sifra=%s, ime=%s", code, folder.name)
+            folder_vat = _norm_vat(folder.name)
+            if folder_vat and folder_vat not in sup_map:
+                sup_map[folder_vat] = {"ime": folder.name, "vat": folder_vat}
+                log.debug("Dodan iz imena mape (VAT): sifra=%s, ime=%s", folder_vat, folder.name)
+            else:
+                code = sanitize_folder_name(folder.name)
+                if code not in sup_map:
+                    sup_map[code] = {"ime": folder.name, "vat": ""}
+                    log.debug("Dodan iz imena mape: sifra=%s, ime=%s", code, folder.name)
     log.info("Najdeni dobavitelji: %s", list(sup_map.keys()))
     return sup_map
 
@@ -148,7 +166,8 @@ def save_supplier(sup_map: dict, sup_file: Path) -> None:
         links_dir = sup_file.parent
 
     for code, info in sup_map.items():
-        folder = links_dir / sanitize_folder_name(info.get("vat") or info["ime"])
+        vat_val = _norm_vat(info.get("vat")) if isinstance(info.get("vat"), str) else ""
+        folder = links_dir / sanitize_folder_name(vat_val or info["ime"])
         folder.mkdir(parents=True, exist_ok=True)
         info_path = folder / "supplier.json"
         try:

--- a/wsm/ui/review/io.py
+++ b/wsm/ui/review/io.py
@@ -82,7 +82,7 @@ def _save_and_close(
                     if target.exists():
                         target = target.with_stem(target.stem + "_old")
                     links_file.rename(target)
-                for p in old_folder.iterdir():
+                for p in old_folder.glob("*.xls*"):
                     dest = new_folder / p.name
                     if dest.exists():
                         dest = dest.with_stem(dest.stem + "_old")
@@ -93,7 +93,7 @@ def _save_and_close(
             log.warning(f"Napaka pri preimenovanju {old_folder} v {new_folder}: {exc}")
             try:
                 new_folder.mkdir(exist_ok=True)
-                for p in old_folder.iterdir():
+                for p in old_folder.glob("*.xls*"):
                     dest = new_folder / p.name
                     if dest.exists():
                         dest = dest.with_stem(dest.stem + "_old")


### PR DESCRIPTION
## Summary
- add `_norm_vat` helper and use it while loading supplier data
- normalize VAT and supplier directory selection logic
- move only Excel files when renaming supplier folders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_6867e98c3c0c83218aefef9ba4a878bd