### PR TITLE
Improve price warning tooltip logic

### DIFF
--- a/tests/test_price_warning.py
+++ b/tests/test_price_warning.py
@@ -18,12 +18,12 @@ def test_apply_price_warning_none():
 
 def test_apply_price_warning_within_threshold():
     tree = DummyTree()
-    tooltip = _apply_price_warning(tree, '1', Decimal('10.4'), Decimal('10'), threshold=Decimal('5'))
+    tooltip = _apply_price_warning(tree, '1', Decimal('10.01'), Decimal('10'), threshold=Decimal('5'))
     assert tree.tags.get('1') == ()
-    assert tooltip is None
+    assert tooltip == ""
 
 def test_apply_price_warning_exceeds_threshold():
     tree = DummyTree()
     tooltip = _apply_price_warning(tree, '1', Decimal('11'), Decimal('10'), threshold=Decimal('5'))
     assert tree.tags.get('1') == ('price_warn',)
-    assert "Prejšnja cena" in tooltip
+    assert tooltip == "±1.00 €"

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -34,25 +34,33 @@ def _apply_price_warning(
     *,
     threshold: Decimal = PRICE_DIFF_THRESHOLD,
 ) -> str | None:
-    """Apply tag if price difference exceeds ``threshold`` percent.
+    """Highlight items where the unit price changed significantly.
 
-    Returns the tooltip text or ``None`` when no warning is needed.
+    When the absolute difference between ``new_price`` and ``prev_price`` does
+    not exceed two cents, the tag is removed and an empty string is returned so
+    that any existing tooltip text is cleared. Otherwise the price difference is
+    shown in euros if it exceeds ``threshold`` percent.
     """
     if prev_price is None or prev_price == 0:
         tree.item(item_id, tags=())
         return None
 
     new_val = Decimal(str(new_price))
+    diff = (new_val - prev_price).quantize(Decimal("0.01"))
+    if abs(diff) <= Decimal("0.02"):
+        tree.item(item_id, tags=())
+        return ""
+
     diff_pct = ((new_val - prev_price) / prev_price * Decimal("100")).quantize(
         Decimal("0.01")
     )
 
     if abs(diff_pct) > threshold:
         tree.item(item_id, tags=("price_warn",))
-        return f"Prejšnja cena: {_fmt(prev_price)} ({_fmt(diff_pct)} %)"
+        return f"±{diff:.2f} €"
 
     tree.item(item_id, tags=())
-    return None
+    return ""
 
 
 


### PR DESCRIPTION
## Summary
- change `_apply_price_warning` to return an empty string for negligible differences
- show absolute euro difference when the change exceeds the rounding threshold
- adapt tests for new behaviour

## Testing
- `pytest tests/test_price_warning.py -q`
- `pytest -q` *(fails: test_cli_review_prefers_vat_from_map, test_duplicate_invoice_warning, test_load_supplier_map_from_folders, test_load_supplier_map_renames_vat_folder, test_supplier_edit_save_saved_to_custom_dir, test_supplier_edit_save_supplier_folder_renamed_on_vat_change, test_unknown_folder_removed_when_vat_exists, test_supplier_move_fallback, test_open_invoice_gui_uses_existing_folder, test_open_invoice_gui_prefers_vat_folder)*

------
https://chatgpt.com/codex/tasks/task_e_686b780c272c8321871597bfd081faa9