### PR TITLE
Add dev optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,13 @@ dependencies = ["pandas", "pdfplumber", "openpyxl", "click"]
 [project.optional-dependencies]
 pyqt = ["PyQt5>=5.15"]
 plot = ["matplotlib", "mplcursors"]
+dev = [
+    "pandas",
+    "openpyxl",
+    "pdfplumber",
+    "PyQt5",
+    "matplotlib",
+]
 
 [project.scripts]
 wsm = "wsm.cli:main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,12 @@
 -r requirements.txt
+
+# Development dependencies
+pandas
+openpyxl
+pdfplumber
+PyQt5
+matplotlib
+
 pytest
 pytest-cov
-matplotlib
 mplcursors


### PR DESCRIPTION
## Summary
- document development dependencies in `pyproject.toml`
- mirror dev extras in `requirements-dev.txt`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lxml')*

------
https://chatgpt.com/codex/tasks/task_e_686b7b7730c08321928887db97d8cb62