### PR TITLE
Support MOA 203 in generic invoice parser

### DIFF
--- a/tests/test_parse_invoice_moa.py
+++ b/tests/test_parse_invoice_moa.py
@@ -1,0 +1,32 @@
+from decimal import Decimal
+from wsm.parsing.eslog import parse_invoice
+
+
+def test_parse_invoice_uses_moa_203_value():
+    xml = (
+        "<Invoice>"
+        "  <InvoiceTotal>130.00</InvoiceTotal>"
+        "  <LineItems>"
+        "    <LineItem>"
+        "      <Quantity>2</Quantity>"
+        "      <S_MOA>"
+        "        <C_C516>"
+        "          <D_5025>203</D_5025>"
+        "          <D_5004>50.00</D_5004>"
+        "        </C_C516>"
+        "      </S_MOA>"
+        "    </LineItem>"
+        "    <LineItem>"
+        "      <PriceNet>40.00</PriceNet>"
+        "      <Quantity>2</Quantity>"
+        "      <DiscountPct>0.00</DiscountPct>"
+        "    </LineItem>"
+        "  </LineItems>"
+        "</Invoice>"
+    )
+    df, header_total, discount_total = parse_invoice(xml)
+    assert header_total == Decimal("130.00")
+    assert discount_total == Decimal("0")
+    assert list(df["izracunana_vrednost"]) == [Decimal("50.00"), Decimal("80.00")]
+    assert list(df["cena_netto"]) == [Decimal("25.0000"), Decimal("40.00")]
+    assert df["rabata_pct"].tolist() == [Decimal("0"), Decimal("0")]


### PR DESCRIPTION
## Summary
- handle MOA 203 amounts when parsing generic `<LineItem>` sections
- add regression test for MOA 203 line values

## Testing
- `pytest -q tests/test_parse_invoice_moa.py tests/test_validate_invoice.py tests/test_decimal_precision.py -q`
- `pytest -q` *(fails: test_cli_env.py::test_cli_review_prefers_vat_from_map, test_duplicate_invoice_warning.py::test_duplicate_invoice_warning, test_load_supplier_map.py::test_load_supplier_map_from_folders, test_load_supplier_map.py::test_load_supplier_map_renames_vat_folder, test_supplier_edit_save.py::test_supplier_edit_saved_to_custom_dir, test_supplier_edit_save.py::test_supplier_folder_renamed_on_vat_change, test_supplier_edit_save.py::test_unknown_folder_removed_when_vat_exists, test_supplier_move_fallback.py::test_supplier_move_fallback, test_use_existing_folder.py::test_open_invoice_gui_uses_existing_folder, test_use_existing_folder.py::test_open_invoice_gui_prefers_vat_folder)*

------
https://chatgpt.com/codex/tasks/task_e_686bb591d7808321a82e8018275c9c07