### PR TITLE
Fix precision loss in review GUI

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -291,7 +291,9 @@ def review_links(
             df["enota_norm"].value_counts().to_dict(),
         )
 
-    df["kolicina_norm"] = df["kolicina_norm"].astype(float)
+    # Keep ``kolicina_norm`` as ``Decimal`` to avoid losing precision in
+    # subsequent calculations and when saving the file. Previously the column
+    # was cast to ``float`` which could introduce rounding errors.
     df["warning"] = pd.NA
     log.debug(f"df po normalizaciji: {df.head().to_dict()}")
 


### PR DESCRIPTION
## Summary
- stop casting `kolicina_norm` to `float` in the review GUI

## Testing
- `pytest -q` *(fails: test_cli_env.py::test_cli_review_prefers_vat_from_map and others)*

------
https://chatgpt.com/codex/tasks/task_e_686bca70b6008321a7896a54b845ce1d