### PR TITLE
Handle decimal thousand separators

### DIFF
--- a/tests/test_decimal_thousands.py
+++ b/tests/test_decimal_thousands.py
@@ -1,0 +1,18 @@
+from decimal import Decimal
+import xml.etree.ElementTree as ET
+
+from wsm.parsing.eslog import _decimal
+
+
+def _make_el(text: str) -> ET.Element:
+    return ET.fromstring(f"<x>{text}</x>")
+
+
+def test_decimal_handles_dot_thousands():
+    el = _make_el("1.234,56")
+    assert _decimal(el) == Decimal("1234.56")
+
+
+def test_decimal_handles_space_thousands():
+    el = _make_el("1 234,56")
+    assert _decimal(el) == Decimal("1234.56")

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -33,8 +33,15 @@ def _text(el: ET.Element | None) -> str:
 
 def _decimal(el: ET.Element | None) -> Decimal:
     try:
-        txt = _text(el).replace(",", ".")
-        return Decimal(txt) if txt else Decimal("0")
+        txt = _text(el)
+        if not txt:
+            return Decimal("0")
+
+        txt = txt.replace("\xa0", "").replace(" ", "")
+        if "," in txt:
+            txt = txt.replace(".", "").replace(",", ".")
+
+        return Decimal(txt)
     except Exception:
         return Decimal("0")
 


### PR DESCRIPTION
## Summary
- support dot and space thousands separators in `_decimal`
- add regression tests for thousand separator parsing

## Testing
- `pytest tests/test_decimal_thousands.py -q`
- `pytest -q` *(fails: test_cli_env::test_cli_review_prefers_vat_from_map, ...)*

------
https://chatgpt.com/codex/tasks/task_e_686ccf75cad0832193268abba8e9e702