### PR TITLE
Add fallback to MOA 79 for header net extraction

### DIFF
--- a/tests/test_extract_header_net.py
+++ b/tests/test_extract_header_net.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+from pathlib import Path
+
+from wsm.parsing.eslog import extract_header_net
+
+
+def test_extract_header_net_falls_back_to_moa_79(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>45.67</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    xml_path = tmp_path / "moa79.xml"
+    xml_path.write_text(xml)
+    assert extract_header_net(xml_path) == Decimal("45.67")
+

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -135,13 +135,14 @@ def get_supplier_info_vat(xml_path: str | Path) -> Tuple[str, str, str | None]:
 
 # ─────────────────────── vsota iz glave ───────────────────────
 def extract_header_net(xml_path: Path | str) -> Decimal:
-    """Vrne znesek iz MOA 389 (neto brez DDV)."""
+    """Vrne znesek iz MOA 389 (neto brez DDV) oz. po potrebi iz MOA 79."""
     try:
         tree = ET.parse(xml_path)
         root = tree.getroot()
-        for moa in root.findall('.//e:G_SG50/e:S_MOA', NS):
-            if _text(moa.find('./e:C_C516/e:D_5025', NS)) == '389':
-                return _decimal(moa.find('./e:C_C516/e:D_5004', NS))
+        for code in ("389", "79"):
+            for moa in root.findall('.//e:G_SG50/e:S_MOA', NS):
+                if _text(moa.find('./e:C_C516/e:D_5025', NS)) == code:
+                    return _decimal(moa.find('./e:C_C516/e:D_5004', NS))
     except Exception:
         pass
     return Decimal('0')


### PR DESCRIPTION
## Summary
- improve `extract_header_net` to try MOA 389 first and then MOA 79
- add regression test covering invoices with only MOA 79

## Testing
- `pytest tests/test_extract_header_net.py -q`
- `pytest -q` *(fails: test_cli_env.py::test_cli_review_prefers_vat_from_map etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686cd0abe5648321b4d477fdada34ffc