### PR TITLE
Add test for handling line discounts with document discount

### DIFF
--- a/tests/test_line_discounts_not_doubled.py
+++ b/tests/test_line_discounts_not_doubled.py
@@ -1,0 +1,53 @@
+from decimal import Decimal
+from pathlib import Path
+
+from wsm import analyze
+
+
+def test_line_discounts_not_doubled(tmp_path: Path) -> None:
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>0001</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item A</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>8</D_5004></C_C516></S_MOA>"
+        "      <G_SG39>"
+        "        <S_ALC><D_5463>A</D_5463></S_ALC>"
+        "        <G_SG42>"
+        "          <S_MOA><C_C516><D_5025>204</D_5025><D_5004>2</D_5004></C_C516></S_MOA>"
+        "        </G_SG42>"
+        "      </G_SG39>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>0002</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item B</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>5</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>5</D_5004></C_C516></S_MOA>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>12</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>204</D_5025><D_5004>1</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    xml_path = tmp_path / "invoice.xml"
+    xml_path.write_text(xml)
+
+    df, header_total, ok = analyze.analyze_invoice(xml_path)
+
+    doc_rows = df[df["sifra_dobavitelja"] == "_DOC_"]
+    assert not doc_rows.empty
+    doc_value = doc_rows["vrednost"].sum()
+
+    line_total = df[df["sifra_dobavitelja"] != "_DOC_"]["vrednost"].sum()
+
+    assert ok
+    assert doc_value == Decimal("-1")
+    assert (line_total + doc_value).quantize(Decimal("0.01")) == header_total


### PR DESCRIPTION
## Summary
- add `test_line_discounts_not_doubled` to ensure invoice totals are correct when line MOA 203 already contains discount and document-level discount exists

## Testing
- `pytest tests/test_line_discounts_not_doubled.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd45f6f948321ab0afd6a57a9438f