### PR TITLE
Add header gross extraction and GUI totals

### DIFF
--- a/tests/test_extract_header_gross.py
+++ b/tests/test_extract_header_gross.py
@@ -1,0 +1,19 @@
+from decimal import Decimal
+from pathlib import Path
+from wsm.parsing.eslog import extract_header_gross
+
+
+def test_extract_header_gross_reads_moa(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>12.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    p = tmp_path / "g.xml"
+    p.write_text(xml)
+    assert extract_header_gross(p) == Decimal("12.20")
+

--- a/tests/test_gui_header_totals.py
+++ b/tests/test_gui_header_totals.py
@@ -1,0 +1,94 @@
+from decimal import Decimal
+from pathlib import Path
+import inspect
+import textwrap
+
+import pandas as pd
+
+import wsm.ui.review.gui as rl
+from wsm.parsing.eslog import (
+    parse_eslog_invoice,
+    extract_header_net,
+    extract_total_tax,
+    extract_header_gross,
+)
+from wsm.parsing.money import detect_round_step
+
+
+class DummyVar:
+    def __init__(self):
+        self.val = ""
+    def set(self, v):
+        self.val = v
+    def get(self):
+        return self.val
+
+
+def _extract_refresh_func():
+    src = inspect.getsource(rl.review_links).splitlines()
+    start = next(i for i, l in enumerate(src) if "def _refresh_header_totals" in l)
+    end = start + 1
+    while end < len(src) and src[end].startswith(" "):
+        end += 1
+    snippet = textwrap.dedent("\n".join(src[start:end]))
+    return snippet
+
+
+def test_header_totals_display_and_no_autofix(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>0001</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "      <G_SG34><S_TAX><C_C243><D_5278>22</D_5278></C_C243></S_TAX></G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>388</D_5025><D_5004>12.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>12.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_TAX><C_C243><D_5278>22</D_5278></C_C243></S_TAX>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>2.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    xml_path = tmp_path / "inv.xml"
+    xml_path.write_text(xml)
+
+    df = parse_eslog_invoice(xml_path, {})
+    header = {
+        "net": extract_header_net(xml_path),
+        "vat": extract_total_tax(xml_path),
+        "gross": extract_header_gross(xml_path),
+    }
+    assert df[df["sifra_dobavitelja"] == "_DOC_"].empty
+    total_calc = df[df["sifra_dobavitelja"] != "_DOC_"]["vrednost"].sum()
+    step = detect_round_step(header["net"], total_calc)
+    diff = header["net"] - total_calc
+    assert not (abs(diff) <= step and diff != 0)
+
+    snippet = _extract_refresh_func()
+    ns = {
+        "_fmt": rl._fmt,
+        "Decimal": Decimal,
+        "var_net": DummyVar(),
+        "var_vat": DummyVar(),
+        "var_total": DummyVar(),
+        "header_totals": header,
+    }
+    exec(snippet, ns)
+    ns["_refresh_header_totals"]()
+    assert ns["var_net"].get() == "10"
+    assert ns["var_vat"].get() == "2.2"
+    assert ns["var_total"].get() == "12.2"
+

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -167,14 +167,17 @@ def review(invoice, wsm_codes, suppliers, keywords, price_warn_pct, use_pyqt):
     vat_safe = sanitize_folder_name(vat_norm) if vat_norm else None
     code_safe = sanitize_folder_name(supplier_code)
 
-    cand_paths = []
-    if vat_safe:
-        cand_paths.append(base / vat_safe)
-    if code_safe != vat_safe:
-        cand_paths.append(base / code_safe)
-    cand_paths.append(base / "unknown")
+    vat_path = base / vat_safe if vat_safe else None
+    code_path = base / code_safe
 
-    links_dir = next((p for p in cand_paths if p.exists()), cand_paths[0])
+    if map_vat and vat_path:
+        links_dir = vat_path
+    elif code_path.exists():
+        links_dir = code_path
+    elif vat_path and vat_path.exists():
+        links_dir = vat_path
+    else:
+        links_dir = code_path
 
     links_dir.mkdir(parents=True, exist_ok=True)
     if (links_dir / f"{supplier_code}_povezane.xlsx").exists():

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -147,6 +147,20 @@ def extract_header_net(xml_path: Path | str) -> Decimal:
         pass
     return Decimal('0')
 
+
+def extract_header_gross(xml_path: Path | str) -> Decimal:
+    """Return gross amount from MOA 9 or 388."""
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+        for code in ("9", "388"):
+            for moa in root.findall('.//e:G_SG50/e:S_MOA', NS):
+                if _text(moa.find('./e:C_C516/e:D_5025', NS)) == code:
+                    return _decimal(moa.find('./e:C_C516/e:D_5004', NS))
+    except Exception:
+        pass
+    return Decimal('0')
+
 # ───────────────────── datum opravljene storitve ─────────────────────
 def extract_service_date(xml_path: Path | str) -> str | None:
     """Vrne datum opravljene storitve (DTM 35) ali datum računa (DTM 137)."""

--- a/wsm/supplier_store.py
+++ b/wsm/supplier_store.py
@@ -13,13 +13,17 @@ log = logging.getLogger(__name__)
 
 
 def _norm_vat(s: str) -> str:
-    """Return digits-only VAT number without a leading ``SI``."""
+    """Return VAT number with ``SI`` prefix and digits only."""
     if not isinstance(s, str):
         return ""
     s = s.strip()
+    if not s:
+        return ""
     if s.upper().startswith("SI"):
-        s = s[2:]
-    return "".join(ch for ch in s if ch.isdigit())
+        digits = "".join(ch for ch in s[2:] if ch.isdigit())
+    else:
+        digits = "".join(ch for ch in s if ch.isdigit())
+    return f"SI{digits}" if digits else ""
 
 
 @lru_cache(maxsize=None)

--- a/wsm/ui/review/io.py
+++ b/wsm/ui/review/io.py
@@ -82,7 +82,7 @@ def _save_and_close(
                     if target.exists():
                         target = target.with_stem(target.stem + "_old")
                     links_file.rename(target)
-                for p in old_folder.glob("*.xls*"):
+                for p in old_folder.iterdir():
                     dest = new_folder / p.name
                     if dest.exists():
                         dest = dest.with_stem(dest.stem + "_old")
@@ -93,7 +93,7 @@ def _save_and_close(
             log.warning(f"Napaka pri preimenovanju {old_folder} v {new_folder}: {exc}")
             try:
                 new_folder.mkdir(exist_ok=True)
-                for p in old_folder.glob("*.xls*"):
+                for p in old_folder.iterdir():
                     dest = new_folder / p.name
                     if dest.exists():
                         dest = dest.with_stem(dest.stem + "_old")


### PR DESCRIPTION
## Summary
- add `extract_header_gross` for MOA 9/388 values
- show invoice header totals in GUI
- parse header totals when loading invoice
- import new helper in GUI
- keep VAT normalization consistent
- move all files when renaming supplier folders
- add regression tests for header totals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce73477588321b0be96918df72904