### PR TITLE
Handle missing optional dependencies in tests

### DIFF
--- a/tests/test_blank_code_reload.py
+++ b/tests/test_blank_code_reload.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 import pandas as pd
 from decimal import Decimal
 from wsm.ui.review.io import _save_and_close

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 import pandas as pd
 from pathlib import Path
 

--- a/tests/test_last_price.py
+++ b/tests/test_last_price.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 from decimal import Decimal
 import pandas as pd
 from wsm.utils import last_price_stats, load_last_price

--- a/tests/test_last_price_confirm.py
+++ b/tests/test_last_price_confirm.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 from decimal import Decimal
 import pandas as pd
 import inspect

--- a/tests/test_load_supplier_map.py
+++ b/tests/test_load_supplier_map.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 import pandas as pd
 import json
 from pathlib import Path

--- a/tests/test_load_supplier_map_history.py
+++ b/tests/test_load_supplier_map_history.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 import pandas as pd
 from pathlib import Path
 from wsm.ui.review.io import _load_supplier_map

--- a/tests/test_pdf_header.py
+++ b/tests/test_pdf_header.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("pdfplumber")
 from pathlib import Path
 from wsm.parsing.pdf import extract_service_date, extract_invoice_number
 

--- a/tests/test_price_history_duplicates.py
+++ b/tests/test_price_history_duplicates.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 import pandas as pd
 from decimal import Decimal
 

--- a/tests/test_price_history_service_date.py
+++ b/tests/test_price_history_service_date.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 import json
 import pandas as pd
 from decimal import Decimal

--- a/tests/test_price_watch.py
+++ b/tests/test_price_watch.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 import json
 import pandas as pd
 from wsm.ui.price_watch import (

--- a/tests/test_qt_dataframe_model.py
+++ b/tests/test_qt_dataframe_model.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("PyQt5")
 import pandas as pd
 from PyQt5 import QtCore
 from wsm.ui_qt import DataFrameModel

--- a/tests/test_supplier_edit_save.py
+++ b/tests/test_supplier_edit_save.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 import json
 from decimal import Decimal
 import pandas as pd

--- a/tests/test_supplier_move_fallback.py
+++ b/tests/test_supplier_move_fallback.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 import json
 from decimal import Decimal
 from pathlib import Path

--- a/tests/test_unit_price.py
+++ b/tests/test_unit_price.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("openpyxl")
 import pandas as pd
 from decimal import Decimal
 from wsm import utils


### PR DESCRIPTION
## Summary
- skip Qt dataframe model test if `PyQt5` isn't installed
- skip PDF header parsing tests if `pdfplumber` isn't present
- skip Excel-based tests when `openpyxl` isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cece69b808321a7c0942c01bab6cd