### PR TITLE
Ensure VAT directory is used when available

### DIFF
--- a/tests/test_blank_code_reload.py
+++ b/tests/test_blank_code_reload.py
@@ -32,7 +32,8 @@ def test_blank_supplier_code_retains_mapping(tmp_path, monkeypatch):
     links_file = links_dir / "SUP_Test_povezane.xlsx"
     monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
     _save_and_close(df, manual_old, wsm_df, links_file, DummyRoot(), "Test", "SUP", {}, base_dir)
-    manual_new = pd.read_excel(links_file, dtype=str)
+    new_file = base_dir / "SUP" / "SUP_povezane.xlsx"
+    manual_new = pd.read_excel(new_file, dtype=str)
     manual_new["sifra_dobavitelja"] = manual_new["sifra_dobavitelja"].fillna("").astype(str)
     assert manual_new["sifra_dobavitelja"].iloc[0] == ""
     manual_new["naziv_ckey"] = manual_new["naziv"].map(_clean)

--- a/tests/test_use_existing_folder.py
+++ b/tests/test_use_existing_folder.py
@@ -84,3 +84,43 @@ def test_open_invoice_gui_prefers_vat_folder(monkeypatch, tmp_path):
     expected = expected_dir / "SUP_SUP_povezane.xlsx"
     assert captured["links"] == expected
     assert expected_dir.exists()
+
+
+def test_open_invoice_gui_uses_vat_from_map(monkeypatch, tmp_path):
+    invoice = tmp_path / "inv.xml"
+    invoice.write_text("<xml/>")
+
+    suppliers_dir = tmp_path / "links"
+
+    captured = {}
+
+    def fake_analyze(inv, suppliers_file):
+        captured["sup"] = Path(suppliers_file)
+        df = pd.DataFrame(
+            {
+                "sifra_dobavitelja": ["SUP"],
+                "naziv": ["Item"],
+                "kolicina": [Decimal("1")],
+                "enota": ["kos"],
+                "vrednost": [Decimal("1")],
+                "rabata": [Decimal("0")],
+            }
+        )
+        return df, Decimal("1"), True
+
+    monkeypatch.setattr("wsm.ui.common.analyze_invoice", fake_analyze)
+    monkeypatch.setattr("wsm.ui.common.pd.read_excel", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(
+        "wsm.ui.common.review_links",
+        lambda df, wdf, lf, total, ip: captured.update({"links": lf}),
+    )
+    monkeypatch.setattr("wsm.utils.povezi_z_wsm", lambda df, *a, **k: df)
+    monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Unknown")
+    monkeypatch.setattr("wsm.ui.common._load_supplier_map", lambda p: {"SUP": {"ime": "Unknown", "vat": "SI222"}})
+
+    open_invoice_gui(invoice_path=invoice, suppliers=suppliers_dir)
+
+    expected_dir = suppliers_dir / "SI222"
+    expected = expected_dir / "SUP_SI222_povezane.xlsx"
+    assert captured["links"] == expected
+    assert expected_dir.exists()

--- a/wsm/supplier_store.py
+++ b/wsm/supplier_store.py
@@ -26,6 +26,20 @@ def _norm_vat(s: str) -> str:
     return f"SI{digits}" if digits else ""
 
 
+def choose_supplier_key(vat: str | None, code: str | None = None) -> str:
+    """Return the VAT number when available, otherwise ``code``.
+
+    The VAT number is first normalized with :func:`_norm_vat`.  If the result
+    is non-empty it is returned; otherwise the ``code`` is used as-is.  When
+    ``code`` is ``None`` an empty string is returned.
+    """
+
+    vat_norm = _norm_vat(vat or "")
+    if vat_norm:
+        return vat_norm
+    return str(code or "")
+
+
 @lru_cache(maxsize=None)
 def load_suppliers(sup_file: Path | str) -> dict[str, dict]:
     """Load supplier info from per-supplier JSON files or a legacy Excel."""

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -15,7 +15,7 @@ from wsm.analyze import analyze_invoice
 from wsm.parsing.pdf import parse_pdf, get_supplier_name_from_pdf
 from wsm.parsing.eslog import get_supplier_name
 from wsm.utils import sanitize_folder_name, _load_supplier_map
-from wsm.supplier_store import _norm_vat
+from wsm.supplier_store import _norm_vat, choose_supplier_key
 from wsm.ui.review.gui import review_links
 
 
@@ -90,21 +90,10 @@ def open_invoice_gui(
 
     info = sup_map.get(supplier_code, {})
     vat_id = vat or (info.get("vat") if isinstance(info, dict) else None)
-    vat_norm = _norm_vat(vat_id or "")
-    vat_safe = sanitize_folder_name(vat_norm) if vat_norm else None
-    code_safe = sanitize_folder_name(supplier_code)
 
-    vat_path = Path(suppliers) / vat_safe if vat_safe else None
-    code_path = Path(suppliers) / code_safe
-
-    if map_vat and vat_path:
-        links_dir = vat_path
-    elif code_path.exists():
-        links_dir = code_path
-    elif vat_path and vat_path.exists():
-        links_dir = vat_path
-    else:
-        links_dir = code_path
+    key = choose_supplier_key(vat_id, supplier_code)
+    key_safe = sanitize_folder_name(key)
+    links_dir = Path(suppliers) / key_safe
 
     links_dir.mkdir(parents=True, exist_ok=True)
 

--- a/wsm/ui/review/io.py
+++ b/wsm/ui/review/io.py
@@ -65,9 +65,11 @@ def _save_and_close(
         new_info["ime"] = supplier_name
         changed = True
     from wsm.utils import sanitize_folder_name
+    from wsm.supplier_store import choose_supplier_key
 
     old_safe = links_file.parent.name
-    new_safe = sanitize_folder_name(vat or supplier_name)
+    new_key = choose_supplier_key(vat, supplier_code)
+    new_safe = sanitize_folder_name(new_key)
     if new_safe != old_safe:
         old_folder = links_file.parent
         new_folder = Path(sup_file) / new_safe


### PR DESCRIPTION
## Summary
- introduce `choose_supplier_key` helper to prefer VAT when choosing supplier directories
- use the new helper in `open_invoice_gui` and `_save_and_close`
- update tests for new behaviour and add coverage for VAT-based directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cee9e38488321a7f1845c876fe5ba