### PR TITLE
Improve document discount summation

### DIFF
--- a/tests/test_parse_eslog_document_discount.py
+++ b/tests/test_parse_eslog_document_discount.py
@@ -14,7 +14,7 @@ def _compute_doc_discount(xml_path: Path) -> Decimal:
     NS = {"e": "urn:eslog:2.00"}
     root = ET.parse(xml_path).getroot()
     discounts = {code: Decimal("0") for code in DEFAULT_DOC_DISCOUNT_CODES}
-    seen_values = set()
+    seen_segments = set()
 
     for seg in root.findall(".//e:G_SG50", NS) + root.findall(".//e:G_SG20", NS):
         for moa in seg.findall(".//e:S_MOA", NS):
@@ -26,9 +26,10 @@ def _compute_doc_discount(xml_path: Path) -> Decimal:
                 val_el = moa.find("./e:C_C516/e:D_5004", NS)
                 amt = Decimal((val_el.text or "0").replace(",", "."))
                 amt = amt.quantize(Decimal("0.01"), ROUND_HALF_UP)
-                if amt in seen_values:
+                key = (code, amt, id(moa))
+                if key in seen_segments:
                     continue
-                seen_values.add(amt)
+                seen_segments.add(key)
                 discounts[code] += amt
 
     # Sum all matching discount codes
@@ -155,4 +156,35 @@ def test_parse_eslog_invoice_handles_moa_500(tmp_path):
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
     assert doc_row["vrednost"] == Decimal("-0.05")
+    assert doc_row["rabata_pct"] == Decimal("100.00")
+
+
+def test_parse_eslog_invoice_sums_duplicate_values(tmp_path):
+    """Discounts with the same code and amount should all be summed."""
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>0001</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>204</D_5025><D_5004>1.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>204</D_5025><D_5004>1.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    xml_path = tmp_path / "disc_dupes.xml"
+    xml_path.write_text(xml)
+
+    df = parse_eslog_invoice(xml_path, {})
+    doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
+
+    assert doc_row["vrednost"] == Decimal("-2.00")
     assert doc_row["rabata_pct"] == Decimal("100.00")


### PR DESCRIPTION
## Summary
- refine duplicate document discount detection
- add regression test for repeated discounts with the same amount

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf0a97d8483219f6bc0eb799c6873