### PR TITLE
Handle supplier folders without VAT

### DIFF
--- a/tests/test_blank_code_reload.py
+++ b/tests/test_blank_code_reload.py
@@ -31,8 +31,9 @@ def test_blank_supplier_code_retains_mapping(tmp_path, monkeypatch):
     links_dir.mkdir(parents=True)
     links_file = links_dir / "SUP_Test_povezane.xlsx"
     monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
+    monkeypatch.setattr("tkinter.messagebox.showwarning", lambda *a, **k: None)
     _save_and_close(df, manual_old, wsm_df, links_file, DummyRoot(), "Test", "SUP", {}, base_dir)
-    new_file = base_dir / "SUP" / "SUP_povezane.xlsx"
+    new_file = links_file
     manual_new = pd.read_excel(new_file, dtype=str)
     manual_new["sifra_dobavitelja"] = manual_new["sifra_dobavitelja"].fillna("").astype(str)
     assert manual_new["sifra_dobavitelja"].iloc[0] == ""

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -139,10 +139,11 @@ def test_open_invoice_gui_uses_env_vars(monkeypatch, tmp_path):
     monkeypatch.setattr("wsm.utils.povezi_z_wsm", fake_povezi)
     monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Test Supplier")
     monkeypatch.setattr("wsm.ui.common._load_supplier_map", lambda p: {})
+    monkeypatch.setattr("tkinter.messagebox.showwarning", lambda *a, **k: None)
 
     open_invoice_gui(invoice_path=invoice)
 
-    expected = suppliers_dir / "SUP" / "SUP_SUP_povezane.xlsx"
+    expected = suppliers_dir / "SUP_links_env_povezane.xlsx"
     assert captured["sup"] == suppliers_dir
     assert captured["codes"] == codes_file
     assert captured["links"] == expected

--- a/tests/test_use_existing_folder.py
+++ b/tests/test_use_existing_folder.py
@@ -36,10 +36,11 @@ def test_open_invoice_gui_uses_existing_folder(monkeypatch, tmp_path):
     monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Unknown")
     monkeypatch.setattr("wsm.parsing.eslog.get_supplier_info_vat", lambda p: ("", "", "SI111"))
     monkeypatch.setattr("wsm.ui.common._load_supplier_map", lambda p: {"SUP": {"ime": "unknown", "vat": ""}})
+    monkeypatch.setattr("tkinter.messagebox.showwarning", lambda *a, **k: None)
 
     open_invoice_gui(invoice_path=invoice, suppliers=suppliers_dir)
 
-    expected = suppliers_dir / "SUP" / "SUP_SUP_povezane.xlsx"
+    expected = suppliers_dir / "SUP_links_povezane.xlsx"
     assert captured["links"] == expected
 
 
@@ -77,11 +78,12 @@ def test_open_invoice_gui_prefers_vat_folder(monkeypatch, tmp_path):
         "wsm.parsing.eslog.get_supplier_info_vat", lambda p: ("", "", "SI111")
     )
     monkeypatch.setattr("wsm.ui.common._load_supplier_map", lambda p: {})
+    monkeypatch.setattr("tkinter.messagebox.showwarning", lambda *a, **k: None)
 
     open_invoice_gui(invoice_path=invoice, suppliers=suppliers_dir)
 
-    expected_dir = suppliers_dir / "SUP"
-    expected = expected_dir / "SUP_SUP_povezane.xlsx"
+    expected_dir = suppliers_dir
+    expected = expected_dir / "SUP_links_povezane.xlsx"
     assert captured["links"] == expected
     assert expected_dir.exists()
 

--- a/wsm/supplier_store.py
+++ b/wsm/supplier_store.py
@@ -27,17 +27,17 @@ def _norm_vat(s: str) -> str:
 
 
 def choose_supplier_key(vat: str | None, code: str | None = None) -> str:
-    """Return the VAT number when available, otherwise ``code``.
+    """Return the normalized VAT number or ``""`` when unavailable.
 
-    The VAT number is first normalized with :func:`_norm_vat`.  If the result
-    is non-empty it is returned; otherwise the ``code`` is used as-is.  When
-    ``code`` is ``None`` an empty string is returned.
+    The ``code`` parameter is ignored.  The VAT number is normalized with
+    :func:`_norm_vat` and returned if non-empty.  Otherwise an empty string is
+    returned.
     """
 
     vat_norm = _norm_vat(vat or "")
     if vat_norm:
         return vat_norm
-    return str(code or "")
+    return ""
 
 
 @lru_cache(maxsize=None)

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -92,10 +92,19 @@ def open_invoice_gui(
     vat_id = vat or (info.get("vat") if isinstance(info, dict) else None)
 
     key = choose_supplier_key(vat_id, supplier_code)
-    key_safe = sanitize_folder_name(key)
-    links_dir = Path(suppliers) / key_safe
+    base_dir = Path(suppliers)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    if not key:
+        messagebox.showwarning(
+            "Opozorilo",
+            "Davčna številka dobavitelja ni znana; mapa ne bo ustvarjena.",
+        )
+        links_dir = base_dir
+    else:
+        key_safe = sanitize_folder_name(key)
+        links_dir = base_dir / key_safe
+        links_dir.mkdir(parents=True, exist_ok=True)
 
-    links_dir.mkdir(parents=True, exist_ok=True)
 
     if (links_dir / f"{supplier_code}_povezane.xlsx").exists():
         links_file = links_dir / f"{supplier_code}_povezane.xlsx"


### PR DESCRIPTION
## Summary
- `choose_supplier_key` now ignores the supplier code if VAT is missing and returns an empty string
- `open_invoice_gui` warns when VAT is absent and skips folder creation
- `_save_and_close` shows a warning and avoids renaming folders when VAT is unknown
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d0cec37a083218862a647db7bd42f