### PR TITLE
Handle VAT across seller groups

### DIFF
--- a/tests/SE_after_SU.XML
+++ b/tests/SE_after_SU.XML
@@ -1,0 +1,22 @@
+<Invoice xmlns='urn:eslog:2.00'>
+  <M_INVOIC>
+    <G_SG2>
+      <S_NAD>
+        <D_3035>SU</D_3035>
+      </S_NAD>
+    </G_SG2>
+    <G_SG2>
+      <S_NAD>
+        <D_3035>SE</D_3035>
+      </S_NAD>
+      <G_SG3>
+        <S_RFF>
+          <C_C506>
+            <D_1153>VA</D_1153>
+            <D_1154>SI11111111</D_1154>
+          </C_C506>
+        </S_RFF>
+      </G_SG3>
+    </G_SG2>
+  </M_INVOIC>
+</Invoice>

--- a/tests/test_supplier_vat.py
+++ b/tests/test_supplier_vat.py
@@ -6,3 +6,9 @@ def test_get_supplier_info_vat_prefers_seller():
     xml = Path("tests/PR5918-Slika2.XML")
     _, _, vat = get_supplier_info_vat(xml)
     assert vat == "SI29746507"
+
+
+def test_get_supplier_info_vat_uses_se_when_su_missing():
+    xml = Path("tests/SE_after_SU.XML")
+    _, _, vat = get_supplier_info_vat(xml)
+    assert vat == "SI11111111"

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -118,31 +118,34 @@ def get_supplier_info_vat(xml_path: str | Path) -> Tuple[str, str, str | None]:
         tree = ET.parse(xml_path)
         root = tree.getroot()
 
-        # Locate the seller party (SU or SE) and search only within that group
-        seller_group = None
-        for sg2 in root.findall(".//e:G_SG2", NS):
-            nad = sg2.find("./e:S_NAD", NS)
-            if _text(nad.find("./e:D_3035", NS)) in {"SU", "SE"}:
-                seller_group = sg2
+        # Collect seller-related groups (SU or SE) in document order
+        groups: List[ET.Element] = [
+            sg2
+            for sg2 in root.findall(".//e:G_SG2", NS)
+            if _text(sg2.find("./e:S_NAD/e:D_3035", NS)) in {"SU", "SE"}
+        ]
+        if not groups:
+            groups = [root]
+
+        for grp in groups:
+            for rff in grp.findall(".//e:S_RFF", NS):
+                rff_code = _text(rff.find("./e:C_C506/e:D_1153", NS))
+                if rff_code in {"VA", "AHP", "0199"}:
+                    vat_val = _text(rff.find("./e:C_C506/e:D_1154", NS))
+                    if vat_val:
+                        vat = vat_val
+                        break
+            if vat:
                 break
-
-        search_root = seller_group if seller_group is not None else root
-
-        for rff in search_root.findall(".//e:S_RFF", NS):
-            rff_code = _text(rff.find("./e:C_C506/e:D_1153", NS))
-            if rff_code in {"VA", "AHP", "0199"}:
-                vat_val = _text(rff.find("./e:C_C506/e:D_1154", NS))
-                if vat_val:
-                    vat = vat_val
-                    break
-        if not vat:
-            for com in search_root.findall(".//e:S_COM", NS):
+            for com in grp.findall(".//e:S_COM", NS):
                 com_code = _text(com.find("./e:C_C076/e:D_3155", NS))
                 if com_code == "9949":
                     vat_val = _text(com.find("./e:C_C076/e:D_3148", NS))
                     if vat_val:
                         vat = vat_val
                         break
+            if vat:
+                break
     except Exception:
         vat = None
     return code, name, vat


### PR DESCRIPTION
## Summary
- search all seller groups for VAT numbers
- add fixture with seller VAT in later group
- test fallback to `SE` seller group for VAT extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1b59b6b8832186daf3190d1e0135