### PR TITLE
Improve VAT extraction

### DIFF
--- a/tests/test_supplier_vat.py
+++ b/tests/test_supplier_vat.py
@@ -6,3 +6,15 @@ def test_get_supplier_info_vat_prefers_seller():
     xml = Path("tests/PR5918-Slika2.XML")
     _, _, vat = get_supplier_info_vat(xml)
     assert vat == "SI29746507"
+
+
+def test_get_supplier_info_vat_prefers_va_over_ahp():
+    xml = Path("tests/vat_ahp_before_va.xml")
+    _, _, vat = get_supplier_info_vat(xml)
+    assert vat == "SI22222222"
+
+
+def test_get_supplier_info_vat_with_gln():
+    xml = Path("tests/vat_with_gln.xml")
+    _, _, vat = get_supplier_info_vat(xml)
+    assert vat == "SI33333333"

--- a/tests/vat_ahp_before_va.xml
+++ b/tests/vat_ahp_before_va.xml
@@ -1,0 +1,16 @@
+<Invoice xmlns="urn:eslog:2.00">
+  <M_INVOIC>
+    <G_SG2>
+      <S_NAD>
+        <D_3035>SE</D_3035>
+        <C_C080><D_3036>Seller A</D_3036></C_C080>
+      </S_NAD>
+      <G_SG3>
+        <S_RFF><C_C506><D_1153>AHP</D_1153><D_1154>SI11111111</D_1154></C_C506></S_RFF>
+      </G_SG3>
+      <G_SG3>
+        <S_RFF><C_C506><D_1153>VA</D_1153><D_1154>si 22222222</D_1154></C_C506></S_RFF>
+      </G_SG3>
+    </G_SG2>
+  </M_INVOIC>
+</Invoice>

--- a/tests/vat_with_gln.xml
+++ b/tests/vat_with_gln.xml
@@ -1,0 +1,14 @@
+<Invoice xmlns="urn:eslog:2.00">
+  <M_INVOIC>
+    <G_SG2>
+      <S_NAD>
+        <S_GLN><D_7402>1234567890123</D_7402></S_GLN>
+        <D_3035>SE</D_3035>
+        <C_C080><D_3036>Seller B</D_3036></C_C080>
+      </S_NAD>
+      <G_SG3>
+        <S_RFF><C_C506><D_1153>VA</D_1153><D_1154>SI33333333</D_1154></C_C506></S_RFF>
+      </G_SG3>
+    </G_SG2>
+  </M_INVOIC>
+</Invoice>


### PR DESCRIPTION
## Summary
- enhance VAT extraction logic to search all seller references
- normalize/validate the VAT code
- cover new VAT edge cases with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3c18c0b88321b90c04b27538091e