### PR TITLE
Improve supplier code selection

### DIFF
--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -149,6 +149,63 @@ def test_open_invoice_gui_uses_env_vars(monkeypatch, tmp_path):
     assert captured["kw"] == keywords_file
 
 
+def test_cli_review_uses_vat_when_not_in_map(monkeypatch, tmp_path):
+    invoice = tmp_path / "inv.xml"
+    invoice.write_text("<xml/>")
+
+    suppliers_dir = tmp_path / "links_env"
+    codes_file = tmp_path / "codes.xlsx"
+    codes_file.write_text("dummy")
+
+    keywords_file = tmp_path / "kw.xlsx"
+    keywords_file.write_text("dummy")
+
+    monkeypatch.setenv("WSM_SUPPLIERS", str(suppliers_dir))
+    monkeypatch.setenv("WSM_CODES", str(codes_file))
+    monkeypatch.setenv("WSM_KEYWORDS", str(keywords_file))
+
+    captured = {}
+
+    def fake_analyze(inv, suppliers_file):
+        captured["sup"] = suppliers_file
+        df = pd.DataFrame({
+            "sifra_dobavitelja": ["SUP"],
+            "naziv": ["Item"],
+            "kolicina": [Decimal("1")],
+            "enota": ["kos"],
+            "vrednost": [Decimal("1")],
+            "rabata": [Decimal("0")],
+        })
+        return df, Decimal("1"), True
+
+    def fake_read_excel(path, dtype=None):
+        captured["codes"] = Path(path)
+        return pd.DataFrame()
+
+    def fake_review_links(df, wsm_df, links_file, total, invoice_path, price_warn_pct=None):
+        captured["links"] = links_file
+        captured["pct"] = price_warn_pct
+
+    def fake_povezi(df, sifre, keywords_path=None, links_dir=None, supplier_code=None):
+        captured["kw"] = Path(keywords_path)
+        return df
+
+    monkeypatch.setattr(cli, "analyze_invoice", fake_analyze)
+    monkeypatch.setattr(cli.pd, "read_excel", fake_read_excel)
+    monkeypatch.setattr("wsm.ui.review.gui.review_links", fake_review_links)
+    monkeypatch.setattr("wsm.utils.povezi_z_wsm", fake_povezi)
+    monkeypatch.setattr(cli, "get_supplier_name", lambda p: "Test Supplier")
+    monkeypatch.setattr("wsm.parsing.eslog.get_supplier_info_vat", lambda p: ("", "", "SI123"))
+    monkeypatch.setattr(cli, "_load_supplier_map", lambda p: {})
+
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["review", str(invoice)])
+    assert result.exit_code == 0
+
+    expected = suppliers_dir / "SI123" / "SI123_SI123_povezane.xlsx"
+    assert captured["links"] == expected
+
+
 def test_cli_review_prefers_vat_from_map(monkeypatch, tmp_path):
     invoice = tmp_path / "inv.xml"
     invoice.write_text("<xml/>")

--- a/tests/test_supplier_vat.py
+++ b/tests/test_supplier_vat.py
@@ -6,3 +6,15 @@ def test_get_supplier_info_vat_prefers_seller():
     xml = Path("tests/PR5918-Slika2.XML")
     _, _, vat = get_supplier_info_vat(xml)
     assert vat == "SI29746507"
+
+
+def test_get_supplier_info_vat_prefers_va_over_ahp():
+    xml = Path("tests/vat_ahp_before_va.xml")
+    _, _, vat = get_supplier_info_vat(xml)
+    assert vat == "SI22222222"
+
+
+def test_get_supplier_info_vat_with_gln():
+    xml = Path("tests/vat_with_gln.xml")
+    _, _, vat = get_supplier_info_vat(xml)
+    assert vat == "SI33333333"

--- a/tests/test_use_existing_folder.py
+++ b/tests/test_use_existing_folder.py
@@ -80,7 +80,7 @@ def test_open_invoice_gui_prefers_vat_folder(monkeypatch, tmp_path):
 
     open_invoice_gui(invoice_path=invoice, suppliers=suppliers_dir)
 
-    expected_dir = suppliers_dir / "SUP"
-    expected = expected_dir / "SUP_SUP_povezane.xlsx"
+    expected_dir = suppliers_dir / "SI111"
+    expected = expected_dir / "SI111_SI111_povezane.xlsx"
     assert captured["links"] == expected
     assert expected_dir.exists()

--- a/tests/vat_ahp_before_va.xml
+++ b/tests/vat_ahp_before_va.xml
@@ -1,0 +1,16 @@
+<Invoice xmlns="urn:eslog:2.00">
+  <M_INVOIC>
+    <G_SG2>
+      <S_NAD>
+        <D_3035>SE</D_3035>
+        <C_C080><D_3036>Seller A</D_3036></C_C080>
+      </S_NAD>
+      <G_SG3>
+        <S_RFF><C_C506><D_1153>AHP</D_1153><D_1154>SI11111111</D_1154></C_C506></S_RFF>
+      </G_SG3>
+      <G_SG3>
+        <S_RFF><C_C506><D_1153>VA</D_1153><D_1154>si 22222222</D_1154></C_C506></S_RFF>
+      </G_SG3>
+    </G_SG2>
+  </M_INVOIC>
+</Invoice>

--- a/tests/vat_with_gln.xml
+++ b/tests/vat_with_gln.xml
@@ -1,0 +1,14 @@
+<Invoice xmlns="urn:eslog:2.00">
+  <M_INVOIC>
+    <G_SG2>
+      <S_NAD>
+        <S_GLN><D_7402>1234567890123</D_7402></S_GLN>
+        <D_3035>SE</D_3035>
+        <C_C080><D_3036>Seller B</D_3036></C_C080>
+      </S_NAD>
+      <G_SG3>
+        <S_RFF><C_C506><D_1153>VA</D_1153><D_1154>SI33333333</D_1154></C_C506></S_RFF>
+      </G_SG3>
+    </G_SG2>
+  </M_INVOIC>
+</Invoice>

--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -157,6 +157,8 @@ def review(invoice, wsm_codes, suppliers, keywords, price_warn_pct, use_pyqt):
         name = supplier_code
     if not vat and map_vat:
         vat = map_vat
+    if vat and (supplier_code == "unknown" or supplier_code not in sup_map):
+        supplier_code = vat
 
     base = Path(suppliers_path)
 

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -90,8 +90,8 @@ def open_invoice_gui(
         name = supplier_code
     if not vat and map_vat:
         vat = map_vat
-    # Če je koda še "unknown" in VAT obstaja, uporabi kar davčno številko
-    if supplier_code == "unknown" and vat:
+    # Če nimamo vnosa v zemljevidu dobaviteljev, uporabi VAT kot kodo
+    if vat and (supplier_code == "unknown" or supplier_code not in sup_map):
         supplier_code = vat
 
     # ───── enotna mapa: supplier_code > VAT > fallback ─────


### PR DESCRIPTION
## Summary
- prefer VAT as supplier code when not present in mapping
- update GUI and CLI paths accordingly
- adjust tests for new VAT logic and add coverage for CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e3c18c0b88321b90c04b27538091e