### PR TITLE
Update article code extraction from LIN or PIA

### DIFF
--- a/tests/test_analyze_invoice.py
+++ b/tests/test_analyze_invoice.py
@@ -9,8 +9,8 @@ def test_analyze_invoice_merges_duplicates():
     path = Path("tests/CUSTOMERINVOICES_2025-04-01T14-29-47_2081078.xml")
     df, total, ok = analyze.analyze_invoice(path)
 
-    # Item 00002122 appears three times with the same discount; should be merged
-    row = df[(df["sifra_artikla"] == "00002122") & (df["rabata_pct"] == Decimal("4.99"))].iloc[0]
+    # Item 54490086 appears three times with the same discount; should be merged
+    row = df[(df["sifra_artikla"] == "54490086") & (df["rabata_pct"] == Decimal("4.99"))].iloc[0]
     assert row["kolicina"] == Decimal("72.00")
     assert row["vrednost"] == Decimal("50.25")
 

--- a/tests/test_pia_code.py
+++ b/tests/test_pia_code.py
@@ -1,0 +1,58 @@
+from decimal import Decimal
+from pathlib import Path
+
+from wsm import analyze
+from wsm.parsing.eslog import parse_eslog_invoice
+
+
+def test_parse_eslog_invoice_reads_code_from_pia():
+    xml = Path('tests/VP2025-1799-racun.xml')
+    df, ok = parse_eslog_invoice(xml, {})
+    df = df[df['sifra_dobavitelja'] != '_DOC_']
+    assert list(df['sifra_artikla']) == [
+        '4025127091881',
+        '4025127088942',
+        '4025127014002',
+    ]
+    assert ok
+
+
+def test_analyze_invoice_groups_duplicate_pia_lines(tmp_path, monkeypatch):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><D_1082>1</D_1082></S_LIN>"
+        "      <S_PIA><C_C212><D_7140>111</D_7140></C_C212></S_PIA>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><D_1082>2</D_1082></S_LIN>"
+        "      <S_PIA><C_C212><D_7140>111</D_7140></C_C212></S_PIA>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG26>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    xml_path = tmp_path / 'invoice.xml'
+    xml_path.write_text(xml)
+
+    monkeypatch.setattr(analyze, 'extract_header_net', lambda p: Decimal('20'))
+    monkeypatch.setattr(analyze, '_norm_unit', lambda q, u, n, vat=None, code=None: (q, u))
+
+    df, total, ok = analyze.analyze_invoice(xml_path)
+    df = df[df['sifra_dobavitelja'] != '_DOC_']
+
+    assert len(df) == 1
+    row = df.iloc[0]
+    assert row['sifra_artikla'] == '111'
+    assert row['kolicina'] == Decimal('2')
+    assert row['vrednost'] == Decimal('20')
+    assert total == Decimal('20')
+    assert ok

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -364,22 +364,11 @@ def parse_eslog_invoice(
         # poiščemo šifro artikla
         art_code = ""
         lin_code = _text(sg26.find(".//e:S_LIN/e:C_C212/e:D_7140", NS))
-        lin_digits = re.sub(r"\D+", "", lin_code)
-        if len(lin_digits) >= 12:
-            art_code = lin_digits
-        else:
-            for pia in sg26.findall(".//e:S_PIA", NS):
-                qual = _text(pia.find("./e:C_C212/e:D_7143", NS))
-                code = _text(pia.find("./e:C_C212/e:D_7140", NS))
-                digits = re.sub(r"\D+", "", code)
-                if qual in {"SA", "SRV"} and digits and not art_code:
-                    art_code = digits
-                    if qual == "SA":
-                        break
-                elif not art_code and digits:
-                    art_code = digits
-            if not art_code:
-                art_code = lin_digits
+        art_code = re.sub(r"\D+", "", lin_code)
+        if not art_code:
+            pia_first = sg26.find(".//e:S_PIA/e:C_C212/e:D_7140", NS)
+            if pia_first is not None:
+                art_code = re.sub(r"\D+", "", pia_first.text or "")
 
         desc = _text(sg26.find(".//e:S_IMD/e:C_C273/e:D_7008", NS))
 


### PR DESCRIPTION
## Summary
- simplify code extraction in `parse_eslog_invoice`
- test parsing of lines that only contain codes in PIA
- adjust expectations for `analyze_invoice` grouping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f8c5bdd3883219f4b8e589365d745