### PR TITLE
Remove unused sup_map argument

### DIFF
--- a/tests/test_analyze_groupby.py
+++ b/tests/test_analyze_groupby.py
@@ -48,7 +48,7 @@ def test_grouping_by_code_and_discount(monkeypatch):
     ])
 
     # Patch parse_eslog_invoice to return our DataFrame and status
-    monkeypatch.setattr(analyze, 'parse_eslog_invoice', lambda path, sup: (data, True))
+    monkeypatch.setattr(analyze, 'parse_eslog_invoice', lambda path: (data, True))
     # Identity normalization
     monkeypatch.setattr(analyze, '_norm_unit', lambda q, u, n, vat=None, code=None: (q, u))
     # Header total equals sum of values

--- a/tests/test_gratis_total.py
+++ b/tests/test_gratis_total.py
@@ -6,7 +6,7 @@ from wsm.parsing.eslog import parse_eslog_invoice
 
 
 def _calc_totals(xml_path: Path):
-    df, ok = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path)
     df_doc = df[df["sifra_dobavitelja"] == "_DOC_"]
     doc_discount_total = df_doc["vrednost"].sum()
     df = df[df["sifra_dobavitelja"] != "_DOC_"].copy()

--- a/tests/test_line_tax_missing.py
+++ b/tests/test_line_tax_missing.py
@@ -7,7 +7,7 @@ from wsm.parsing.eslog import parse_eslog_invoice, _line_tax, NS
 
 def test_line_tax_fallback_to_rate():
     xml_path = Path('tests/line_missing_moa124.xml')
-    df, ok = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path)
     assert len(df) == 2
     assert ok
 

--- a/tests/test_minimal_line_discount.py
+++ b/tests/test_minimal_line_discount.py
@@ -6,7 +6,7 @@ from wsm.parsing.eslog import parse_eslog_invoice, extract_header_net
 
 def test_minimal_line_discount():
     xml_path = Path("tests/minimal_line_discount.xml")
-    df, ok = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path)
 
     assert len(df) == 1
     line = df.iloc[0]

--- a/tests/test_parse_eslog_document_discount.py
+++ b/tests/test_parse_eslog_document_discount.py
@@ -41,7 +41,7 @@ def _compute_doc_discount(xml_path: Path) -> Decimal:
 def test_parse_eslog_invoice_returns_doc_discount_row():
     xml_path = Path("tests/PR5697-Slika2.XML")
     expected_discount = _compute_doc_discount(xml_path)
-    df, ok = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path)
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
     
     assert doc_row["vrednost"] == -expected_discount
@@ -69,7 +69,7 @@ def test_parse_eslog_invoice_handles_additional_discount_codes(tmp_path):
     xml_path = tmp_path / "disc131.xml"
     xml_path.write_text(xml)
 
-    df, ok = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path)
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
     assert doc_row["vrednost"] == Decimal("-2.50")
@@ -100,7 +100,7 @@ def test_parse_eslog_invoice_sums_multiple_discount_codes(tmp_path):
     xml_path = tmp_path / "disc_multi.xml"
     xml_path.write_text(xml)
 
-    df, ok = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path)
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
     assert doc_row["vrednost"] == Decimal("-3.50")
@@ -110,7 +110,7 @@ def test_parse_eslog_invoice_sums_multiple_discount_codes(tmp_path):
 
 def test_line_and_doc_discount_total_matches_header():
     xml_path = Path("tests/minimal_doc_discount.xml")
-    df, ok = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path)
 
     doc_rows = df[df["sifra_dobavitelja"] == "_DOC_"]
     assert not doc_rows.empty

--- a/tests/test_pia_code.py
+++ b/tests/test_pia_code.py
@@ -7,7 +7,7 @@ from wsm.parsing.eslog import parse_eslog_invoice
 
 def test_parse_eslog_invoice_reads_code_from_pia():
     xml = Path('tests/VP2025-1799-racun.xml')
-    df, ok = parse_eslog_invoice(xml, {})
+    df, ok = parse_eslog_invoice(xml)
     df = df[df['sifra_dobavitelja'] != '_DOC_']
     assert list(df['sifra_artikla']) == [
         '4025127091881',

--- a/tests/test_unlinked_total.py
+++ b/tests/test_unlinked_total.py
@@ -7,7 +7,7 @@ from wsm.parsing.money import detect_round_step
 
 
 def _calc_unlinked_total(xml_path: Path) -> Decimal:
-    df, ok = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path)
     invoice_total = extract_header_net(xml_path)
     df_doc = df[df["sifra_dobavitelja"] == "_DOC_"].copy()
     doc_discount_total = df_doc["vrednost"].sum()

--- a/tests/test_vat_rate.py
+++ b/tests/test_vat_rate.py
@@ -4,7 +4,7 @@ from wsm.parsing.eslog import parse_eslog_invoice
 
 
 def test_vat_rate_22():
-    df, ok = parse_eslog_invoice(Path('tests/VP2025-1799-racun.xml'), {})
+    df, ok = parse_eslog_invoice(Path('tests/VP2025-1799-racun.xml'))
     df = df[df['sifra_dobavitelja'] != '_DOC_']
     assert 'ddv_stopnja' in df.columns
     assert df['ddv_stopnja'].iloc[0] == Decimal('22.00')
@@ -12,7 +12,7 @@ def test_vat_rate_22():
 
 
 def test_vat_rate_9_5():
-    df, ok = parse_eslog_invoice(Path('tests/PR5691-Slika2.XML'), {})
+    df, ok = parse_eslog_invoice(Path('tests/PR5691-Slika2.XML'))
     df = df[df['sifra_dobavitelja'] != '_DOC_']
     assert set(df['ddv_stopnja'].unique()) == {Decimal('9.5')}
     assert ok

--- a/tests/test_vat_rounding.py
+++ b/tests/test_vat_rounding.py
@@ -7,7 +7,7 @@ from wsm.parsing.eslog import parse_eslog_invoice, _line_tax, NS
 
 def test_vat_rounding_totals():
     xml_path = Path('tests/25-24412.xml')
-    df, ok = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path)
 
     root = ET.parse(xml_path).getroot()
     lines = root.findall('.//e:G_SG26', NS)

--- a/wsm/analyze.py
+++ b/wsm/analyze.py
@@ -5,7 +5,6 @@ import pandas as pd
 
 from wsm.parsing.eslog import parse_eslog_invoice
 from wsm.ui.review.helpers import _norm_unit
-from wsm.supplier_store import load_suppliers as _load_supplier_map
 from wsm.parsing.eslog import extract_header_net
 from wsm.parsing.money import detect_round_step, round_to_step
 
@@ -17,8 +16,7 @@ def analyze_invoice(xml_path: str, suppliers_file: str | None = None) -> tuple[p
     percentage (``rabata_pct``) are merged together. The product name is kept
     from the first occurrence.
     """
-    sup_map = _load_supplier_map(Path(suppliers_file)) if suppliers_file else {}
-    df, grand_ok = parse_eslog_invoice(xml_path, sup_map)
+    df, grand_ok = parse_eslog_invoice(xml_path)
 
     # normalize units
     df[['kolicina', 'enota']] = [

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -313,7 +313,6 @@ def extract_invoice_number(xml_path: Path | str) -> str | None:
 # ──────────────────── glavni parser za ESLOG INVOIC ────────────────────
 def parse_eslog_invoice(
     xml_path: str | Path,
-    sup_map: dict,
     discount_codes: List[str] | None = None,
 ) -> tuple[pd.DataFrame, bool]:
     """
@@ -337,9 +336,6 @@ def parse_eslog_invoice(
     ----------
     xml_path : str | Path
         Pot do eSLOG XML datoteke.
-    sup_map : dict
-        Mapa dobaviteljev za prilagoditve. Trenutno se uporablja
-        predvsem pri normalizaciji enot (funkcija ``_norm_unit``).
     discount_codes : list[str] | None, optional
         Seznam kod za dokumentarni popust.  Privzeto je
         ``DEFAULT_DOC_DISCOUNT_CODES``.
@@ -542,7 +538,7 @@ def parse_invoice(source: str | Path):
 
     # Ali je pravi eSLOG (urn:eslog:2.00)?
     if root.tag.endswith('Invoice') and root.find('.//e:M_INVOIC', NS) is not None:
-        df_items, totals_ok = parse_eslog_invoice(source, {})
+        df_items, totals_ok = parse_eslog_invoice(source)
         header_total = extract_header_net(Path(source) if isinstance(source, (str, Path)) else source)
         df = pd.DataFrame({
             'cena_netto': df_items['cena_netto'],


### PR DESCRIPTION
## Summary
- drop `sup_map` from `parse_eslog_invoice`
- update parse helpers and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f9b0be24c8321a09025618cc17180