### PR TITLE
Remove builtins.ok and standardize parse_eslog_invoice return

### DIFF
--- a/tests/test_decimal_precision.py
+++ b/tests/test_decimal_precision.py
@@ -25,4 +25,3 @@ def test_parse_invoice_high_precision_values():
     assert header_total == Decimal("132.00")
     assert discount_total == Decimal("0")
     assert sum(df["izracunana_vrednost"]) == Decimal("132.00")
-    assert ok

--- a/tests/test_gui_header_totals.py
+++ b/tests/test_gui_header_totals.py
@@ -65,7 +65,7 @@ def test_header_totals_display_and_no_autofix(tmp_path):
     xml_path = tmp_path / "inv.xml"
     xml_path.write_text(xml)
 
-    df = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path, {})
     header = {
         "net": extract_header_net(xml_path),
         "vat": extract_total_tax(xml_path),
@@ -121,7 +121,7 @@ def test_no_doc_row_added_for_small_diff(tmp_path):
     xml_path = tmp_path / "inv.xml"
     xml_path.write_text(xml)
 
-    df = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path, {})
     header_net = extract_header_net(xml_path)
     assert df[df["sifra_dobavitelja"] == "_DOC_"].empty
     total_calc = df[df["sifra_dobavitelja"] != "_DOC_"]["vrednost"].sum()
@@ -159,7 +159,7 @@ def test_header_totals_display_small_diff(tmp_path):
     xml_path = tmp_path / "inv.xml"
     xml_path.write_text(xml)
 
-    df = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path, {})
     header = {
         "net": extract_header_net(xml_path),
         "vat": extract_total_tax(xml_path),

--- a/tests/test_missing_unit.py
+++ b/tests/test_missing_unit.py
@@ -15,4 +15,3 @@ def test_missing_unit_defaults_to_kos(tmp_path):
 
     df, _, _ = parse_invoice(xml)
     assert df.loc[0, "enota"] == "kos"
-    assert ok

--- a/tests/test_parse_eslog_document_discount.py
+++ b/tests/test_parse_eslog_document_discount.py
@@ -128,7 +128,7 @@ def test_parse_eslog_invoice_handles_moa_176():
     xml_path = Path("tests/PR5690-Slika1.XML")
     expected_discount = _compute_doc_discount(xml_path)
 
-    df = parse_eslog_invoice(xml_path, {})
+    df, _ = parse_eslog_invoice(xml_path, {})
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
     assert doc_row["vrednost"] == -expected_discount
@@ -155,7 +155,7 @@ def test_parse_eslog_invoice_handles_moa_500(tmp_path):
     xml_path = tmp_path / "disc500.xml"
     xml_path.write_text(xml)
 
-    df = parse_eslog_invoice(xml_path, {})
+    df, _ = parse_eslog_invoice(xml_path, {})
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
     assert doc_row["vrednost"] == Decimal("-0.05")
@@ -186,7 +186,7 @@ def test_parse_eslog_invoice_sums_duplicate_values(tmp_path):
     xml_path = tmp_path / "disc_dupes.xml"
     xml_path.write_text(xml)
 
-    df = parse_eslog_invoice(xml_path, {})
+    df, _ = parse_eslog_invoice(xml_path, {})
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
     assert doc_row["vrednost"] == Decimal("-2.00")

--- a/tests/test_unlinked_total.py
+++ b/tests/test_unlinked_total.py
@@ -5,7 +5,7 @@ from wsm.parsing.eslog import parse_eslog_invoice
 
 
 def _calc_unlinked_total(xml_path: Path) -> Decimal:
-    df = parse_eslog_invoice(xml_path, {})
+    df, ok = parse_eslog_invoice(xml_path, {})
     df = df[df["sifra_dobavitelja"] != "_DOC_"].copy()
     df["total_net"] = df["vrednost"]
 

--- a/tests/test_validate_invoice.py
+++ b/tests/test_validate_invoice.py
@@ -62,7 +62,6 @@ def test_parse_invoice_minimal():
     assert discount_total == Decimal("0")
     # Seštevek izračunanih vrstic:
     assert sum(df["izracunana_vrednost"]) == Decimal("150.00")
-    assert ok
 
 
 def test_parse_invoice_with_line_and_doc_discount():
@@ -99,7 +98,6 @@ def test_parse_invoice_with_line_and_doc_discount():
     assert discount_total == Decimal("50.00")
     # Skupaj izračunanih vrstic:
     assert sum(df["izracunana_vrednost"]) == Decimal("280.00")
-    assert ok
     # Potrdimo, da extract_total_amount vrne 250 (300 - 50):
     from xml.etree import ElementTree as ET
 


### PR DESCRIPTION
## Summary
- drop the global `builtins.ok` variable
- `parse_eslog_invoice` always returns `(df, ok)`
- update `parse_invoice` to unpack the tuple
- adjust tests for the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870dc7eea648321b987f2fe6a34bb02