### PR TITLE
Improve supplier GLN/VAT detection

### DIFF
--- a/tests/test_supplier_vat.py
+++ b/tests/test_supplier_vat.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from wsm.parsing.eslog import get_supplier_info_vat
+from wsm.parsing.eslog import get_supplier_info_vat, get_supplier_info
 
 
 def test_get_supplier_info_vat_prefers_seller():
@@ -12,3 +12,15 @@ def test_get_supplier_info_vat_uses_se_when_su_missing():
     xml = Path("tests/SE_after_SU.XML")
     _, _, vat = get_supplier_info_vat(xml)
     assert vat == "SI11111111"
+
+
+def test_get_supplier_info_returns_gln_when_available():
+    xml = Path("tests/PR5690-Slika1.XML")
+    code, _ = get_supplier_info(xml)
+    assert code == "3830029809998"
+
+
+def test_get_supplier_info_uses_vat_when_no_gln():
+    xml = Path("tests/vat_ahp_before_va.xml")
+    code, _ = get_supplier_info(xml)
+    assert code == "si 22222222"


### PR DESCRIPTION
## Summary
- detect GLN code with qualifier `0088`
- fall back to VAT IDs from `RFF` (VA/0199) when GLN missing
- add tests for GLN and VAT based supplier codes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ad83315c8321870a7131b04812ad