### PR TITLE
Fix CLI validate command

### DIFF
--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -55,7 +55,7 @@ def _validate_file(file_path: Path):
         return
 
     try:
-        ok = validate_invoice(df, header_total) and total_ok
+        ok = validate_invoice(df, header_total)
     except Exception as e:
         click.echo(f"[NAPAKA VALIDACIJE] {filename}: {e}")
         return


### PR DESCRIPTION
## Summary
- avoid NameError in CLI validation by dropping the unused variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b486bd2c8321b309cc8a30264029