### PR TITLE
Support GLN from S_GLN element

### DIFF
--- a/tests/test_supplier_gln.py
+++ b/tests/test_supplier_gln.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+from wsm.parsing.eslog import get_supplier_info
+
+
+def test_get_supplier_info_reads_sgln():
+    xml = Path("tests/vat_with_gln.xml")
+    code, _ = get_supplier_info(xml)
+    assert code == "1234567890123"

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -80,6 +80,18 @@ def _find_gln(nad: ET.Element) -> str:
             code_el = c082.find("./D_3039")
             if code_el is not None and code_el.text:
                 return code_el.text.strip()
+
+    gln_el = nad.find(".//e:S_GLN/e:D_7402", NS)
+    if gln_el is not None:
+        val = _text(gln_el)
+        if val:
+            return val
+    gln_el = nad.find(".//S_GLN/D_7402")
+    if gln_el is not None and gln_el.text:
+        val = gln_el.text.strip()
+        if val:
+            return val
+
     return ""
 
 


### PR DESCRIPTION
## Summary
- support extracting GLN from `<S_GLN><D_7402>` in ESLOG files
- test GLN extraction from new element

## Testing
- `pytest -q tests/test_supplier_gln.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874cdfe6b2c8321b040658922a15a8f