### PR TITLE
Document VAT qualifiers

### DIFF
--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -112,7 +112,10 @@ def _find_any_code(nad: ET.Element) -> str:
 
 
 def _find_vat(grp: ET.Element) -> str:
-    """Return VAT number from related ``S_RFF`` segments."""
+    """Return VAT number from related ``S_RFF`` segments.
+
+    Recognized qualifiers are ``VA``, ``0199`` and ``AHP``.
+    """
     vat_ahp = ""
     rffs = grp.findall(".//e:S_RFF", NS) + grp.findall(".//S_RFF")
     for rff in rffs:


### PR DESCRIPTION
## Summary
- clarify which VAT qualifiers are accepted when parsing ESLOG invoices

## Testing
- `pre-commit run --files wsm/parsing/eslog.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875fd84aee08321b4be38ba07ccc68a