### PR TITLE
Fix XML parser security

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ pre-commit install  # opcijsko
 - **Bolj zmogljiv GUI**: Tkinter je enostaven, a za obsežnejše tabele bi lahko razmislili o prehodu na `PyQt5`, ki omogoča naprednejše filtriranje in iskanje.
 - **Testne enote za GUI**: poleg obstoječih testov za parsanje XML je smiselno dodati teste, ki preverijo logiko povezovanja (npr. ali `_save_and_close` pravilno posodobi Excel). Osnovne funkcije GUI se da avtomatizirati z unit testi.
 
+## Varnost
+
+Pri odpiranju XML datotek se uporablja `lxml` z onemogočenim
+reševanjem zunanjih entitet (`resolve_entities=False`). S tem se
+izognemo branju datotek ali nalaganju vsebine preko zunanjih entitet
+(XXE napadi).
+
 
 ## Licenca
 Ta projekt uporablja licenco MIT. Celotno besedilo najdete v datoteki [LICENSE](LICENSE).

--- a/tests/test_xxe.py
+++ b/tests/test_xxe.py
@@ -1,0 +1,19 @@
+from wsm.parsing import eslog
+
+
+def test_external_entities_are_ignored(tmp_path):
+    secret = tmp_path / "secret.txt"
+    secret.write_text("LEAK")
+    xml = tmp_path / "evil.xml"
+    xml.write_text(
+        f"""<!DOCTYPE Invoice [<!ENTITY ext SYSTEM '{secret.as_uri()}'>]>
+<Invoice xmlns='urn:eslog:2.00'>
+  <M_INVOIC>&ext;</M_INVOIC>
+</Invoice>"""
+    )
+    df, ok = eslog.parse_eslog_invoice(xml)
+    assert df.empty
+    assert ok
+    root = eslog.LET.parse(xml, parser=eslog.XML_PARSER).getroot()
+    assert "LEAK" not in "".join(root.itertext())
+

--- a/wsm/parsing/money.py
+++ b/wsm/parsing/money.py
@@ -1,6 +1,6 @@
 # File: wsm/parsing/money.py
 from decimal import Decimal, ROUND_HALF_UP
-import xml.etree.ElementTree as ET
+from lxml import etree as LET
 import pandas as pd
 
 def round_to_step(value: Decimal, step: Decimal, rounding=ROUND_HALF_UP) -> Decimal:
@@ -26,7 +26,7 @@ def quantize_like(value: Decimal, reference: Decimal, rounding=ROUND_HALF_UP) ->
     quant = Decimal('1').scaleb(reference.as_tuple().exponent)
     return value.quantize(quant, rounding=rounding)
 
-def extract_total_amount(xml_root: ET.Element) -> Decimal:
+def extract_total_amount(xml_root: LET._Element) -> Decimal:
     """
     Prebere osnovno glavo (<InvoiceTotal>) in, če obstaja, odšteje vrednost iz
     <DocumentDiscount>. Če katerikoli manjka, privzame 0.00.
@@ -67,7 +67,7 @@ def extract_total_amount(xml_root: ET.Element) -> Decimal:
 
     return (base - discount).quantize(Decimal("0.01"))
 
-def extract_line_items(xml_root: ET.Element) -> pd.DataFrame:
+def extract_line_items(xml_root: LET._Element) -> pd.DataFrame:
     """
     Iz <LineItems> vsak <LineItem> prebere 'PriceNet', 'Quantity', 'DiscountPct'
     in izračuna izracunana_vrednost = price_net * quantity * (1 - discount_pct/100).


### PR DESCRIPTION
## Summary
- disable entity resolution when parsing XML
- use the secure parser in all parsing functions
- add a regression test for external entities
- document security measure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875ff54ea7c832198619d0cc56053a7