### PR TITLE
Implement sum_moa helper for ESLOG discounts

### DIFF
--- a/tests/sg20_doc_discount.xml
+++ b/tests/sg20_doc_discount.xml
@@ -1,0 +1,16 @@
+<Invoice xmlns='urn:eslog:2.00'>
+  <M_INVOIC>
+    <G_SG26>
+      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>
+      <S_LIN><C_C212><D_7140>0001</D_7140></C_C212></S_LIN>
+      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>
+      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>
+      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>
+    </G_SG26>
+    <G_SG16>
+      <G_SG20>
+        <S_MOA><C_C516><D_5025>204</D_5025><D_5004>1.50</D_5004></C_C516></S_MOA>
+      </G_SG20>
+    </G_SG16>
+  </M_INVOIC>
+</Invoice>


### PR DESCRIPTION
## Summary
- add `sum_moa` helper to aggregate MOA amounts
- use `sum_moa` in `parse_eslog_invoice`
- adjust document discount tests and add SG20 case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68761f9c29ac8321bde8c4bbd112324d