### PR TITLE
Fix test warnings and ensure compatibility

### DIFF
--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -655,7 +655,11 @@ def load_last_price(label: str, suppliers_dir: Path) -> Decimal | None:
         if "time" not in df.columns:
             continue
 
-        df["price"] = df["unit_price"].fillna(df["line_netto"])
+        df["price"] = (
+            df["unit_price"]
+            .where(df["unit_price"].notna(), df["line_netto"])
+            .infer_objects(copy=False)
+        )
         if df["price"].isna().all():
             continue
 


### PR DESCRIPTION
## Summary
- no `a or b` patterns found in `eslog.py`
- avoid pandas `FutureWarning` during `load_last_price` tests by calling `Series.where(...).infer_objects()`

## Testing
- `pytest -q -W error::FutureWarning`

------
https://chatgpt.com/codex/tasks/task_e_6876256609a883218682285321dba145