### PR TITLE
Use supplier code when VAT missing

### DIFF
--- a/tests/test_blank_code_reload.py
+++ b/tests/test_blank_code_reload.py
@@ -56,7 +56,7 @@ def test_blank_supplier_code_retains_mapping(tmp_path, monkeypatch):
         {},
         base_dir,
     )
-    new_file = links_file
+    new_file = base_dir / "SUP" / "SUP_povezane.xlsx"
     manual_new = pd.read_excel(new_file, dtype=str)
     manual_new["sifra_dobavitelja"] = (
         manual_new["sifra_dobavitelja"].fillna("").astype(str)

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -143,11 +143,13 @@ def test_open_invoice_gui_uses_env_vars(monkeypatch, tmp_path):
 
     open_invoice_gui(invoice_path=invoice)
 
-    expected = suppliers_dir / "SUP_links_env_povezane.xlsx"
+    expected_dir = suppliers_dir / "SUP"
+    expected = expected_dir / "SUP_SUP_povezane.xlsx"
     assert captured["sup"] == suppliers_dir
     assert captured["codes"] == codes_file
     assert captured["links"] == expected
     assert captured["kw"] == keywords_file
+    assert expected_dir.exists()
 
 
 def test_cli_review_uses_vat_when_not_in_map(monkeypatch, tmp_path):

--- a/tests/test_use_existing_folder.py
+++ b/tests/test_use_existing_folder.py
@@ -40,8 +40,10 @@ def test_open_invoice_gui_uses_existing_folder(monkeypatch, tmp_path):
 
     open_invoice_gui(invoice_path=invoice, suppliers=suppliers_dir)
 
-    expected = suppliers_dir / "SUP_links_povezane.xlsx"
+    expected_dir = suppliers_dir / "SUP"
+    expected = expected_dir / "SUP_SUP_povezane.xlsx"
     assert captured["links"] == expected
+    assert expected_dir.exists()
 
 
 def test_open_invoice_gui_prefers_vat_folder(monkeypatch, tmp_path):
@@ -82,8 +84,8 @@ def test_open_invoice_gui_prefers_vat_folder(monkeypatch, tmp_path):
 
     open_invoice_gui(invoice_path=invoice, suppliers=suppliers_dir)
 
-    expected_dir = suppliers_dir
-    expected = expected_dir / "SUP_links_povezane.xlsx"
+    expected_dir = suppliers_dir / "SUP"
+    expected = expected_dir / "SUP_SUP_povezane.xlsx"
     assert captured["links"] == expected
     assert expected_dir.exists()
 

--- a/wsm/supplier_store.py
+++ b/wsm/supplier_store.py
@@ -27,16 +27,18 @@ def _norm_vat(s: str) -> str:
 
 
 def choose_supplier_key(vat: str | None, code: str | None = None) -> str:
-    """Return the normalized VAT number or ``""`` when unavailable.
+    """Return the normalized VAT number or a sanitized supplier code.
 
-    The ``code`` parameter is ignored.  The VAT number is normalized with
-    :func:`_norm_vat` and returned if non-empty.  Otherwise an empty string is
-    returned.
+    The VAT number is normalized with :func:`_norm_vat` and returned if
+    non-empty.  When no VAT is available, ``sanitize_folder_name(code)`` is
+    returned if ``code`` is provided.  Otherwise an empty string is returned.
     """
 
     vat_norm = _norm_vat(vat or "")
     if vat_norm:
         return vat_norm
+    if code:
+        return sanitize_folder_name(str(code))
     return ""
 
 


### PR DESCRIPTION
## Summary
- update `choose_supplier_key` to fall back to sanitized supplier code
- adjust open invoice GUI tests expecting new folder names
- fix blank code reload test to read from moved file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68762eb1eac4832183f89596b7f6b138