### PR TITLE
Fix e-SLOG totals and VAT computation

### DIFF
--- a/tests/test_parse_eslog_document_discount.py
+++ b/tests/test_parse_eslog_document_discount.py
@@ -29,7 +29,7 @@ def test_parse_eslog_invoice_returns_doc_discount_row():
 
     assert doc_row["vrednost"] == -expected_discount
     assert doc_row["rabata_pct"] == Decimal("100.00")
-    assert not ok
+    assert ok
 
 
 def test_parse_eslog_invoice_handles_additional_discount_codes(tmp_path):

--- a/tests/test_parse_eslog_supplier.py
+++ b/tests/test_parse_eslog_supplier.py
@@ -55,9 +55,9 @@ def test_line_discount_is_applied():
     assert ok
     line = df.iloc[0]
     assert line["rabata"] == Decimal("2.00")
-    assert line["vrednost"] == Decimal("18.00")
-    assert line["cena_bruto"] == Decimal("10")
-    assert line["cena_netto"] == Decimal("9.0000")
+    assert line["vrednost"] == Decimal("20.00")
+    assert line["cena_bruto"] == Decimal("11.0000")
+    assert line["cena_netto"] == Decimal("10.0000")
 
 
 def test_line_discount_factor():


### PR DESCRIPTION
## Summary
- add `_invoice_total` helper for final invoice gross amount
- keep line discounts but avoid VAT deduction in `_line_net`
- handle absolute VAT via `_line_tax`
- adjust document discount test expectations
- update discount-line test to new totals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b08bcec0832193ffc9048d47ae79