### PR TITLE
Fix invoice total fallback branch

### DIFF
--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -349,9 +349,9 @@ def _invoice_total(
     if header_net != 0:
         net = header_net
     else:
-        net = line_net_total + doc_discount
+        net = line_net_total - doc_discount
 
-    return (net + doc_charge + tax_total).quantize(DEC2, ROUND_HALF_UP)
+    return (net + doc_charge + tax_total).quantize(DEC2, rounding=ROUND_HALF_UP)
 
 
 # ───────────────────── datum opravljene storitve ─────────────────────


### PR DESCRIPTION
## Summary
- handle document discount correctly when header net is missing
- use rounding keyword for consistent Decimal quantization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d3036c448321bc31e87d1f235293