### PR TITLE
Fix VAT summation for multiple MOA 124 segments

### DIFF
--- a/tests/test_line_tax_multiple_moa124.py
+++ b/tests/test_line_tax_multiple_moa124.py
@@ -1,0 +1,43 @@
+from decimal import Decimal
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+from wsm.parsing.eslog import parse_eslog_invoice, _line_tax, NS
+
+
+def test_line_tax_sums_multiple_entries(tmp_path: Path) -> None:
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "      <G_SG34>"
+        "        <S_TAX><C_C243><D_5278>22</D_5278></C_C243></S_TAX>"
+        "        <S_MOA><C_C516><D_5025>124</D_5025><D_5004>1.10</D_5004></C_C516></S_MOA>"
+        "        <S_MOA><C_C516><D_5025>124</D_5025><D_5004>0.10</D_5004></C_C516></S_MOA>"
+        "      </G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>11.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    xml_path = tmp_path / "invoice.xml"
+    xml_path.write_text(xml)
+
+    df, ok = parse_eslog_invoice(xml_path)
+    assert ok
+    assert len(df) == 1
+
+    root = ET.parse(xml_path).getroot()
+    sg26 = root.findall(".//e:G_SG26", NS)[0]
+    tax = _line_tax(sg26)
+    assert tax == Decimal("1.20")

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -351,7 +351,9 @@ def _invoice_total(
     else:
         net = line_net_total - doc_discount
 
-    return (net + doc_charge + tax_total).quantize(DEC2, rounding=ROUND_HALF_UP)
+    return (net + doc_charge + tax_total).quantize(
+        DEC2, rounding=ROUND_HALF_UP
+    )
 
 
 # ───────────────────── datum opravljene storitve ─────────────────────
@@ -549,48 +551,50 @@ def _line_pct_discount(sg26: LET._Element) -> Decimal:
 def _line_net(sg26: LET._Element) -> Decimal:
     """Return net line amount without VAT or discounts."""
 
-    for moa in sg26.findall('.//e:S_MOA', NS) + sg26.findall('.//S_MOA'):
-        code = _text(moa.find('./e:C_C516/e:D_5025', NS)) or _text(
-            moa.find('./C_C516/D_5025')
+    for moa in sg26.findall(".//e:S_MOA", NS) + sg26.findall(".//S_MOA"):
+        code = _text(moa.find("./e:C_C516/e:D_5025", NS)) or _text(
+            moa.find("./C_C516/D_5025")
         )
         if code in {"203", "125"}:
-            val_el = moa.find('./e:C_C516/e:D_5004', NS)
+            val_el = moa.find("./e:C_C516/e:D_5004", NS)
             if val_el is None:
-                val_el = moa.find('./C_C516/D_5004')
+                val_el = moa.find("./C_C516/D_5004")
             val = _decimal(val_el)
             if val:
                 return val.quantize(DEC2, ROUND_HALF_UP)
 
-    qty = _decimal(sg26.find('.//e:S_QTY/e:C_C186/e:D_6060', NS))
+    qty = _decimal(sg26.find(".//e:S_QTY/e:C_C186/e:D_6060", NS))
     price_net = Decimal("0")
     price_gross = Decimal("0")
-    for pri in sg26.findall('.//e:S_PRI', NS) + sg26.findall('.//S_PRI'):
-        code = _text(pri.find('./e:C_C509/e:D_5125', NS)) or _text(
-            pri.find('./C_C509/D_5125')
+    for pri in sg26.findall(".//e:S_PRI", NS) + sg26.findall(".//S_PRI"):
+        code = _text(pri.find("./e:C_C509/e:D_5125", NS)) or _text(
+            pri.find("./C_C509/D_5125")
         )
         if code == "AAA":
-            val_el = pri.find('./e:C_C509/e:D_5118', NS)
+            val_el = pri.find("./e:C_C509/e:D_5118", NS)
             if val_el is None:
-                val_el = pri.find('./C_C509/D_5118')
+                val_el = pri.find("./C_C509/D_5118")
             price_net = _decimal(val_el)
             break
         if code == "AAB" and price_gross == 0:
-            val_el = pri.find('./e:C_C509/e:D_5118', NS)
+            val_el = pri.find("./e:C_C509/e:D_5118", NS)
             if val_el is None:
-                val_el = pri.find('./C_C509/D_5118')
+                val_el = pri.find("./C_C509/D_5118")
             price_gross = _decimal(val_el)
 
     if price_net == 0 and price_gross != 0:
         pct = Decimal("0")
-        for sg39 in sg26.findall('.//e:G_SG39', NS) + sg26.findall('.//G_SG39'):
+        for sg39 in sg26.findall(".//e:G_SG39", NS) + sg26.findall(
+            ".//G_SG39"
+        ):
             qualifier = _text(
-                sg39.find('./e:G_SG41/e:S_PCD/e:C_C501/e:D_5249', NS)
-            ) or _text(sg39.find('./G_SG41/S_PCD/C_C501/D_5249'))
+                sg39.find("./e:G_SG41/e:S_PCD/e:C_C501/e:D_5249", NS)
+            ) or _text(sg39.find("./G_SG41/S_PCD/C_C501/D_5249"))
             if qualifier != "1":
                 continue
-            pct_el = sg39.find('./e:G_SG41/e:S_PCD/e:C_C501/e:D_5482', NS)
+            pct_el = sg39.find("./e:G_SG41/e:S_PCD/e:C_C501/e:D_5482", NS)
             if pct_el is None:
-                pct_el = sg39.find('./G_SG41/S_PCD/C_C501/D_5482')
+                pct_el = sg39.find("./G_SG41/S_PCD/C_C501/D_5482")
             pct = _decimal(pct_el)
             if pct != 0:
                 break
@@ -604,7 +608,9 @@ def _line_net(sg26: LET._Element) -> Decimal:
     elif price_net == 0:
         price_net = price_gross
 
-    amount = (price_net * qty - _line_discount(sg26)).quantize(DEC2, ROUND_HALF_UP)
+    amount = (price_net * qty - _line_discount(sg26)).quantize(
+        DEC2, ROUND_HALF_UP
+    )
     return amount
 
 
@@ -613,17 +619,20 @@ def _line_tax(
 ) -> Decimal:
     """Return VAT amount for a line."""
     abs_tax = Decimal("0")
-    for moa in sg26.findall('.//e:G_SG34/e:S_MOA', NS) + sg26.findall('.//S_MOA'):
-        code = _text(moa.find('./e:C_C516/e:D_5025', NS)) or _text(
-            moa.find('./C_C516/D_5025')
+    for moa in sg26.findall(".//e:G_SG34/e:S_MOA", NS) + sg26.findall(
+        ".//S_MOA"
+    ):
+        code = _text(moa.find("./e:C_C516/e:D_5025", NS)) or _text(
+            moa.find("./C_C516/D_5025")
         )
         if code == "124":
-            val_el = moa.find('./e:C_C516/e:D_5004', NS)
+            val_el = moa.find("./e:C_C516/e:D_5004", NS)
             if val_el is None:
-                val_el = moa.find('./C_C516/D_5004')
-            abs_tax = _decimal(val_el)
-            if abs_tax:
-                return abs_tax.quantize(DEC2, ROUND_HALF_UP)
+                val_el = moa.find("./C_C516/D_5004")
+            abs_tax += _decimal(val_el)
+
+    if abs_tax:
+        return abs_tax.quantize(DEC2, ROUND_HALF_UP)
 
     rate = None
     for path in (".//e:G_SG34/e:S_TAX", ".//e:G_SG52/e:S_TAX"):
@@ -789,7 +798,6 @@ def parse_eslog_invoice(
             rabata_pct = explicit_pct
         else:
             if rebate > 0 and qty and cena_pred > 0:
-
                 rabata_pct = (
                     (rebate / qty) / cena_pred * Decimal("100")
                 ).quantize(Decimal("0.01"), ROUND_HALF_UP)


### PR DESCRIPTION
## Summary
- accumulate VAT from all MOA 124 segments in a line
- add regression test covering lines with two VAT entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878a16e7a2883219130892d83aaf631