### PR TITLE
Fix expected gross price in discount test

### DIFF
--- a/tests/test_parse_eslog_supplier.py
+++ b/tests/test_parse_eslog_supplier.py
@@ -56,7 +56,7 @@ def test_line_discount_is_applied():
     line = df.iloc[0]
     assert line["rabata"] == Decimal("2.00")
     assert line["vrednost"] == Decimal("18.00")
-    assert line["cena_bruto"] == Decimal("10.0000")
+    assert line["cena_bruto"] == Decimal("10")
     assert line["cena_netto"] == Decimal("9.0000")
 
 


### PR DESCRIPTION
## Summary
- adjust discount test expectations for `test_line_discount_is_applied`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878a7193e7483219495a97b4c980b11