### PR TITLE
Handle doc discounts in totals

### DIFF
--- a/tests/test_gratis_total.py
+++ b/tests/test_gratis_total.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pandas as pd
 
 from wsm.parsing.eslog import parse_eslog_invoice
+from wsm.ui.review.helpers import _split_totals
 
 
 def _calc_totals(xml_path: Path):
@@ -15,9 +16,7 @@ def _calc_totals(xml_path: Path):
     df["wsm_sifra"] = pd.NA
     df.loc[df["naziv"] == "Normal", "wsm_sifra"] = "X"
 
-    valid = df[~df["is_gratis"]]
-    linked_total = valid[valid["wsm_sifra"].notna()]["total_net"].sum() + doc_discount_total
-    unlinked_total = valid[valid["wsm_sifra"].isna()]["total_net"].sum()
+    linked_total, unlinked_total, _ = _split_totals(df, doc_discount_total)
     assert ok
     return linked_total, unlinked_total
 

--- a/tests/test_split_totals_doc_discount.py
+++ b/tests/test_split_totals_doc_discount.py
@@ -1,0 +1,37 @@
+from decimal import Decimal
+from pathlib import Path
+import pandas as pd
+
+from wsm.parsing.eslog import parse_eslog_invoice, extract_header_net
+from wsm.ui.review.helpers import _split_totals
+
+
+def _prepare(path: Path):
+    df, ok = parse_eslog_invoice(path)
+    assert ok
+    df_doc = df[df["sifra_dobavitelja"] == "_DOC_"]
+    disc = df_doc["vrednost"].sum()
+    df = df[df["sifra_dobavitelja"] != "_DOC_"].copy()
+    df["total_net"] = df["vrednost"]
+    df["is_gratis"] = False
+    df["wsm_sifra"] = pd.NA
+    return df, disc, extract_header_net(path)
+
+
+def test_split_totals_linked_discount():
+    path = Path("tests/minimal_doc_discount.xml")
+    df, disc, header = _prepare(path)
+    df.loc[0, "wsm_sifra"] = "X"
+    linked, unlinked, total = _split_totals(df, disc)
+    assert total == header
+    assert linked == df.loc[0, "total_net"] + disc
+    assert unlinked == Decimal("0")
+
+
+def test_split_totals_unlinked_discount():
+    path = Path("tests/minimal_doc_discount.xml")
+    df, disc, header = _prepare(path)
+    linked, unlinked, total = _split_totals(df, disc)
+    assert total == header
+    assert linked == Decimal("0")
+    assert unlinked == df["total_net"].sum() + disc

--- a/wsm/ui_qt/review_links_qt.py
+++ b/wsm/ui_qt/review_links_qt.py
@@ -22,7 +22,7 @@ except Exception as exc:  # pragma: no cover - optional dependency
     raise ImportError("PyQt5 is required for the Qt GUI") from exc
 
 from wsm.constants import PRICE_DIFF_THRESHOLD
-from wsm.ui.review.helpers import _fmt, _norm_unit
+from wsm.ui.review.helpers import _fmt, _norm_unit, _split_totals
 from wsm.ui.review.io import _save_and_close, _load_supplier_map
 from wsm.parsing.money import detect_round_step
 from wsm.utils import short_supplier_name
@@ -254,9 +254,7 @@ def review_links_qt(
                 for c_i, v in enumerate(vals):
                     summary.setItem(r_i, c_i, QtWidgets.QTableWidgetItem(str(v)))
 
-        linked_total = df[df["wsm_sifra"].notna()]["total_net"].sum() + doc_discount_total
-        unlinked_total = df[df["wsm_sifra"].isna()]["total_net"].sum()
-        total_sum = linked_total + unlinked_total
+        linked_total, unlinked_total, total_sum = _split_totals(df, doc_discount_total)
         step_total = detect_round_step(header_totals["net"], total_sum)
         match_symbol = "✓" if abs(total_sum - header_totals["net"]) <= step_total else "✗"
         total_label.setText(


### PR DESCRIPTION
## Summary
- compute totals using a new `_split_totals` helper that accepts the document discount
- update Tkinter/Qt review GUIs to supply the discount when splitting totals
- adjust gratis total test to use the new helper
- add tests ensuring `_split_totals` respects document discounts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878d2a4841c8321a9cc3e74723ba896