### PR TITLE
Ensure Qt review GUI handles gratis lines

### DIFF
--- a/wsm/ui_qt/review_links_qt.py
+++ b/wsm/ui_qt/review_links_qt.py
@@ -128,6 +128,7 @@ def review_links_qt(
         axis=1,
     )
     df["total_net"] = df["vrednost"]
+    df["is_gratis"] = df["rabata_pct"] >= Decimal("99.9")
     df["kolicina_norm"], df["enota_norm"] = zip(
         *[
             _norm_unit(Decimal(str(q)), u, n, vat, code)


### PR DESCRIPTION
## Summary
- flag gratis invoice rows in the PyQt review GUI
- propagate the is_gratis column so totals exclude gratis items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878d87e88488321b46daf375ececfec