### PR TITLE
Change button color to brown

### DIFF
--- a/wsm/ui/main_menu.py
+++ b/wsm/ui/main_menu.py
@@ -26,10 +26,24 @@ def launch_main_menu() -> None:
         launch_price_watch(root)
         root.deiconify()
 
-    btn_invoice = tk.Button(root, text="Vnesi račun", width=20, command=_enter_invoice)
+    btn_invoice = tk.Button(
+        root,
+        text="Vnesi račun",
+        width=20,
+        command=_enter_invoice,
+        bg="brown",
+        fg="white",
+    )
     btn_invoice.pack(pady=20)
 
-    btn_prices = tk.Button(root, text="Spremljaj cene", width=20, command=_watch_prices)
+    btn_prices = tk.Button(
+        root,
+        text="Spremljaj cene",
+        width=20,
+        command=_watch_prices,
+        bg="brown",
+        fg="white",
+    )
     btn_prices.pack(pady=10)
 
     root.mainloop()


### PR DESCRIPTION
## Summary
- tweak Tk buttons for invoice entry and price watch to use brown background with white text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878de7f5d848321b358270276a522fb