### PR TITLE
Add shared header totals helper

### DIFF
--- a/tests/test_build_header_totals.py
+++ b/tests/test_build_header_totals.py
@@ -1,0 +1,55 @@
+from decimal import Decimal
+from pathlib import Path
+
+from wsm.utils import _build_header_totals
+
+
+def test_build_header_totals_extracts(tmp_path: Path) -> None:
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>2</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>12</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    p = tmp_path / "inv.xml"
+    p.write_text(xml)
+    totals = _build_header_totals(p, Decimal("0"))
+    assert totals == {
+        "net": Decimal("10"),
+        "vat": Decimal("2"),
+        "gross": Decimal("12"),
+    }
+
+
+def test_build_header_totals_fills_missing_net(tmp_path: Path) -> None:
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>0</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>2.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>12.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    p = tmp_path / "inv.xml"
+    p.write_text(xml)
+    totals = _build_header_totals(p, Decimal("0"))
+    assert totals["net"] == Decimal("10")
+    assert totals["vat"] == Decimal("2.20")
+    assert totals["gross"] == Decimal("12.20")
+

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -12,13 +12,8 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 
 from wsm.parsing.money import detect_round_step
-from wsm.utils import short_supplier_name, _clean
+from wsm.utils import short_supplier_name, _clean, _build_header_totals
 from wsm.constants import PRICE_DIFF_THRESHOLD
-from wsm.parsing.eslog import (
-    extract_header_net,
-    extract_total_tax,
-    extract_header_gross,
-)
 from .helpers import (
     _fmt,
     _norm_unit,
@@ -133,19 +128,8 @@ def review_links(
     log.info(f"Default name retrieved: {default_name}")
     log.debug(f"Supplier info: {supplier_info}")
 
-    header_totals = {
-        "net": invoice_total,
-        "vat": Decimal("0"),
-        "gross": invoice_total,
-    }
-    if invoice_path and invoice_path.suffix.lower() == ".xml":
-        try:
-            header_totals["net"] = extract_header_net(invoice_path)
-            header_totals["vat"] = extract_total_tax(invoice_path)
-            header_totals["gross"] = extract_header_gross(invoice_path)
-            invoice_total = header_totals["net"]
-        except Exception as exc:
-            log.warning(f"Napaka pri branju zneskov glave: {exc}")
+    header_totals = _build_header_totals(invoice_path, invoice_total)
+    invoice_total = header_totals["net"]
 
     try:
         manual_old = pd.read_excel(links_file, dtype=str)


### PR DESCRIPTION
## Summary
- factor header total extraction into `_build_header_totals`
- reuse new helper from Tk and Qt review UIs
- cover helper with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f5b67a8c8321911e4bb717a38434