### PR TITLE
Refactor totals handling

### DIFF
--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -285,10 +285,9 @@ def _split_totals(
         ``(linked_total, unlinked_total, total_sum)``.
     """
 
-    if "is_gratis" in df.columns:
-        valid = df[~df["is_gratis"]]
-    else:
-        valid = df
+    valid = df.copy()
+    if "is_gratis" in valid.columns:
+        valid = valid[~valid["is_gratis"]]
 
     dd_total = (
         doc_discount_total
@@ -296,9 +295,10 @@ def _split_totals(
         else Decimal(str(doc_discount_total))
     )
 
-    linked_total = valid[valid["wsm_sifra"].notna()]["total_net"].sum()
-    unlinked_total = valid[valid["wsm_sifra"].isna()]["total_net"].sum()
-    if valid["wsm_sifra"].notna().any():
+    linked_mask = valid["wsm_sifra"].notna()
+    linked_total = valid[linked_mask]["total_net"].sum()
+    unlinked_total = valid[~linked_mask]["total_net"].sum()
+    if linked_mask.any():
         linked_total += dd_total
     else:
         unlinked_total += dd_total


### PR DESCRIPTION
## Summary
- refactor `_split_totals` to copy dataframe first
- reuse a `linked_mask` variable
- apply document discount depending on whether any items are linked

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f76237148321b96756346865b848