### PR TITLE
Add totals check when header net code missing

### DIFF
--- a/tests/test_totals_missing_389.py
+++ b/tests/test_totals_missing_389.py
@@ -1,0 +1,18 @@
+from decimal import Decimal
+from pathlib import Path
+
+from wsm.parsing.eslog import parse_eslog_invoice
+
+
+def test_totals_missing_389():
+    xml_path = Path("tests/sg20_doc_discount.xml")
+    df, ok = parse_eslog_invoice(xml_path)
+    assert ok
+
+    doc_discount = -df[df["sifra_dobavitelja"] == "_DOC_"]["vrednost"].sum()
+    lines = df[df["sifra_dobavitelja"] != "_DOC_"]
+    lines = lines[lines["rabata_pct"] < Decimal("99.9")]
+    line_total = lines["vrednost"].sum()
+
+    header_net = df["vrednost"].sum()
+    assert line_total - doc_discount == header_net


### PR DESCRIPTION
## Summary
- add a regression test verifying totals when MOA 389/79 is absent

## Testing
- `pytest -q tests/test_totals_missing_389.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f8e63a248321b8ed85ea06f6ade7