### PR TITLE
Fix rounding in header net totals

### DIFF
--- a/tests/test_build_header_totals.py
+++ b/tests/test_build_header_totals.py
@@ -41,7 +41,7 @@ def test_build_header_totals_fills_missing_net(tmp_path: Path) -> None:
         "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>2.20</D_5004></C_C516></S_MOA>"
         "    </G_SG52>"
         "    <G_SG50>"
-        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>12.20</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>12.206</D_5004></C_C516></S_MOA>"
         "    </G_SG50>"
         "  </M_INVOIC>"
         "</Invoice>"
@@ -49,7 +49,7 @@ def test_build_header_totals_fills_missing_net(tmp_path: Path) -> None:
     p = tmp_path / "inv.xml"
     p.write_text(xml)
     totals = _build_header_totals(p, Decimal("0"))
-    assert totals["net"] == Decimal("10")
+    assert totals["net"] == Decimal("10.01")
     assert totals["vat"] == Decimal("2.20")
-    assert totals["gross"] == Decimal("12.20")
+    assert totals["gross"] == Decimal("12.206")
 

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -7,7 +7,7 @@ shranjevanje zgodovine cen, ipd.
 from __future__ import annotations
 
 from pathlib import Path
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 import os
 import re
 from typing import Tuple, Union, List, Dict
@@ -127,6 +127,7 @@ def _build_header_totals(
                 extract_header_net,
                 extract_total_tax,
                 extract_header_gross,
+                DEC2,
             )
 
             net = extract_header_net(invoice_path)
@@ -134,7 +135,7 @@ def _build_header_totals(
             gross = extract_header_gross(invoice_path)
 
             if net == 0 and vat != 0 and gross != 0:
-                net = gross - vat
+                net = (gross - vat).quantize(DEC2, ROUND_HALF_UP)
 
             totals = {"net": net, "vat": vat, "gross": gross}
         except Exception as exc:  # pragma: no cover - robust against IO


### PR DESCRIPTION
## Summary
- ensure `_build_header_totals` rounds the `net` fallback value using the DEC2 constant
- adjust tests to cover net rounding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879012a0cb08321b44ad4134f7f3550