### PR TITLE
Add logging for header totals debug

### DIFF
--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -141,6 +141,13 @@ def _build_header_totals(
         except Exception as exc:  # pragma: no cover - robust against IO
             log.warning(f"Napaka pri branju zneskov glave: {exc}")
 
+    log.debug(
+        "HEADER  %s  ⇒  net=%s  vat=%s  gross=%s",
+        invoice_path,
+        totals["net"],
+        totals["vat"],
+        totals["gross"],
+    )
     return totals
 
 


### PR DESCRIPTION
## Summary
- log computed header totals in `_build_header_totals`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687946a94098832182fc51591f0609f8