### PR TITLE
Handle missing VAT or gross in header totals

### DIFF
--- a/tests/test_build_header_totals.py
+++ b/tests/test_build_header_totals.py
@@ -9,13 +9,16 @@ def test_build_header_totals_extracts(tmp_path: Path) -> None:
         "<Invoice xmlns='urn:eslog:2.00'>"
         "  <M_INVOIC>"
         "    <G_SG50>"
-        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025>"
+        "<D_5004>10</D_5004></C_C516></S_MOA>"
         "    </G_SG50>"
         "    <G_SG52>"
-        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>2</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025>"
+        "<D_5004>2</D_5004></C_C516></S_MOA>"
         "    </G_SG52>"
         "    <G_SG50>"
-        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>12</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025>"
+        "<D_5004>12</D_5004></C_C516></S_MOA>"
         "    </G_SG50>"
         "  </M_INVOIC>"
         "</Invoice>"
@@ -35,13 +38,16 @@ def test_build_header_totals_fills_missing_net(tmp_path: Path) -> None:
         "<Invoice xmlns='urn:eslog:2.00'>"
         "  <M_INVOIC>"
         "    <G_SG50>"
-        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>0</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025>"
+        "<D_5004>0</D_5004></C_C516></S_MOA>"
         "    </G_SG50>"
         "    <G_SG52>"
-        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>2.20</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025>"
+        "<D_5004>2.20</D_5004></C_C516></S_MOA>"
         "    </G_SG52>"
         "    <G_SG50>"
-        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>12.206</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025>"
+        "<D_5004>12.206</D_5004></C_C516></S_MOA>"
         "    </G_SG50>"
         "  </M_INVOIC>"
         "</Invoice>"
@@ -53,3 +59,56 @@ def test_build_header_totals_fills_missing_net(tmp_path: Path) -> None:
     assert totals["vat"] == Decimal("2.20")
     assert totals["gross"] == Decimal("12.206")
 
+
+def test_build_header_totals_fills_missing_gross(tmp_path: Path) -> None:
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025>"
+        "<D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025>"
+        "<D_5004>2</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025>"
+        "<D_5004>0</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    p = tmp_path / "inv.xml"
+    p.write_text(xml)
+    totals = _build_header_totals(p, Decimal("0"))
+    assert totals["net"] == Decimal("10")
+    assert totals["vat"] == Decimal("2")
+    assert totals["gross"] == Decimal("12")
+
+
+def test_build_header_totals_fills_missing_vat(tmp_path: Path) -> None:
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025>"
+        "<D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025>"
+        "<D_5004>0</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025>"
+        "<D_5004>12</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    p = tmp_path / "inv.xml"
+    p.write_text(xml)
+    totals = _build_header_totals(p, Decimal("0"))
+    assert totals["net"] == Decimal("10")
+    assert totals["vat"] == Decimal("2")
+    assert totals["gross"] == Decimal("12")

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -119,7 +119,11 @@ def _build_header_totals(
     amount and VAT defaults to ``0``.
     """
 
-    totals = {"net": invoice_total, "vat": Decimal("0"), "gross": invoice_total}
+    totals = {
+        "net": invoice_total,
+        "vat": Decimal("0"),
+        "gross": invoice_total,
+    }
 
     if invoice_path and invoice_path.suffix.lower() == ".xml":
         try:
@@ -136,6 +140,12 @@ def _build_header_totals(
 
             if net == 0 and vat != 0 and gross != 0:
                 net = (gross - vat).quantize(DEC2, ROUND_HALF_UP)
+
+            if gross == 0 and net != 0 and vat != 0:
+                gross = (net + vat).quantize(DEC2, ROUND_HALF_UP)
+
+            if vat == 0 and net != 0 and gross != 0:
+                vat = (gross - net).quantize(DEC2, ROUND_HALF_UP)
 
             totals = {"net": net, "vat": vat, "gross": gross}
         except Exception as exc:  # pragma: no cover - robust against IO


### PR DESCRIPTION
## Summary
- compute gross when missing using net+vat
- compute VAT when missing using gross-net
- keep net correction logic
- add tests for missing gross and VAT cases

## Testing
- `pre-commit run --files wsm/utils.py tests/test_build_header_totals.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879f4e27f008321ae2bcbd8b4127f3c