### PR TITLE
Fix header total net assignment

### DIFF
--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -151,6 +151,8 @@ def _build_header_totals(
         except Exception as exc:  # pragma: no cover - robust against IO
             log.warning(f"Napaka pri branju zneskov glave: {exc}")
 
+    invoice_total = totals["net"]
+
     log.debug(
         "HEADER  %s  ⇒  net=%s  vat=%s  gross=%s",
         invoice_path,


### PR DESCRIPTION
## Summary
- set `invoice_total` to computed `net` inside `_build_header_totals`
- ensure invoice callers continue to use returned net total

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879fa0bbb7c8321b29bb8c430bc1982