### PR TITLE
Fix totals calculation and update GUI text

### DIFF
--- a/wsm/ui_qt/review_links_qt.py
+++ b/wsm/ui_qt/review_links_qt.py
@@ -285,11 +285,10 @@ def review_links_qt(
             "✓" if abs(total_sum - header_totals["net"]) <= step_total else "✗"
         )
         text = (
-            f"Skupaj povezano: {_fmt(linked_total)} € + "
-            f"Skupaj ostalo: {_fmt(unlinked_total)} € = "
-            f"Skupni seštevek: {_fmt(total_sum)} € | "
-            "Skupna vrednost računa: "
-            f"{_fmt(header_totals['net'])} € {match_symbol}"
+            f"Skupaj povezano: {_fmt(linked_total)} €  |  "
+            f"Skupaj ostalo: {_fmt(unlinked_total)} €  |  "
+            f"Skupni seštevek: {_fmt(total_sum)} €  |  "
+            f"Skupna vrednost računa: {_fmt(header_totals['net'])} € {match_symbol}"  # noqa: E501
         )
         total_label.setText(text)
 


### PR DESCRIPTION
## Summary
- refine `_split_totals` for ignored rows and safe decimal math
- present totals in GUI with clearer separators

## Testing
- `pre-commit run --files wsm/ui/review/helpers.py wsm/ui_qt/review_links_qt.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a42a2166c8321980e82608276529a