### PR TITLE
Handle dir creation failures in open_invoice_gui

### DIFF
--- a/tests/test_open_invoice_gui.py
+++ b/tests/test_open_invoice_gui.py
@@ -1,0 +1,52 @@
+import pandas as pd
+from decimal import Decimal
+from pathlib import Path
+
+from wsm.ui.common import open_invoice_gui
+
+
+def test_open_invoice_gui_handles_base_dir_error(monkeypatch, tmp_path):
+    invoice = tmp_path / "inv.xml"
+    invoice.write_text("<xml/>")
+
+    suppliers_dir = tmp_path / "links"
+
+    def fake_analyze(inv, suppliers_file):
+        df = pd.DataFrame(
+            {
+                "sifra_dobavitelja": ["SUP"],
+                "naziv": ["Item"],
+                "kolicina": [Decimal("1")],
+                "enota": ["kos"],
+                "vrednost": [Decimal("1")],
+                "rabata": [Decimal("0")],
+            }
+        )
+        return df, Decimal("1"), True
+
+    monkeypatch.setattr("wsm.ui.common.analyze_invoice", fake_analyze)
+    monkeypatch.setattr(
+        "wsm.ui.common.pd.read_excel", lambda *a, **k: pd.DataFrame()
+    )
+    monkeypatch.setattr("wsm.ui.common.review_links", lambda *a, **k: None)
+    monkeypatch.setattr("wsm.utils.povezi_z_wsm", lambda df, *a, **k: df)
+    monkeypatch.setattr("wsm.utils.main_supplier_code", lambda df: "SUP")
+    monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Unknown")
+    monkeypatch.setattr("wsm.ui.common._load_supplier_map", lambda p: {})
+    monkeypatch.setattr("tkinter.messagebox.showwarning", lambda *a, **k: None)
+
+    captured = {}
+
+    def fake_showerror(title, msg):
+        captured["msg"] = msg
+
+    monkeypatch.setattr("tkinter.messagebox.showerror", fake_showerror)
+
+    def raise_error(self, *a, **k):
+        raise FileNotFoundError("cannot create")
+
+    monkeypatch.setattr(Path, "mkdir", raise_error)
+
+    open_invoice_gui(invoice_path=invoice, suppliers=suppliers_dir)
+
+    assert "ni mogo\u010de ustvariti" in captured["msg"]

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -101,7 +101,14 @@ def open_invoice_gui(
 
     key = choose_supplier_key(vat_id, supplier_code)
     base_dir = Path(suppliers)
-    base_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        base_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        messagebox.showerror(
+            "Napaka",
+            f"Mapa {base_dir} ni dosegljiva oziroma je ni mogoče ustvariti.",
+        )
+        return
     if not key:
         messagebox.showwarning(
             "Opozorilo",


### PR DESCRIPTION
## Summary
- handle `Path.mkdir` failures when creating links directory
- test that open_invoice_gui shows an error if its base directory can't be created

## Testing
- `pytest tests/test_use_existing_folder.py tests/test_cli_env.py tests/test_open_invoice_gui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887659485d883219cebff39e2a1a0c2