### PR TITLE
Update totals splitting to return VAT info

### DIFF
--- a/tests/test_gratis_total.py
+++ b/tests/test_gratis_total.py
@@ -16,9 +16,11 @@ def _calc_totals(xml_path: Path):
     df["wsm_sifra"] = pd.NA
     df.loc[df["naziv"] == "Normal", "wsm_sifra"] = "X"
 
-    linked_total, unlinked_total, _ = _split_totals(df, doc_discount_total)
+    net, vat, gross = _split_totals(
+        df, doc_discount_total, vat_rate=Decimal("0")
+    )
     assert ok
-    return linked_total, unlinked_total
+    return net, vat, gross
 
 
 def test_gratis_line_excluded_from_totals(tmp_path):
@@ -52,6 +54,7 @@ def test_gratis_line_excluded_from_totals(tmp_path):
     xml_path = tmp_path / "gratis.xml"
     xml_path.write_text(xml)
 
-    linked, unlinked = _calc_totals(xml_path)
-    assert linked == Decimal("10")
-    assert unlinked == Decimal("0")
+    net, vat, gross = _calc_totals(xml_path)
+    assert net == Decimal("10")
+    assert vat == Decimal("0")
+    assert gross == net

--- a/tests/test_split_totals_doc_discount.py
+++ b/tests/test_split_totals_doc_discount.py
@@ -22,16 +22,16 @@ def test_split_totals_linked_discount():
     path = Path("tests/minimal_doc_discount.xml")
     df, disc, header = _prepare(path)
     df.loc[0, "wsm_sifra"] = "X"
-    linked, unlinked, total = _split_totals(df, disc)
-    assert total == header
-    assert linked == df.loc[0, "total_net"] + disc
-    assert unlinked == Decimal("0")
+    net, vat, gross = _split_totals(df, disc, vat_rate=Decimal("0"))
+    assert net == header
+    assert vat == Decimal("0")
+    assert gross == net
 
 
 def test_split_totals_unlinked_discount():
     path = Path("tests/minimal_doc_discount.xml")
     df, disc, header = _prepare(path)
-    linked, unlinked, total = _split_totals(df, disc)
-    assert total == header
-    assert linked == Decimal("0")
-    assert unlinked == df["total_net"].sum() + disc
+    net, vat, gross = _split_totals(df, disc, vat_rate=Decimal("0"))
+    assert net == header
+    assert vat == Decimal("0")
+    assert gross == net

--- a/tests/test_split_totals_no_doc_row.py
+++ b/tests/test_split_totals_no_doc_row.py
@@ -23,18 +23,17 @@ def test_split_totals_matches_header_without_doc_row():
     df, disc, header = _prepare(path)
     assert disc == Decimal("0")
     df.loc[0, "wsm_sifra"] = "X"
-    linked, unlinked, total = _split_totals(df, disc)
-    assert linked == df["total_net"].sum()
-    assert unlinked == Decimal("0")
-    assert total == header
+    net, vat, gross = _split_totals(df, disc, vat_rate=Decimal("0"))
+    assert net == df["total_net"].sum()
+    assert vat == Decimal("0")
+    assert gross == header
 
 
 def test_split_totals_matches_header_with_doc_row():
     path = Path("tests/minimal_doc_discount.xml")
     df, disc, header = _prepare(path)
     df.loc[0, "wsm_sifra"] = "X"
-    linked, unlinked, total = _split_totals(df, disc)
-    assert (df["total_net"].sum() + disc).quantize(Decimal("0.01")) == header
-    assert linked == df.loc[0, "total_net"] + disc
-    assert unlinked == Decimal("0")
-    assert total == header
+    net, vat, gross = _split_totals(df, disc, vat_rate=Decimal("0"))
+    assert (df["total_net"].sum() + disc).quantize(Decimal("0.01")) == net
+    assert vat == Decimal("0")
+    assert gross == net

--- a/tests/test_split_totals_vat.py
+++ b/tests/test_split_totals_vat.py
@@ -1,0 +1,15 @@
+from decimal import Decimal
+import pandas as pd
+from wsm.ui.review.helpers import _split_totals
+
+
+def test_split_totals_vat_calculation():
+    df = pd.DataFrame({"wsm_sifra": ["X"], "total_net": [Decimal("100")]})
+    net, vat, gross = _split_totals(
+        df, Decimal("0"), vat_rate=Decimal("0.095")
+    )
+    assert (net, vat, gross) == (
+        Decimal("100"),
+        Decimal("9.5"),
+        Decimal("109.5"),
+    )

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -598,18 +598,26 @@ def review_links(
     total_frame = tk.Frame(root)
     total_frame.pack(fill="x", pady=5)
 
-    linked_total, unlinked_total, total_sum = _split_totals(
-        df, doc_discount_total
+    vat_rate = (
+        header_totals["vat"] / header_totals["net"]
+        if header_totals["net"]
+        else Decimal("0")
+    )
+    net_total, vat_total, gross_total = _split_totals(
+        df, doc_discount_total, vat_rate
     )
     match_symbol = (
         "✓"
-        if abs(total_sum - header_totals["net"]) <= Decimal("0.02")
+        if abs(net_total - header_totals["net"]) <= Decimal("0.02")
         else "✗"
     )
 
     tk.Label(
         total_frame,
-        text=f"Skupaj povezano: {_fmt(linked_total)} € + Skupaj ostalo: {_fmt(unlinked_total)} € = Skupni seštevek: {_fmt(total_sum)} € | Skupna vrednost računa: {_fmt(header_totals['net'])} € {match_symbol}",
+        text=(
+            f"Neto: {_fmt(net_total)} € | DDV: {_fmt(vat_total)} € | Bruto: {_fmt(gross_total)} € | "
+            f"Skupna vrednost računa: {_fmt(header_totals['net'])} € {match_symbol}"
+        ),
         font=("Arial", 10, "bold"),
         name="total_sum",
     ).pack(side="left", padx=10)
@@ -646,16 +654,21 @@ def review_links(
                 ),
             )
 
-        linked_total, unlinked_total, total_sum = _split_totals(
-            df, dd_total if not df_doc.empty else Decimal("0")
+        vat_rate = (
+            header_totals["vat"] / header_totals["net"]
+            if header_totals["net"]
+            else Decimal("0")
+        )
+        net_total, vat_total, gross_total = _split_totals(
+            df, dd_total if not df_doc.empty else Decimal("0"), vat_rate
         )
         match_symbol = (
-            "✓" if abs(total_sum - inv_total) <= Decimal("0.02") else "✗"
+            "✓" if abs(net_total - inv_total) <= Decimal("0.02") else "✗"
         )
         total_frame.children["total_sum"].config(
             text=(
-                f"Skupaj povezano: {_fmt(linked_total)} € + Skupaj ostalo: {_fmt(unlinked_total)} € = "
-                f"Skupni seštevek: {_fmt(total_sum)} € | Skupna vrednost računa: {_fmt(inv_total)} € {match_symbol}"
+                f"Neto: {_fmt(net_total)} € | DDV: {_fmt(vat_total)} € | Bruto: {_fmt(gross_total)} € | "
+                f"Skupna vrednost računa: {_fmt(inv_total)} € {match_symbol}"
             )
         )
 

--- a/wsm/ui_qt/review_links_qt.py
+++ b/wsm/ui_qt/review_links_qt.py
@@ -277,17 +277,22 @@ def review_links_qt(
                         r_i, c_i, QtWidgets.QTableWidgetItem(str(v))
                     )
 
-        linked_total, unlinked_total, total_sum = _split_totals(
-            df, doc_discount_total
+        vat_rate = (
+            header_totals["vat"] / header_totals["net"]
+            if header_totals["net"]
+            else Decimal("0")
         )
-        step_total = detect_round_step(header_totals["net"], total_sum)
+        net_total, vat_total, gross_total = _split_totals(
+            df, doc_discount_total, vat_rate
+        )
+        step_total = detect_round_step(header_totals["net"], net_total)
         match_symbol = (
-            "✓" if abs(total_sum - header_totals["net"]) <= step_total else "✗"
+            "✓" if abs(net_total - header_totals["net"]) <= step_total else "✗"
         )
         text = (
-            f"Skupaj povezano: {_fmt(linked_total)} €  |  "
-            f"Skupaj ostalo: {_fmt(unlinked_total)} €  |  "
-            f"Skupni seštevek: {_fmt(total_sum)} €  |  "
+            f"Neto: {_fmt(net_total)} €  |  "
+            f"DDV: {_fmt(vat_total)} €  |  "
+            f"Bruto: {_fmt(gross_total)} €  |  "
             f"Skupna vrednost računa: {_fmt(header_totals['net'])} € {match_symbol}"  # noqa: E501
         )
         total_label.setText(text)


### PR DESCRIPTION
## Summary
- modify `_split_totals` to return `(net, vat, gross)`
- adapt GUI helpers to display new totals
- adjust Qt version to match
- update tests for new API and add VAT test

## Testing
- `black wsm/ui/review/helpers.py wsm/ui/review/gui.py wsm/ui_qt/review_links_qt.py tests/test_split_totals_doc_discount.py tests/test_split_totals_no_doc_row.py tests/test_gratis_total.py tests/test_split_totals_vat.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b61e593ec8321a788e825ce35c227