### PR TITLE
Improve totals display

### DIFF
--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -1,0 +1,64 @@
+import inspect
+import textwrap
+from decimal import Decimal
+
+import pandas as pd
+
+import wsm.ui.review.gui as rl
+from wsm.parsing.money import detect_round_step
+
+
+class DummyLabel:
+    def __init__(self):
+        self.text = ""
+
+    def config(self, *, text):
+        self.text = text
+
+
+class DummyMsgBox:
+    @staticmethod
+    def showwarning(*args, **kwargs):
+        pass
+
+
+class DummyFrame:
+    def __init__(self, child):
+        self.children = {"total_sum": child}
+
+
+def _extract_update_func():
+    src = inspect.getsource(rl.review_links).splitlines()
+    start = next(i for i, l in enumerate(src) if "def _update_totals" in l)
+    end = next(
+        i
+        for i in range(start + 1, len(src))
+        if src[i].lstrip().startswith("bottom =")
+    )
+    return textwrap.dedent("\n".join(src[start:end]))
+
+
+def test_totals_label_contains_terms():
+    snippet = _extract_update_func()
+    lbl = DummyLabel()
+    df = pd.DataFrame({"total_net": [Decimal("10")], "wsm_sifra": ["A"]})
+    df_doc = pd.DataFrame()
+    ns = {
+        "Decimal": Decimal,
+        "df": df,
+        "df_doc": df_doc,
+        "doc_discount_total": Decimal("0"),
+        "header_totals": {
+            "net": Decimal("10"),
+            "vat": Decimal("2"),
+            "gross": Decimal("12"),
+        },
+        "detect_round_step": detect_round_step,
+        "_split_totals": rl._split_totals,
+        "messagebox": DummyMsgBox,
+        "total_frame": DummyFrame(lbl),
+    }
+    exec(snippet, ns)
+    ns["_update_totals"]()
+    assert "DDV:" in lbl.text
+    assert "Skupaj:" in lbl.text

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -606,21 +606,19 @@ def review_links(
     net_total, vat_total, gross_total = _split_totals(
         df, doc_discount_total, vat_rate
     )
-    match_symbol = (
-        "✓"
-        if abs(net_total - header_totals["net"]) <= Decimal("0.02")
-        else "✗"
-    )
 
-    tk.Label(
+    lbl_totals = tk.Label(
         total_frame,
         text=(
-            f"Neto: {_fmt(net_total)} € | DDV: {_fmt(vat_total)} € | Bruto: {_fmt(gross_total)} € | "
-            f"Skupna vrednost računa: {_fmt(header_totals['net'])} € {match_symbol}"
+            f"Neto:   {net_total:,.2f} €\n"
+            f"DDV:    {vat_total:,.2f} €\n"
+            f"Skupaj: {gross_total:,.2f} €"
         ),
         font=("Arial", 10, "bold"),
         name="total_sum",
-    ).pack(side="left", padx=10)
+        justify="left",
+    )
+    lbl_totals.pack(side="left", padx=10)
 
     def _update_totals():
         line_total_raw = df["total_net"].sum()
@@ -659,16 +657,14 @@ def review_links(
             if header_totals["net"]
             else Decimal("0")
         )
-        net_total, vat_total, gross_total = _split_totals(
+        net, vat, gross = _split_totals(
             df, dd_total if not df_doc.empty else Decimal("0"), vat_rate
-        )
-        match_symbol = (
-            "✓" if abs(net_total - inv_total) <= Decimal("0.02") else "✗"
         )
         total_frame.children["total_sum"].config(
             text=(
-                f"Neto: {_fmt(net_total)} € | DDV: {_fmt(vat_total)} € | Bruto: {_fmt(gross_total)} € | "
-                f"Skupna vrednost računa: {_fmt(inv_total)} € {match_symbol}"
+                f"Neto:   {net:,.2f} €\n"
+                f"DDV:    {vat:,.2f} €\n"
+                f"Skupaj: {gross:,.2f} €"
             )
         )
 

--- a/wsm/ui_qt/review_links_qt.py
+++ b/wsm/ui_qt/review_links_qt.py
@@ -282,20 +282,12 @@ def review_links_qt(
             if header_totals["net"]
             else Decimal("0")
         )
-        net_total, vat_total, gross_total = _split_totals(
-            df, doc_discount_total, vat_rate
+        net, vat, gross = _split_totals(df, doc_discount_total, vat_rate)
+        total_label.setText(
+            f"Neto:   {net:,.2f} €\n"
+            f"DDV:    {vat:,.2f} €\n"
+            f"Skupaj: {gross:,.2f} €"
         )
-        step_total = detect_round_step(header_totals["net"], net_total)
-        match_symbol = (
-            "✓" if abs(net_total - header_totals["net"]) <= step_total else "✗"
-        )
-        text = (
-            f"Neto: {_fmt(net_total)} €  |  "
-            f"DDV: {_fmt(vat_total)} €  |  "
-            f"Bruto: {_fmt(gross_total)} €  |  "
-            f"Skupna vrednost računa: {_fmt(header_totals['net'])} € {match_symbol}"  # noqa: E501
-        )
-        total_label.setText(text)
 
     update_summary()
 


### PR DESCRIPTION
## Summary
- show totals vertically in Tk GUI
- adjust totals label in Qt GUI
- test that totals label includes DDV and Skupaj

## Testing
- `flake8`
- `pytest tests/test_totals.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688b640281bc8321b3c214ad22008c38