### PR TITLE
Add AVG_COST_SKIP_ZERO docs and expand linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,2 @@
 [flake8]
 max-line-length = 79
-filename = tests/test_cli_env.py, tests/test_analyze_invoice.py, wsm/cli.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ﻿SHELL := /bin/bash
 
-.PHONY: sync deps test run
+.PHONY: sync deps test validate run
 
 # 1) Sinhronizacija z GitHub (če obstaja .git mape)
 sync:
@@ -19,8 +19,12 @@ if [ -f "wsm_program_vnasanje/requirements.txt" ] ; then \
   pip install -r wsm_program_vnasanje/requirements.txt ; \
 fi
 
-# 3) Zagon validacije
+# 3) Zagon unit testov
 test:
+pytest -q
+
+# Dodatna validacija
+validate:
 python -m wsm validate tests
 
 # 4) Celoten “pipeline” (sync → deps → test)

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ pre-commit install  # opcijsko
 
 Če je nastavljen `pre-commit`, se oba orodja zaženeta ob vsakem commitu.
 
+### Okoljske spremenljivke
+
+- `AVG_COST_SKIP_ZERO` — when set to `1` (default `0`) the helper
+  `wsm.utils.average_cost` skips zero-price invoice lines while computing
+  the average.
+
 ## Možne izboljšave
 
 - **Izboljšano samodejno povezovanje**: poleg iskanja po ključnih besedah bi lahko uporabili knjižnice za "bližnje ujemanje" (npr. `rapidfuzz`), ali pa vektorsko iskanje, kot nakazuje mapa `wsm_vector_embedding`. Tako bi sistem lažje našel ustrezno WSM šifro tudi pri rahlo različnih nazivih artiklov.

--- a/build_and_test.ps1
+++ b/build_and_test.ps1
@@ -20,5 +20,5 @@ if (Test-Path "wsm_program_vnasanje\requirements.txt") {
     pip install -r wsm_program_vnasanje\requirements.txt
 }
 
-Write-Host "► Zagon validacije"
-python -m wsm validate tests
+Write-Host "► Zagon testov"
+pytest -q

--- a/wsm/ui/review/io.py
+++ b/wsm/ui/review/io.py
@@ -28,7 +28,25 @@ def _update_supplier_info(
     sup_file: Path,
     vat: str | None,
 ) -> tuple[Path, Path]:
-    """Return updated links file path and supplier folder."""
+    """Update supplier details and rename folders if needed.
+
+    Args:
+        df: Invoice lines with supplier columns.
+        links_file: Excel file with manual mappings.
+        supplier_name: Name of the supplier from the invoice.
+        supplier_code: Supplier code from the invoice.
+        sup_map: Dictionary loaded from ``supplier.json``.
+        sup_file: Directory containing supplier folders.
+        vat: VAT number if available.
+
+    Returns:
+        Tuple containing the updated ``links_file`` path and the supplier
+        folder.
+
+    Side effects:
+        - Renames or moves folders on disk.
+        - Updates ``supplier.json`` and logs warnings.
+    """
 
     df["sifra_dobavitelja"] = df["sifra_dobavitelja"].fillna("").astype(str)
     empty_sifra = df["sifra_dobavitelja"] == ""
@@ -160,7 +178,16 @@ def _write_excel_links(
     manual_old: pd.DataFrame,
     links_file: Path,
 ) -> None:
-    """Write updated mappings to ``links_file``."""
+    """Persist manual links to an Excel file.
+
+    Args:
+        df: DataFrame with updated links from the GUI.
+        manual_old: DataFrame loaded from the existing ``links_file``.
+        links_file: Target Excel file for writing mappings.
+
+    Side effects:
+        Overwrites ``links_file`` with merged data and logs progress.
+    """
 
     if not manual_old.empty:
         manual_old = manual_old.dropna(
@@ -242,7 +269,23 @@ def _write_history_files(
     sup_file: Path,
     root,
 ) -> bool:
-    """Record price history and clean temporary files."""
+    """Save price history for an invoice.
+
+    Args:
+        df: Processed invoice DataFrame.
+        invoice_path: Original XML or PDF invoice.
+        new_folder: Directory where supplier files are stored.
+        links_file: Excel file with manual mappings.
+        sup_file: Base directory with supplier subfolders.
+        root: Tkinter root widget used for message boxes.
+
+    Returns:
+        ``True`` if the user aborted due to a duplicate invoice, otherwise
+        ``False``.
+
+    Side effects:
+        Writes to ``price_history.xlsx`` and may remove temporary folders.
+    """
 
     invoice_hash = None
     if invoice_path and invoice_path.suffix.lower() == ".xml":


### PR DESCRIPTION
## Summary
- document `AVG_COST_SKIP_ZERO` env var in README
- run flake8 over all sources
- call `pytest -q` from Makefile and PS script
- document review I/O helpers

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c6deee7b4832183e25221f14339cf