### PR TITLE
Update Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,31 @@
-﻿SHELL := /bin/bash
+SHELL := /bin/bash
 
-.PHONY: sync deps test run
+.PHONY: sync deps test validate run
 
 # 1) Sinhronizacija z GitHub (če obstaja .git mape)
 sync:
-if [ -d ".git" ] ; then \
-  echo "► git pull origin main" ; \
-  git pull origin main ; \
-else \
-  echo "► .git ni, preskočujem pull" ; \
-fi
+	if [ -d ".git" ] ; then \
+	echo "► git pull origin main" ; \
+	git pull origin main ; \
+	else \
+	echo "► .git ni, preskočujem pull" ; \
+	fi
 
 # 2) Namestitev odvisnosti
 deps:
-pip install --upgrade pip
-pip install -r requirements.txt
-if [ -f "wsm_program_vnasanje/requirements.txt" ] ; then \
-  pip install -r wsm_program_vnasanje/requirements.txt ; \
-fi
+	pip install --upgrade pip
+	pip install -r requirements.txt
+	if [ -f "wsm_program_vnasanje/requirements.txt" ] ; then \
+	pip install -r wsm_program_vnasanje/requirements.txt ; \
+	fi
 
-# 3) Zagon validacije
+# 3) Zagon testov
 test:
-python -m wsm validate tests
+	pytest -q
 
-# 4) Celoten “pipeline” (sync → deps → test)
+# 4) Validacija podatkov
+validate:
+	python -m wsm validate tests
+
+# 5) Celoten “pipeline” (sync → deps → test)
 run: sync deps test


### PR DESCRIPTION
## Summary
- remove UTF-8 BOM from `Makefile`
- switch `test` recipe to run `pytest -q`
- add a `validate` recipe
- ensure recipe commands are tab-indented

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c78780e5483218e26baf6464916e4