### PR TITLE
Switch validate target to pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 
 # 4) Validacija podatkov
 validate:
-	python -m wsm validate tests
+	pytest -q
 
 # 5) Celoten “pipeline” (sync → deps → test)
 run: sync deps test


### PR DESCRIPTION
## Summary
- use pytest for `validate` Makefile target

## Testing
- `make run`
- `make validate`

------
https://chatgpt.com/codex/tasks/task_e_688c86214b008321a81ec3f5889597bb