### PR TITLE
Improve testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ pip install -r requirements-dev.txt
 
 ### Poganjanje testov
 
-Pred zagonom `pytest` namestite pakete iz `requirements-dev.txt`:
+Pred zagonom `pytest` je **obvezno**, da namestite pakete iz
+`requirements-dev.txt`. Uporabite naslednje ukaze:
 
 ```bash
 pip install -r requirements-dev.txt


### PR DESCRIPTION
## Summary
- clarify that `requirements-dev.txt` *must* be installed before running `pytest`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c965b811c83218adc124d06dc6886