### PR TITLE
Improve helper docstrings

### DIFF
--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -26,7 +26,14 @@ PRICE_DIFF_THRESHOLD = (
 
 
 def _fmt(v) -> str:
-    """Human-friendly format števil (Decimal / float / int)."""
+    """Return a human-friendly representation of ``v``.
+
+    Args:
+        v: Numeric value convertible to :class:`~decimal.Decimal`.
+
+    Returns:
+        str: ``v`` formatted without trailing zeros.
+    """
     if v is None or (isinstance(v, float) and math.isnan(v)) or pd.isna(v):
         return ""
     d = v if isinstance(v, Decimal) else Decimal(str(v))
@@ -47,7 +54,14 @@ _rx_fraction = re.compile(r"(\d+(?:[.,]\d+)?)/1\b", re.I)
 
 
 def _dec(x: str) -> Decimal:
-    """Convert a comma-separated string to ``Decimal``."""
+    """Convert a comma-separated string to :class:`~decimal.Decimal`.
+
+    Args:
+        x (str): Numeric value using a comma as decimal separator.
+
+    Returns:
+        Decimal: Parsed numeric value.
+    """
     return Decimal(x.replace(",", "."))
 
 
@@ -58,7 +72,26 @@ def _norm_unit(
     vat_rate: Decimal | float | str | None = None,
     code: str | None = None,
 ) -> Tuple[Decimal, str]:
-    """Normalize quantity and unit to (kg / L / ``kos``)."""
+    """Normalize quantity and unit to ``kg``/``L``/``kos``.
+
+    Parameters
+    ----------
+    q : Decimal
+        Original quantity value.
+    u : str
+        Unit code or textual unit.
+    name : str
+        Item description used for unit detection.
+    vat_rate : Decimal | float | str | None, optional
+        VAT rate used for fallback heuristics.
+    code : str | None, optional
+        Supplier article code for weight lookup.
+
+    Returns
+    -------
+    tuple[Decimal, str]
+        ``(quantity, unit)`` in normalized form.
+    """
     log.debug(f"Normalizacija: q={q}, u={u}, name={name}")
     unit_map = {
         "KGM": ("kg", 1),

--- a/wsm/ui/review/io.py
+++ b/wsm/ui/review/io.py
@@ -28,7 +28,21 @@ def _update_supplier_info(
     sup_file: Path,
     vat: str | None,
 ) -> tuple[Path, Path]:
-    """Return updated links file path and supplier folder."""
+    """Update supplier metadata and return new file and folder paths.
+
+    Args:
+        df (pandas.DataFrame): Invoice rows with supplier codes.
+        links_file (pathlib.Path): Existing mapping file path.
+        supplier_name (str): Display name of the supplier.
+        supplier_code (str): Unique supplier identifier.
+        sup_map (dict): Mapping of supplier codes to info dictionaries.
+        sup_file (pathlib.Path): Directory containing per-supplier data.
+        vat (str | None): VAT number used when renaming folders.
+
+    Returns:
+        tuple[pathlib.Path, pathlib.Path]: Updated ``links_file`` path and
+        the supplier folder where it resides.
+    """
 
     df["sifra_dobavitelja"] = df["sifra_dobavitelja"].fillna("").astype(str)
     empty_sifra = df["sifra_dobavitelja"] == ""
@@ -160,7 +174,17 @@ def _write_excel_links(
     manual_old: pd.DataFrame,
     links_file: Path,
 ) -> None:
-    """Write updated mappings to ``links_file``."""
+    """Write updated mappings to ``links_file``.
+
+    Args:
+        df (pandas.DataFrame): Invoice lines to persist.
+        manual_old (pandas.DataFrame): Existing mappings read from
+            ``links_file``.
+        links_file (pathlib.Path): Destination Excel file.
+
+    Returns:
+        None
+    """
 
     if not manual_old.empty:
         manual_old = manual_old.dropna(
@@ -242,7 +266,21 @@ def _write_history_files(
     sup_file: Path,
     root,
 ) -> bool:
-    """Record price history and clean temporary files."""
+    """Record price history and clean temporary files.
+
+    Args:
+        df (pandas.DataFrame): Rows to log in the history file.
+        invoice_path (pathlib.Path | None): Original invoice for hash and
+            metadata extraction.
+        new_folder (pathlib.Path): Supplier folder containing history data.
+        links_file (pathlib.Path): Mapping file referenced in history logs.
+        sup_file (pathlib.Path): Directory containing supplier folders.
+        root: ``tkinter`` root used for prompts and closing.
+
+    Returns:
+        bool: ``True`` when the user opts to cancel due to a duplicate
+        invoice, ``False`` otherwise.
+    """
 
     invoice_hash = None
     if invoice_path and invoice_path.suffix.lower() == ".xml":


### PR DESCRIPTION
## Summary
- expand documentation for `_update_supplier_info`, `_write_excel_links` and `_write_history_files`
- document helper functions in `wsm/ui/review/helpers.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c9fce54ac8321b6930274d9530cea