### PR TITLE
Handle MOA search without namespace

### DIFF
--- a/tests/test_sum_moa_no_ns.py
+++ b/tests/test_sum_moa_no_ns.py
@@ -1,0 +1,24 @@
+from decimal import Decimal
+import xml.etree.ElementTree as ET
+
+from wsm.parsing.eslog import sum_moa
+
+
+def test_sum_moa_handles_groups_without_namespace():
+    xml = (
+        "<Invoice>"
+        "  <M_INVOIC>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>204</D_5025>"
+        "        <D_5004>1.50</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG20>"
+        "      <S_MOA><C_C516><D_5025>204</D_5025>"
+        "        <D_5004>2.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG20>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    root = ET.fromstring(xml)
+    total = sum_moa(root, ["204"])
+    assert total == Decimal("3.50")


### PR DESCRIPTION
## Summary
- extend `sum_moa` to search G_SG50 and G_SG20 groups regardless of namespace
- document non-namespaced support for `sum_moa`
- add regression test for MOA detection in XML without namespace

## Testing
- `pre-commit run --files wsm/parsing/eslog.py tests/test_sum_moa_no_ns.py`
- `pytest tests/test_sum_moa_no_ns.py tests/test_parse_eslog_document_discount.py::test_parse_eslog_invoice_handles_sg20_level_discount tests/test_parse_eslog_document_discount.py::test_parse_eslog_invoice_handles_sg16_level_discount -q`


------
https://chatgpt.com/codex/tasks/task_e_6890714ded888321b988d12557658426