### PR TITLE
Filter document discount rows and ignore charges

### DIFF
--- a/tests/test_parse_eslog_document_charge.py
+++ b/tests/test_parse_eslog_document_charge.py
@@ -1,13 +1,17 @@
 from decimal import Decimal
 from pathlib import Path
-from wsm.parsing.eslog import parse_eslog_invoice, extract_header_net
+from wsm.parsing.eslog import (
+    parse_eslog_invoice,
+    parse_invoice,
+    extract_header_net,
+)
 
 
 def test_parse_eslog_invoice_handles_doc_charge():
     xml_path = Path("tests/minimal_doc_charge.xml")
     df, ok = parse_eslog_invoice(xml_path)
 
-    charge_rows = df[df["sifra_dobavitelja"] == "_DOC_CHARGE_"]
+    charge_rows = df[df["sifra_dobavitelja"] == "DOC_CHG"]
     assert not charge_rows.empty
     charge_value = charge_rows.iloc[0]["vrednost"]
 
@@ -17,3 +21,7 @@ def test_parse_eslog_invoice_handles_doc_charge():
     assert charge_value == Decimal("1")
     assert lines_total == header_total
     assert ok
+
+    # parse_invoice should ignore document charges when computing discounts
+    _, _, discount_total = parse_invoice(xml_path)
+    assert discount_total == Decimal("0.00")


### PR DESCRIPTION
## Summary
- Collect document-level discounts and charges via `sum_moa` and record charges as `DOC_CHG`
- Filter `_DOC_` rows by negative value when calculating invoice discounts and fall back to MOA summing
- Extend document discount codes and test that `DOC_CHG` rows don't affect discounts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907e30ba5c83218a28c7a4b20e5d15