### PR TITLE
Adjust header net for doc discounts and charges

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -655,9 +655,7 @@ def review_links(
             else Decimal(str(header_totals["net"]))
         )
 
-        calc_total = line_total + (
-            dd_total if not df_doc.empty else Decimal("0")
-        )
+        calc_total = line_total
         diff = inv_total - calc_total
         step = detect_round_step(inv_total, calc_total)
         if abs(diff) > step:


### PR DESCRIPTION
## Summary
- Include document-level allowances and charges when computing header net totals
- Compare invoice line totals directly against header totals in review GUI

## Testing
- `pytest -q` *(fails: 11 failed, 166 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6890a3337ee08321b6119b41f729a6a2