### PR TITLE
Avoid reapplying document discount when updating totals

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -644,20 +644,13 @@ def review_links(
             if isinstance(line_total_raw, Decimal)
             else Decimal(str(line_total_raw))
         )
-        dd_total = (
-            doc_discount_total
-            if isinstance(doc_discount_total, Decimal)
-            else Decimal(str(doc_discount_total))
-        )
         inv_total = (
             header_totals["net"]
             if isinstance(header_totals["net"], Decimal)
             else Decimal(str(header_totals["net"]))
         )
 
-        calc_total = line_total + (
-            dd_total if not df_doc.empty else Decimal("0")
-        )
+        calc_total = line_total + doc_discount_total
         diff = inv_total - calc_total
         step = detect_round_step(inv_total, calc_total)
         if abs(diff) > step:
@@ -674,9 +667,8 @@ def review_links(
             if header_totals["net"]
             else Decimal("0")
         )
-        net, vat, gross = _split_totals(
-            df, dd_total if not df_doc.empty else Decimal("0"), vat_rate
-        )
+        # _DOC_ rows were already removed from df; avoid re-applying the discount
+        net, vat, gross = _split_totals(df, Decimal("0"), vat_rate)
         total_frame.children["total_sum"].config(
             text=(
                 f"Neto:   {net:,.2f} €\n"


### PR DESCRIPTION
## Summary
- prevent `_update_totals` from applying document-level discount twice
- keep document discount only for diff calculation

## Testing
- `pytest`
- `pre-commit run --files wsm/ui/review/gui.py` *(flake8 skipped; file contains pre-existing long lines)*

------
https://chatgpt.com/codex/tasks/task_e_6891b245d040832197d2ecb62d3a3d6a