### PR TITLE
Add ddv to ESLOG invoice items

### DIFF
--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -1016,6 +1016,7 @@ def parse_eslog_invoice(
                         "rabata_pct": Decimal("0.00"),
                         "vrednost": amount,
                         "ddv_stopnja": vat_rate,
+                        "ddv": vat_amount,
                         "is_gratis": False,
                     }
                 )
@@ -1036,6 +1037,7 @@ def parse_eslog_invoice(
                 "rabata": doc_discount,
                 "rabata_pct": Decimal("100.00"),
                 "vrednost": -doc_discount,
+                "ddv": Decimal("0"),
                 "is_gratis": False,
             }
         )
@@ -1052,6 +1054,7 @@ def parse_eslog_invoice(
                 "rabata": Decimal("0"),
                 "rabata_pct": Decimal("0.00"),
                 "vrednost": doc_charge,
+                "ddv": Decimal("0"),
                 "is_gratis": False,
             }
         )


### PR DESCRIPTION
## Summary
- attach VAT amount to each ESLOG line item in `ddv` field
- populate `ddv` for allowance/charge and document-level rows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891d4b372ec832193a0e3ecc596d4a2