### PR TITLE
Ensure ddv field on parsed invoice lines

### DIFF
--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -959,6 +959,9 @@ def parse_eslog_invoice(
             }
         )
 
+        if "ddv" not in item:
+            item["ddv"] = Decimal("0")
+
         items.append(item)
 
         for ac in sg26.findall(".//e:AllowanceCharge", NS) + sg26.findall(


### PR DESCRIPTION
## Summary
- Guarantee `ddv` field exists on every line item before adding it to the invoice lines list, defaulting to `Decimal('0')` when missing.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891e44bae208321ad4cb407dade3100