### PR TITLE
Add calculate_vat helper for consistent VAT rounding

### DIFF
--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -30,6 +30,7 @@ from .utils import _normalize_date
 from wsm.parsing.money import (
     extract_total_amount,
     validate_invoice as validate_line_values,
+    calculate_vat,
 )
 
 XML_PARSER = LET.XMLParser(resolve_entities=False)
@@ -1021,9 +1022,7 @@ def parse_eslog_invoice(
                         tax_el = ac.find(".//TaxTotal/TaxAmount")
                 vat_amount = _decimal(tax_el)
                 if vat_amount == 0 and vat_rate != 0:
-                    vat_amount = (amount * vat_rate / Decimal("100")).quantize(
-                        Decimal("0.01"), ROUND_HALF_UP
-                    )
+                    vat_amount = calculate_vat(amount, vat_rate)
 
                 net_total = (net_total + amount).quantize(
                     Decimal("0.01"), ROUND_HALF_UP

--- a/wsm/parsing/money.py
+++ b/wsm/parsing/money.py
@@ -4,6 +4,15 @@ from lxml import etree as LET
 import pandas as pd
 
 
+def calculate_vat(base: Decimal, rate: Decimal) -> Decimal:
+    """Return VAT for ``base`` at ``rate`` percent.
+
+    The calculation multiplies ``base`` by ``rate`` and divides by 100,
+    rounding the result to 2 decimal places using ``ROUND_HALF_UP``.
+    """
+    return (base * rate / Decimal("100")).quantize(Decimal("0.01"), ROUND_HALF_UP)
+
+
 def round_to_step(
     value: Decimal, step: Decimal, rounding=ROUND_HALF_UP
 ) -> Decimal:


### PR DESCRIPTION
## Summary
- add `calculate_vat` utility for VAT amount calculation using ROUND_HALF_UP rounding
- use `calculate_vat` in `eslog` parser to replace inline VAT formula

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689307a03b20832196f6b8c3d71a2d06