### PR TITLE
Use ROUND_HALF_UP rounding in _split_totals

### DIFF
--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -4,7 +4,7 @@ import logging
 import math
 import os
 import re
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Tuple
 
 from wsm.constants import (
@@ -367,11 +367,11 @@ def _split_totals(
         rate = Decimal("0")
 
     vat = (
-        (net_amount * rate).quantize(Decimal("0.01"))
+        (net_amount * rate).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         if net_amount
         else Decimal("0")
     )
-    gross = (net_amount + vat).quantize(Decimal("0.01"))
+    gross = (net_amount + vat).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
     return net_amount, vat, gross
 


### PR DESCRIPTION
## Summary
- ensure VAT and gross totals are quantized with ROUND_HALF_UP
## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68930a2986548321b98b079705cb6449