### PR TITLE
Validate VAT amounts and expose mismatch

### DIFF
--- a/tests/test_vat_mismatch_flag.py
+++ b/tests/test_vat_mismatch_flag.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+
+from wsm.parsing.eslog import parse_eslog_invoice
+
+
+def test_parse_eslog_invoice_detects_vat_mismatch(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    xml = """
+<Invoice xmlns='urn:eslog:2.00'>
+  <M_INVOIC>
+    <G_SG26>
+      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>
+      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>
+      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>
+      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>
+      <S_MOA><C_C516><D_5025>38</D_5025><D_5004>10</D_5004></C_C516></S_MOA>
+      <G_SG34>
+        <S_TAX><C_C243><D_5278>22</D_5278></C_C243></S_TAX>
+        <S_MOA><C_C516><D_5025>124</D_5025><D_5004>3</D_5004></C_C516></S_MOA>
+      </G_SG34>
+    </G_SG26>
+    <G_SG50><S_MOA><C_C516><D_5025>389</D_5025><D_5004>10</D_5004></C_C516></S_MOA></G_SG50>
+    <G_SG50><S_MOA><C_C516><D_5025>9</D_5025><D_5004>13</D_5004></C_C516></S_MOA></G_SG50>
+  </M_INVOIC>
+</Invoice>
+"""
+    path = tmp_path / "vat_mismatch.xml"
+    path.write_text(xml, encoding="utf-8")
+    with caplog.at_level("ERROR"):
+        df, ok = parse_eslog_invoice(path)
+    assert ok
+    assert df.attrs.get("vat_mismatch")
+    assert any("VAT mismatch" in rec.message for rec in caplog.records)

--- a/wsm/analyze.py
+++ b/wsm/analyze.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from pathlib import Path
 from decimal import Decimal
+import logging
 import pandas as pd
 
 from wsm.parsing.eslog import parse_eslog_invoice
@@ -8,17 +9,38 @@ from wsm.ui.review.helpers import _norm_unit
 from wsm.parsing.eslog import extract_header_net
 from wsm.parsing.money import detect_round_step, round_to_step
 
+log = logging.getLogger(__name__)
+
 
 def analyze_invoice(
-    xml_path: str, suppliers_file: str | None = None
+    xml_path: str,
+    suppliers_file: str | None = None,
+    *,
+    raise_on_vat_mismatch: bool = False,
 ) -> tuple[pd.DataFrame, Decimal, bool]:
     """Parse, normalize and group an eSLOG invoice.
 
     Lines with the same product code (``sifra_artikla``) and equal discount
     percentage (``rabata_pct``) are merged together. The product name is kept
     from the first occurrence.
+
+    Parameters
+    ----------
+    xml_path:
+        Path to the invoice XML file.
+    suppliers_file:
+        Optional path to supplier definitions.
+    raise_on_vat_mismatch:
+        When ``True`` a :class:`ValueError` is raised if any line's VAT
+        ``TaxAmount`` differs from the value calculated from net amount and
+        rate.
     """
     df, grand_ok = parse_eslog_invoice(xml_path)
+    vat_mismatch = df.attrs.get("vat_mismatch", False)
+    if vat_mismatch:
+        log.error("VAT mismatch detected in invoice %s", xml_path)
+        if raise_on_vat_mismatch:
+            raise ValueError("VAT amount differs from calculated value")
 
     # normalize units
     df[["kolicina", "enota"]] = [
@@ -70,5 +92,5 @@ def analyze_invoice(
     raw_sum = Decimal(str(result["vrednost"].sum()))
     step = detect_round_step(header_total, raw_sum)
     line_sum = round_to_step(raw_sum, step)
-    ok = abs(line_sum - header_total) <= step and grand_ok
+    ok = abs(line_sum - header_total) <= step and grand_ok and not vat_mismatch
     return result, header_total, ok


### PR DESCRIPTION
## Summary
- log raw `cbc:TaxAmount` values and warn when missing
- recompute VAT for lines and charges and flag mismatches
- allow analysis to raise when XML `TaxAmount` differs from calculated VAT

## Testing
- `pre-commit run --files wsm/parsing/eslog.py wsm/analyze.py tests/test_vat_mismatch_flag.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68930db57a90832190b60619ce0e56c2