### PR TITLE
Log initial invoice DataFrame before filtering

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -59,6 +59,7 @@ def review_links(
         rows.
     """
     df = df.copy()
+    log.debug("Initial invoice DataFrame:\n%s", df.to_string())
     if {"cena_bruto", "cena_netto"}.issubset(df.columns):
         for idx, row in df.iterrows():
             log.info(


### PR DESCRIPTION
## Summary
- log initial invoice DataFrame in `review_links` to aid debugging of invoice lines

## Testing
- `pre-commit run --files wsm/ui/review/gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68931fe13c608321b6ada2191b93d2bb