### PR TITLE
Prioritize supplier VAT over GLN

### DIFF
--- a/tests/test_supplier_gln.py
+++ b/tests/test_supplier_gln.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from wsm.parsing.eslog import get_supplier_info
 
 
-def test_get_supplier_info_reads_sgln():
+def test_get_supplier_info_prefers_vat_over_gln():
     xml = Path("tests/vat_with_gln.xml")
     code, _ = get_supplier_info(xml)
-    assert code == "1234567890123"
+    assert code == "SI33333333"

--- a/tests/test_supplier_vat.py
+++ b/tests/test_supplier_vat.py
@@ -14,10 +14,10 @@ def test_get_supplier_info_vat_uses_se_when_su_missing():
     assert vat == "SI11111111"
 
 
-def test_get_supplier_info_returns_gln_when_available():
+def test_get_supplier_info_prefers_vat_over_gln():
     xml = Path("tests/PR5690-Slika1.XML")
     code, _ = get_supplier_info(xml)
-    assert code == "3830029809998"
+    assert code == "1121499"
 
 
 def test_get_supplier_info_uses_vat_when_no_gln():
@@ -30,3 +30,10 @@ def test_get_supplier_info_vat_handles_plain_rff():
     xml = Path("tests/Racun_st._25-24412.xml")
     _, _, vat = get_supplier_info_vat(xml)
     assert vat == "SI47083026"
+
+
+def test_get_supplier_info_vat_reads_ubl_vat():
+    xml = Path("tests/ubl_vat.xml")
+    code, _, vat = get_supplier_info_vat(xml)
+    assert vat == "SI99999999"
+    assert code == "SI99999999"

--- a/tests/ubl_vat.xml
+++ b/tests/ubl_vat.xml
@@ -1,0 +1,17 @@
+<Invoice xmlns="urn:eslog:2.00"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>UBL Supplier</cbc:Name>
+      </cac:PartyName>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">0000000000000</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="VAT">SI99999999</cbc:CompanyID>
+      </cac:PartyTaxScheme>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+</Invoice>


### PR DESCRIPTION
## Summary
- Prefer VAT identification when extracting supplier info, including UBL `PartyTaxScheme` lookups with debug logging
- Align supplier info helpers to return VAT ahead of GLN
- Add tests covering VAT-first behaviour and UBL-style VAT extraction

## Testing
- `pre-commit run --files wsm/parsing/eslog.py tests/test_supplier_vat.py tests/test_supplier_gln.py tests/ubl_vat.xml`
- `pytest tests/test_supplier_vat.py tests/test_supplier_gln.py tests/test_parse_eslog_supplier.py`


------
https://chatgpt.com/codex/tasks/task_e_6893363afe988321b61a010815c58480