### PR TITLE
Prefer VAT when resolving supplier code

### DIFF
--- a/tests/test_supplier_extraction.py
+++ b/tests/test_supplier_extraction.py
@@ -1,0 +1,23 @@
+from lxml import etree as LET
+
+from wsm.parsing.eslog import get_supplier_info
+
+
+def test_get_supplier_info_prefers_vat():
+    xml = """
+    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+             xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+      <cac:AccountingSupplierParty>
+        <cac:Party>
+          <cac:PartyIdentification>
+            <cbc:ID schemeID="0088">1234567890005</cbc:ID>
+          </cac:PartyIdentification>
+          <cac:PartyTaxScheme>
+            <cbc:CompanyID schemeID="VA">SI69092958</cbc:CompanyID>
+          </cac:PartyTaxScheme>
+        </cac:Party>
+      </cac:AccountingSupplierParty>
+    </Invoice>
+    """
+    tree = LET.ElementTree(LET.fromstring(xml))
+    assert get_supplier_info(tree) == "SI69092958"

--- a/tests/test_supplier_gln.py
+++ b/tests/test_supplier_gln.py
@@ -1,14 +1,18 @@
 from pathlib import Path
+from lxml import etree as LET
+
 from wsm.parsing.eslog import get_supplier_info
 
 
 def test_get_supplier_info_prefers_vat_over_gln():
     xml = Path("tests/vat_with_gln.xml")
-    code, _ = get_supplier_info(xml)
+    tree = LET.parse(xml)
+    code = get_supplier_info(tree)
     assert code == "SI33333333"
 
 
 def test_get_supplier_info_uses_gln_when_vat_missing():
     xml = Path("tests/gln_only.xml")
-    code, _ = get_supplier_info(xml)
+    tree = LET.parse(xml)
+    code = get_supplier_info(tree)
     assert code == "9876543210987"

--- a/tests/test_supplier_vat.py
+++ b/tests/test_supplier_vat.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from decimal import Decimal
 import pandas as pd
 import pytest
+from lxml import etree as LET
 import wsm.ui.review.gui as rl
 from wsm.parsing.eslog import get_supplier_info_vat, get_supplier_info
 
@@ -20,13 +21,15 @@ def test_get_supplier_info_vat_uses_se_when_su_missing():
 
 def test_get_supplier_info_prefers_vat_over_gln():
     xml = Path("tests/PR5690-Slika1.XML")
-    code, _ = get_supplier_info(xml)
+    tree = LET.parse(xml)
+    code = get_supplier_info(tree)
     assert code == "1121499"
 
 
 def test_get_supplier_info_uses_vat_when_no_gln():
     xml = Path("tests/vat_ahp_before_va.xml")
-    code, _ = get_supplier_info(xml)
+    tree = LET.parse(xml)
+    code = get_supplier_info(tree)
     assert code == "si 22222222"
 
 


### PR DESCRIPTION
## Summary
- refactor `get_supplier_info` to work on parsed XML trees and prioritise VAT identifiers, falling back to GLN when VAT is missing
- update review GUI to use the new helper and log resolved supplier code without relying on file name
- add regression tests ensuring VAT is preferred over GLN

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68934687ab8c8321bc9a435833e980e6