### PR TITLE
Prioritize VAT ID over GLN for supplier code extraction

### DIFF
--- a/tests/test_supplier_extraction.py
+++ b/tests/test_supplier_extraction.py
@@ -1,23 +1,68 @@
-from lxml import etree as LET
+# flake8: noqa
+import pytest
+from lxml import etree
 
 from wsm.parsing.eslog import get_supplier_info
 
 
-def test_get_supplier_info_prefers_vat():
-    xml = """
-    <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-             xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-      <cac:AccountingSupplierParty>
-        <cac:Party>
-          <cac:PartyIdentification>
-            <cbc:ID schemeID="0088">1234567890005</cbc:ID>
-          </cac:PartyIdentification>
-          <cac:PartyTaxScheme>
-            <cbc:CompanyID schemeID="VA">SI69092958</cbc:CompanyID>
-          </cac:PartyTaxScheme>
-        </cac:Party>
-      </cac:AccountingSupplierParty>
-    </Invoice>
+@pytest.fixture
+def sample_xml():
+    xml_str = """
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>SI69092958</cbc:CompanyID>
+      </cac:PartyTaxScheme>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">3830045969997</cbc:ID>
+      </cac:PartyIdentification>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+</Invoice>
     """
-    tree = LET.ElementTree(LET.fromstring(xml))
-    assert get_supplier_info(tree) == "SI69092958"
+    return etree.fromstring(xml_str.encode())
+
+
+def test_get_supplier_info_prioritizes_vat(sample_xml):
+    code = get_supplier_info(sample_xml)
+    assert code == "SI69092958"
+
+
+def test_get_supplier_info_fallback_to_gln():
+    xml_str = """
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">3830045969997</cbc:ID>
+      </cac:PartyIdentification>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+</Invoice>
+    """
+    tree = etree.fromstring(xml_str.encode())
+    code = get_supplier_info(tree)
+    assert code == "3830045969997"
+
+
+def test_get_supplier_info_custom_va_tag():
+    xml_str = """
+<Invoice>
+  <VA>SI69092958</VA>
+</Invoice>
+    """
+    tree = etree.fromstring(xml_str.encode())
+    code = get_supplier_info(tree)
+    assert code == "SI69092958"
+
+
+def test_get_supplier_info_unknown():
+    xml_str = """
+<Invoice />
+    """
+    tree = etree.fromstring(xml_str.encode())
+    code = get_supplier_info(tree)
+    assert code == "Unknown"

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -14,7 +14,7 @@ from lxml import etree as LET
 
 from wsm.utils import short_supplier_name, _clean, _build_header_totals
 from wsm.constants import PRICE_DIFF_THRESHOLD
-from wsm.parsing.eslog import get_supplier_info
+from wsm.parsing.eslog import get_supplier_info, XML_PARSER
 from .helpers import (
     _fmt,
     _norm_unit,
@@ -79,8 +79,9 @@ def review_links(
     supplier_code: str = "Unknown"
     if invoice_path and invoice_path.suffix.lower() == ".xml":
         try:
-            tree = LET.parse(invoice_path)
-            supplier_code = get_supplier_info(tree) or "Unknown"
+            tree = LET.parse(invoice_path, parser=XML_PARSER)
+            supplier_code = get_supplier_info(tree)
+            log.info("Supplier code extracted: %s", supplier_code)
         except Exception as exc:
             log.debug("Supplier code lookup failed: %s", exc)
     suppliers_file = links_file.parent.parent


### PR DESCRIPTION
## Summary
- enhance VAT extraction to handle UBL `CompanyID` without `schemeID` and return `Unknown` when no code present
- use `get_supplier_info` in GUI with secure XML parser
- add regression tests covering VAT priority, GLN fallback, custom `<VA>` tag and no identifiers

## Testing
- `pre-commit run --files wsm/parsing/eslog.py wsm/ui/review/gui.py tests/test_supplier_extraction.py`
- `pytest tests/test_supplier_extraction.py tests/test_supplier_gln.py tests/test_supplier_vat.py`


------
https://chatgpt.com/codex/tasks/task_e_689349b755048321a4f7dd946443a5ab