### PR TITLE
Clarify supplier code extraction

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -77,6 +77,7 @@ def review_links(
         else PRICE_DIFF_THRESHOLD
     )
     supplier_code: str = "Unknown"
+    # Try to extract supplier code directly from the invoice XML
     if invoice_path and invoice_path.suffix.lower() == ".xml":
         try:
             tree = LET.parse(invoice_path, parser=XML_PARSER)


### PR DESCRIPTION
## Summary
- Clarify supplier code extraction within `review_links`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689442eea5e08321a3f181e066fd4e26