### PR TITLE
Expose grand total from ESLOG invoices

### DIFF
--- a/tests/test_allowance_204.py
+++ b/tests/test_allowance_204.py
@@ -5,6 +5,6 @@ from wsm.parsing.eslog import parse_invoice
 
 def test_document_moa_204_discount():
     xml_path = Path("tests/minimal_doc_discount.xml")
-    df, header_total, discount_total = parse_invoice(xml_path)
+    df, header_total, discount_total, gross_total = parse_invoice(xml_path)
     assert header_total == Decimal("7.00")
     assert discount_total == Decimal("1.00")

--- a/tests/test_build_header_totals.py
+++ b/tests/test_build_header_totals.py
@@ -112,3 +112,22 @@ def test_build_header_totals_fills_missing_vat(tmp_path: Path) -> None:
     assert totals["net"] == Decimal("10")
     assert totals["vat"] == Decimal("2")
     assert totals["gross"] == Decimal("12")
+
+
+def test_build_header_totals_uses_passed_gross(tmp_path: Path) -> None:
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025>"
+        "<D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    p = tmp_path / "inv.xml"
+    p.write_text(xml)
+    totals = _build_header_totals(p, Decimal("10"), Decimal("15"))
+    assert totals["net"] == Decimal("10")
+    assert totals["gross"] == Decimal("15")
+    assert totals["vat"] == Decimal("5")

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -64,7 +64,13 @@ def test_cli_review_uses_env_vars(monkeypatch, tmp_path):
         return pd.DataFrame()
 
     def fake_review_links(
-        df, wsm_df, links_file, total, invoice_path, price_warn_pct=None
+        df,
+        wsm_df,
+        links_file,
+        total,
+        invoice_path,
+        price_warn_pct=None,
+        invoice_gross=None,
     ):
         captured["links"] = links_file
         captured["pct"] = price_warn_pct
@@ -129,7 +135,13 @@ def test_open_invoice_gui_uses_env_vars(monkeypatch, tmp_path):
         return pd.DataFrame()
 
     def fake_review_links(
-        df, wsm_df, links_file, total, invoice_path, price_warn_pct=None
+        df,
+        wsm_df,
+        links_file,
+        total,
+        invoice_path,
+        price_warn_pct=None,
+        invoice_gross=None,
     ):
         captured["links"] = links_file
         captured["pct"] = price_warn_pct
@@ -197,7 +209,13 @@ def test_cli_review_uses_vat_when_not_in_map(monkeypatch, tmp_path):
         return pd.DataFrame()
 
     def fake_review_links(
-        df, wsm_df, links_file, total, invoice_path, price_warn_pct=None
+        df,
+        wsm_df,
+        links_file,
+        total,
+        invoice_path,
+        price_warn_pct=None,
+        invoice_gross=None,
     ):
         captured["links"] = links_file
         captured["pct"] = price_warn_pct
@@ -262,7 +280,13 @@ def test_cli_review_prefers_vat_from_map(monkeypatch, tmp_path):
         return pd.DataFrame()
 
     def fake_review_links(
-        df, wsm_df, links_file, total, invoice_path, price_warn_pct=None
+        df,
+        wsm_df,
+        links_file,
+        total,
+        invoice_path,
+        price_warn_pct=None,
+        invoice_gross=None,
     ):
         captured["links"] = links_file
         captured["pct"] = price_warn_pct
@@ -318,7 +342,13 @@ def test_cli_review_passes_price_warn_pct(monkeypatch, tmp_path):
         return pd.DataFrame()
 
     def fake_review_links(
-        df, wsm_df, links_file, total, invoice_path, price_warn_pct=None
+        df,
+        wsm_df,
+        links_file,
+        total,
+        invoice_path,
+        price_warn_pct=None,
+        invoice_gross=None,
     ):
         captured["pct"] = price_warn_pct
 

--- a/tests/test_decimal_precision.py
+++ b/tests/test_decimal_precision.py
@@ -21,7 +21,7 @@ def test_parse_invoice_high_precision_values():
         "</Invoice>"
     )
 
-    df, header_total, discount_total = parse_invoice(xml)
+    df, header_total, discount_total, gross_total = parse_invoice(xml)
     assert header_total == Decimal("132.00")
     assert discount_total == Decimal("0")
     assert sum(df["izracunana_vrednost"]) == Decimal("132.00")

--- a/tests/test_missing_unit.py
+++ b/tests/test_missing_unit.py
@@ -15,5 +15,5 @@ def test_missing_unit_defaults_to_kos(tmp_path):
     </Racun>"""
     )
 
-    df, _, _ = parse_invoice(xml)
+    df, _, _, _ = parse_invoice(xml)
     assert df.loc[0, "enota"] == "kos"

--- a/tests/test_parse_eslog_document_charge.py
+++ b/tests/test_parse_eslog_document_charge.py
@@ -23,5 +23,5 @@ def test_parse_eslog_invoice_handles_doc_charge():
     assert ok
 
     # parse_invoice should ignore document charges when computing discounts
-    _, _, discount_total = parse_invoice(xml_path)
+    _, _, discount_total, _ = parse_invoice(xml_path)
     assert discount_total == Decimal("0.00")

--- a/tests/test_parse_invoice_eslog_string.py
+++ b/tests/test_parse_invoice_eslog_string.py
@@ -37,7 +37,7 @@ def test_parse_invoice_eslog_string_no_fs(monkeypatch):
 
     monkeypatch.setattr(builtins, "open", fail_open)
 
-    df, header_total, discount_total = parse_invoice(xml)
+    df, header_total, discount_total, gross_total = parse_invoice(xml)
     assert header_total == Decimal("7")
     assert discount_total == Decimal("1")
     assert not df.empty

--- a/tests/test_parse_invoice_gross_total.py
+++ b/tests/test_parse_invoice_gross_total.py
@@ -1,0 +1,34 @@
+from decimal import Decimal
+from wsm.parsing.eslog import parse_invoice
+
+
+def test_parse_invoice_extracts_gross_total():
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "      <G_SG34><S_TAX><C_C243><D_5278>22</D_5278></C_C243></S_TAX></G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_TAX><C_C243><D_5278>22</D_5278></C_C243></S_TAX>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>2.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>12.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    df, header_total, discount_total, gross_total = parse_invoice(xml)
+    assert header_total == Decimal("10")
+    assert gross_total == Decimal("12.20")
+    assert discount_total == Decimal("0")
+    assert not df.empty
+

--- a/tests/test_parse_invoice_moa.py
+++ b/tests/test_parse_invoice_moa.py
@@ -24,7 +24,7 @@ def test_parse_invoice_uses_moa_203_value():
         "  </LineItems>"
         "</Invoice>"
     )
-    df, header_total, discount_total = parse_invoice(xml)
+    df, header_total, discount_total, gross_total = parse_invoice(xml)
     assert header_total == Decimal("130.00")
     assert discount_total == Decimal("0")
     assert list(df["izracunana_vrednost"]) == [

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -14,8 +14,9 @@ class DummyLabel:
     def __init__(self):
         self.text = ""
 
-    def config(self, *, text):
-        self.text = text
+    def config(self, **kwargs):
+        if "text" in kwargs:
+            self.text = kwargs["text"]
 
 
 class DummyMsgBox:
@@ -43,6 +44,7 @@ def _extract_update_func():
 def test_totals_label_contains_terms():
     snippet = _extract_update_func()
     lbl = DummyLabel()
+    indicator = DummyLabel()
     df = pd.DataFrame(
         {
             "total_net": [Decimal("10")],
@@ -65,6 +67,7 @@ def test_totals_label_contains_terms():
         "_split_totals": _split_totals,
         "messagebox": DummyMsgBox,
         "total_frame": DummyFrame(lbl),
+        "indicator_label": indicator,
         "log": logging.getLogger("test"),
     }
     exec(snippet, ns)

--- a/tests/test_use_existing_folder.py
+++ b/tests/test_use_existing_folder.py
@@ -35,7 +35,7 @@ def test_open_invoice_gui_uses_existing_folder(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "wsm.ui.common.review_links",
-        lambda df, wdf, lf, total, ip: captured.update({"links": lf}),
+        lambda df, wdf, lf, total, ip, **k: captured.update({"links": lf}),
     )
     monkeypatch.setattr("wsm.utils.povezi_z_wsm", lambda df, *a, **k: df)
     monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Unknown")
@@ -84,7 +84,7 @@ def test_open_invoice_gui_prefers_vat_folder(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "wsm.ui.common.review_links",
-        lambda df, wdf, lf, total, ip: captured.update({"links": lf}),
+        lambda df, wdf, lf, total, ip, **k: captured.update({"links": lf}),
     )
     monkeypatch.setattr("wsm.utils.povezi_z_wsm", lambda df, *a, **k: df)
     monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Unknown")
@@ -130,7 +130,7 @@ def test_open_invoice_gui_uses_vat_from_map(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "wsm.ui.common.review_links",
-        lambda df, wdf, lf, total, ip: captured.update({"links": lf}),
+        lambda df, wdf, lf, total, ip, **k: captured.update({"links": lf}),
     )
     monkeypatch.setattr("wsm.utils.povezi_z_wsm", lambda df, *a, **k: df)
     monkeypatch.setattr("wsm.ui.common.get_supplier_name", lambda p: "Unknown")

--- a/tests/test_validate_invoice.py
+++ b/tests/test_validate_invoice.py
@@ -56,7 +56,7 @@ def test_parse_invoice_minimal():
         "</Invoice>"
     )
     # V tem primeru je vsota vrstic (50 + 100) = 150, glava = 150
-    df, header_total, discount_total = parse_invoice(xml)
+    df, header_total, discount_total, gross_total = parse_invoice(xml)
     assert header_total == Decimal("150.00")
     assert discount_total == Decimal("0")
     # Seštevek izračunanih vrstic:
@@ -92,7 +92,7 @@ def test_parse_invoice_with_line_and_doc_discount():
     # Ker vsota vrstic (280.00) + doc discount (50.00) = 330.00, kar se ne ujema z
     # glavo (300.00), parse_invoice vrne `header_total` po odštetem popustu (250.00)
     # in DataFrame z `izracunana_vrednost`.
-    df, header_total, discount_total = parse_invoice(xml)
+    df, header_total, discount_total, gross_total = parse_invoice(xml)
     assert header_total == Decimal("250.00")
     assert discount_total == Decimal("50.00")
     # Skupaj izračunanih vrstic:

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -13,7 +13,7 @@ from tkinter import filedialog, messagebox
 
 from wsm.analyze import analyze_invoice
 from wsm.parsing.pdf import parse_pdf, get_supplier_name_from_pdf
-from wsm.parsing.eslog import get_supplier_name
+from wsm.parsing.eslog import get_supplier_name, extract_grand_total
 from wsm.utils import sanitize_folder_name, _load_supplier_map
 from wsm.supplier_store import _norm_vat, choose_supplier_key
 from wsm.ui.review.gui import review_links
@@ -60,6 +60,7 @@ def open_invoice_gui(
     try:
         if invoice_path.suffix.lower() == ".xml":
             df, total, _ = analyze_invoice(str(invoice_path), str(suppliers))
+            gross = extract_grand_total(invoice_path)
 
             if "rabata" in df.columns:
                 df["rabata"] = df["rabata"].fillna(Decimal("0"))
@@ -71,6 +72,7 @@ def open_invoice_gui(
             if "rabata" not in df.columns:
                 df["rabata"] = Decimal("0")
             total = df["vrednost"].sum()
+            gross = total
         else:
             messagebox.showerror(
                 "Napaka", f"Nepodprta datoteka: {invoice_path}"
@@ -146,4 +148,4 @@ def open_invoice_gui(
     except Exception as exc:
         logging.warning(f"Napaka pri samodejnem povezovanju: {exc}")
 
-    review_links(df, wsm_df, links_file, total, invoice_path)
+    review_links(df, wsm_df, links_file, total, invoice_path, invoice_gross=gross)

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -34,6 +34,7 @@ def review_links(
     invoice_total: Decimal,
     invoice_path: Path | None = None,
     price_warn_pct: float | int | Decimal | None = None,
+    invoice_gross: Decimal | None = None,
 ) -> pd.DataFrame:
     """Interactively map supplier invoice rows to WSM items.
 
@@ -53,6 +54,9 @@ def review_links(
     price_warn_pct : float | int | Decimal, optional
         Threshold for price change warnings expressed in percent. When not
         provided, the value of ``PRICE_DIFF_THRESHOLD`` is used.
+    invoice_gross : decimal.Decimal, optional
+        Invoice grand total used when the XML is not available for extracting
+        header amounts.
 
     Returns
     -------
@@ -146,7 +150,7 @@ def review_links(
     log.info(f"Default name retrieved: {default_name}")
     log.debug(f"Supplier info: {supplier_info}")
 
-    header_totals = _build_header_totals(invoice_path, invoice_total)
+    header_totals = _build_header_totals(invoice_path, invoice_total, invoice_gross)
 
     try:
         manual_old = pd.read_excel(links_file, dtype=str)


### PR DESCRIPTION
## Summary
- include MOA 9 grand total as `gross_total` when parsing invoices
- allow `_build_header_totals` and GUI reviewers to use provided grand total
- add tests for MOA9 extraction and header total integration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68945ce16fe483219bf078ca3e98ef5f