### PR TITLE
Fix type error in unbooked tags addition

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -543,6 +543,8 @@ def review_links(
         key = (str(row["sifra_dobavitelja"]), row["naziv_ckey"])
         if key not in booked_keys:
             current_tags = tree.item(str(i)).get("tags", ())
+            if not isinstance(current_tags, tuple):
+                current_tags = (current_tags,) if current_tags else ()
             tree.item(str(i), tags=current_tags + ("unbooked",))
         if "is_gratis" in row and row["is_gratis"]:
             current_tags = tree.item(str(i)).get("tags", ())


### PR DESCRIPTION
## Summary
- Avoid TypeError when tagging unbooked rows by ensuring Treeview tags are tuples before concatenation.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68947b2997f88321afc41987a06bd99c