### PR TITLE
Adjust prices when applying quantity multipliers

### DIFF
--- a/tests/test_multiplier.py
+++ b/tests/test_multiplier.py
@@ -1,0 +1,22 @@
+from decimal import Decimal
+import pandas as pd
+
+from wsm.ui.review.gui import _apply_multiplier
+
+
+def test_apply_multiplier_preserves_total_net():
+    df = pd.DataFrame([
+        {
+            "kolicina_norm": Decimal("2"),
+            "cena_po_rabatu": Decimal("50"),
+            "cena_pred_rabatom": Decimal("60"),
+            "total_net": Decimal("100"),
+        }
+    ])
+
+    _apply_multiplier(df, 0, Decimal("5"))
+
+    assert df.at[0, "kolicina_norm"] == Decimal("10")
+    assert df.at[0, "cena_po_rabatu"] == Decimal("10")
+    assert df.at[0, "cena_pred_rabatom"] == Decimal("12")
+    assert df.at[0, "total_net"] == Decimal("100")


### PR DESCRIPTION
## Summary
- add helper to multiply quantity and divide unit prices, keeping total constant
- allow applying multipliers from the review GUI and refresh totals
- test multiplier logic to ensure line total remains unchanged

## Testing
- `pytest tests/test_multiplier.py -q`
- `pip install pyvirtualdisplay -q`
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `apt-get install -y xvfb >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689994fe49e48321b7db90e9e064e099