### PR TITLE
test: verify multiplier adjusts quantities

### DIFF
--- a/tests/test_multiplier.py
+++ b/tests/test_multiplier.py
@@ -1,22 +1,26 @@
 from decimal import Decimal
+
 import pandas as pd
 
 from wsm.ui.review.gui import _apply_multiplier
 
 
-def test_apply_multiplier_preserves_total_net():
-    df = pd.DataFrame([
-        {
-            "kolicina_norm": Decimal("2"),
-            "cena_po_rabatu": Decimal("50"),
-            "cena_pred_rabatom": Decimal("60"),
-            "total_net": Decimal("100"),
-        }
-    ])
+def test_apply_multiplier():
+    df = pd.DataFrame(
+        [
+            {
+                "kolicina_norm": Decimal("2"),
+                "cena_pred_rabatom": Decimal("20"),
+                "cena_po_rabatu": Decimal("10"),
+                "total_net": Decimal("20"),
+            }
+        ]
+    )
 
-    _apply_multiplier(df, 0, Decimal("5"))
+    original_total = df.at[0, "total_net"]
+    _apply_multiplier(df, 0, Decimal("10"))
 
-    assert df.at[0, "kolicina_norm"] == Decimal("10")
-    assert df.at[0, "cena_po_rabatu"] == Decimal("10")
-    assert df.at[0, "cena_pred_rabatom"] == Decimal("12")
-    assert df.at[0, "total_net"] == Decimal("100")
+    assert df.at[0, "kolicina_norm"] == Decimal("20")
+    assert df.at[0, "cena_pred_rabatom"] == Decimal("2")
+    assert df.at[0, "cena_po_rabatu"] == Decimal("1")
+    assert df.at[0, "total_net"] == original_total


### PR DESCRIPTION
## Summary
- add coverage for `_apply_multiplier`, asserting quantity scaling and price division preserve total net

## Testing
- `pre-commit run --files tests/test_multiplier.py`
- `pytest tests/test_multiplier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689999030b6c8321bcc679f34c20bda8