### PR TITLE
Add multiplier support for review links

### DIFF
--- a/tests/test_multiplier.py
+++ b/tests/test_multiplier.py
@@ -13,6 +13,7 @@ def test_apply_multiplier():
                 "cena_pred_rabatom": Decimal("20"),
                 "cena_po_rabatu": Decimal("10"),
                 "total_net": Decimal("20"),
+                "multiplier": Decimal("1"),
             }
         ]
     )
@@ -24,3 +25,4 @@ def test_apply_multiplier():
     assert df.at[0, "cena_pred_rabatom"] == Decimal("2")
     assert df.at[0, "cena_po_rabatu"] == Decimal("1")
     assert df.at[0, "total_net"] == original_total
+    assert df.at[0, "multiplier"] == Decimal("10")

--- a/tests/test_write_excel_links.py
+++ b/tests/test_write_excel_links.py
@@ -1,0 +1,27 @@
+from decimal import Decimal
+
+import pandas as pd
+
+from wsm.ui.review.io import _write_excel_links
+
+
+def test_write_excel_links_saves_multiplier(tmp_path):
+    df = pd.DataFrame(
+        [
+            {
+                "sifra_dobavitelja": "1",
+                "naziv": "Item",
+                "naziv_ckey": "item",
+                "wsm_sifra": "A1",
+                "dobavitelj": "Supp",
+                "enota_norm": "kos",
+                "multiplier": Decimal("2"),
+            }
+        ]
+    )
+    manual_old = pd.DataFrame()
+    links_file = tmp_path / "links.xlsx"
+    _write_excel_links(df, manual_old, links_file)
+    saved = pd.read_excel(links_file)
+    assert "multiplier" in saved.columns
+    assert saved.loc[0, "multiplier"] == 2

--- a/wsm/ui/review/io.py
+++ b/wsm/ui/review/io.py
@@ -196,6 +196,8 @@ def _write_excel_links(
         manual_new = manual_old.set_index(["sifra_dobavitelja", "naziv_ckey"])
         if "enota_norm" not in manual_new.columns:
             manual_new["enota_norm"] = pd.NA
+        if "multiplier" not in manual_new.columns:
+            manual_new["multiplier"] = 1
         log.info(
             "Število prebranih povezav iz manual_old: %s",
             len(manual_old),
@@ -213,14 +215,17 @@ def _write_excel_links(
                 "wsm_sifra",
                 "dobavitelj",
                 "enota_norm",
+                "multiplier",
             ]
         ).set_index(["sifra_dobavitelja", "naziv_ckey"])
         log.info("Manual_old je prazen, ustvarjam nov DataFrame")
 
     df["sifra_dobavitelja"] = df["sifra_dobavitelja"].fillna("").astype(str)
+    if "multiplier" not in df.columns:
+        df["multiplier"] = 1
     df["naziv_ckey"] = df["naziv"].map(_clean)
     df_links = df.set_index(["sifra_dobavitelja", "naziv_ckey"])[
-        ["naziv", "wsm_sifra", "dobavitelj", "enota_norm"]
+        ["naziv", "wsm_sifra", "dobavitelj", "enota_norm", "multiplier"]
     ]
 
     if manual_new.empty:
@@ -234,7 +239,13 @@ def _write_excel_links(
         if not common.empty:
             manual_new.loc[
                 common,
-                ["naziv", "wsm_sifra", "dobavitelj", "enota_norm"],
+                [
+                    "naziv",
+                    "wsm_sifra",
+                    "dobavitelj",
+                    "enota_norm",
+                    "multiplier",
+                ],
             ] = df_links.loc[common]
             log.debug(
                 "Updated existing mappings with new units: %s",


### PR DESCRIPTION
## Summary
- track a `multiplier` for invoice rows, applying it during review data prep and saving it back to Excel mappings
- persist multipliers in `_write_excel_links`
- cover multiplier behaviour with new tests

## Testing
- `pre-commit run --files wsm/ui/review/io.py wsm/ui/review/gui.py tests/test_multiplier.py tests/test_write_excel_links.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68999b786b38832182f3a8c0a8bbf815