### PR TITLE
Add test for quantity multiplier persistence

### DIFF
--- a/tests/test_quantity_multiplier.py
+++ b/tests/test_quantity_multiplier.py
@@ -1,0 +1,120 @@
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+import wsm.ui.review.gui as rl
+from wsm.ui.review.io import _save_and_close
+from wsm.utils import _clean
+
+pytest.importorskip("openpyxl")
+
+
+class DummyRoot:
+    def quit(self):
+        pass
+
+
+def test_quantity_multiplier_persist(tmp_path, monkeypatch):
+    df = pd.DataFrame(
+        {
+            "sifra_dobavitelja": ["1"],
+            "naziv": ["Item"],
+            "kolicina": [Decimal("1")],
+            "enota": ["kos"],
+            "vrednost": [Decimal("10")],
+            "rabata": [Decimal("0")],
+            "ddv": [Decimal("0")],
+            "ddv_stopnja": [Decimal("0")],
+            "sifra_artikla": [pd.NA],
+        }
+    )
+    df["wsm_sifra"] = ["A1"]
+    df["dobavitelj"] = ["Test"]
+    df["kolicina_norm"] = df["kolicina"]
+    df["enota_norm"] = ["kos"]
+    df["cena_pred_rabatom"] = df["vrednost"] / df["kolicina"]
+    df["cena_po_rabatu"] = df["vrednost"] / df["kolicina"]
+    df["total_net"] = df["vrednost"]
+    df["naziv_ckey"] = df["naziv"].map(_clean)
+    df["multiplier"] = Decimal("1")
+
+    original_total = df.at[0, "total_net"]
+    rl._apply_multiplier(df, 0, Decimal("10"))
+    assert df.at[0, "kolicina_norm"] == Decimal("10")
+    assert df.at[0, "cena_po_rabatu"] == Decimal("1")
+    assert df.at[0, "total_net"] == original_total
+
+    manual_old = pd.DataFrame(
+        columns=[
+            "sifra_dobavitelja",
+            "naziv",
+            "wsm_sifra",
+            "dobavitelj",
+            "naziv_ckey",
+            "enota_norm",
+            "multiplier",
+        ]
+    )
+    wsm_df = pd.DataFrame({"wsm_sifra": ["A1"], "wsm_naziv": ["Art"]})
+    base_dir = tmp_path / "suppliers"
+    links_dir = base_dir / "Test"
+    links_dir.mkdir(parents=True)
+    links_file = links_dir / "SUP_Test_povezane.xlsx"
+
+    monkeypatch.setattr("wsm.utils.log_price_history", lambda *a, **k: None)
+    monkeypatch.setattr("tkinter.messagebox.showwarning", lambda *a, **k: None)
+    monkeypatch.setattr("wsm.ui.review.io._write_history_files", lambda *a, **k: False)
+
+    _save_and_close(
+        df,
+        manual_old,
+        wsm_df,
+        links_file,
+        DummyRoot(),
+        "Test",
+        "SUP",
+        {},
+        base_dir,
+    )
+
+    saved_file = base_dir / "SUP" / "SUP_povezane.xlsx"
+    manual_new = pd.read_excel(saved_file)
+    assert manual_new.loc[0, "multiplier"] == 10
+
+    captured = {}
+    original_apply = rl._apply_multiplier
+
+    def capture_apply(dframe, idx, mult, *args, **kwargs):
+        original_apply(dframe, idx, mult, *args, **kwargs)
+        captured["df"] = dframe.copy()
+
+    monkeypatch.setattr(rl, "_apply_multiplier", capture_apply)
+    monkeypatch.setattr(rl, "_load_supplier_map", lambda p: {})
+    monkeypatch.setattr(rl, "_build_header_totals", lambda *a, **k: {})
+    monkeypatch.setattr(rl.tk, "Tk", lambda: (_ for _ in ()).throw(RuntimeError))
+
+    with pytest.raises(RuntimeError):
+        rl.review_links(
+            pd.DataFrame(
+                {
+                    "sifra_dobavitelja": ["1"],
+                    "naziv": ["Item"],
+                    "kolicina": [Decimal("1")],
+                    "enota": ["kos"],
+                    "vrednost": [Decimal("10")],
+                    "rabata": [Decimal("0")],
+                    "ddv": [Decimal("0")],
+                    "ddv_stopnja": [Decimal("0")],
+                    "sifra_artikla": [pd.NA],
+                }
+            ),
+            pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"]),
+            saved_file,
+            Decimal("10"),
+        )
+
+    reloaded = captured["df"]
+    assert reloaded.at[0, "kolicina_norm"] == Decimal("10")
+    assert reloaded.at[0, "cena_po_rabatu"] == Decimal("1")
+    assert reloaded.at[0, "total_net"] == Decimal("10")


### PR DESCRIPTION
## Summary
- add regression test ensuring quantity multiplier is saved and reapplied on reload

## Testing
- `pytest tests/test_quantity_multiplier.py::test_quantity_multiplier_persist -q`

------
https://chatgpt.com/codex/tasks/task_e_6899a75296d8832193926d8e3d8fb06d