### PR TITLE
Add quantity multiplier button in review GUI

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -1191,6 +1191,13 @@ def review_links(
         )
         return "break"
 
+    multiplier_btn = tk.Button(
+        btn_frame,
+        text="Pomnoži količino z 10",
+        command=_apply_multiplier_prompt,
+    )
+    multiplier_btn.grid(row=0, column=2, padx=(6, 0))
+
     def _clear_wsm_connection(_=None):
         sel_i = tree.focus()
         if not sel_i:


### PR DESCRIPTION
## Summary
- add "Pomnoži količino z 10" button to the review GUI
- cover multiplier prompt with tests simulating the button command

## Testing
- `pre-commit run --files wsm/ui/review/gui.py tests/test_quantity_multiplier.py`
- `pytest tests/test_quantity_multiplier.py`

------
https://chatgpt.com/codex/tasks/task_e_6899c7ba0c40832184d3ac7f1dbb9361