### PR TITLE
Skip unbooked tag when multiplier > 1

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -628,10 +628,18 @@ def review_links(
         df.at[i, "warning"] = tooltip
         key = (str(row["sifra_dobavitelja"]), row["naziv_ckey"])
         if key not in booked_keys:
-            current_tags = tree.item(str(i)).get("tags", ())
-            if not isinstance(current_tags, tuple):
-                current_tags = (current_tags,) if current_tags else ()
-            tree.item(str(i), tags=current_tags + ("unbooked",))
+            multiplier = row.get("multiplier", Decimal("1"))
+            if multiplier > 1:
+                logging.debug(
+                    "Skipping unbooked tag for row %s due to multiplier %s",
+                    i,
+                    multiplier,
+                )
+            else:
+                current_tags = tree.item(str(i)).get("tags", ())
+                if not isinstance(current_tags, tuple):
+                    current_tags = (current_tags,) if current_tags else ()
+                tree.item(str(i), tags=current_tags + ("unbooked",))
         if "is_gratis" in row and row["is_gratis"]:
             current_tags = tree.item(str(i)).get("tags", ())
             if not isinstance(current_tags, tuple):


### PR DESCRIPTION
## Summary
- Skip adding "unbooked" tag for rows with multiplier greater than 1
- Log debug message when skipping to help diagnose issues

## Testing
- `pytest tests/test_last_price_confirm.py -q` *(fails: NameError: name 'tk' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6899d8a7dc0c8321bab5e16d4ef7c9fb