### PR TITLE
Add multiplier-aware unbooked highlight test

### DIFF
--- a/tests/test_unbooked_highlight.py
+++ b/tests/test_unbooked_highlight.py
@@ -9,50 +9,50 @@ from pyvirtualdisplay import Display
 
 
 def test_unbooked_highlight():
-    df = pd.DataFrame([
-        {
-            "sifra_dobavitelja": "1",
-            "naziv": "Booked",
-            "enota_norm": "",
-            "kolicina_norm": Decimal("1"),
-            "cena_pred_rabatom": Decimal("0"),
-            "rabata_pct": Decimal("0"),
-            "cena_po_rabatu": Decimal("0"),
-            "total_net": Decimal("0"),
-            "warning": "",
-            "wsm_naziv": "",
-            "dobavitelj": "",
-            "multiplier": Decimal("1"),
-        },
-        {
-            "sifra_dobavitelja": "2",
-            "naziv": "Unbooked",
-            "enota_norm": "",
-            "kolicina_norm": Decimal("1"),
-            "cena_pred_rabatom": Decimal("0"),
-            "rabata_pct": Decimal("0"),
-            "cena_po_rabatu": Decimal("0"),
-            "total_net": Decimal("0"),
-            "warning": "",
-            "wsm_naziv": "",
-            "dobavitelj": "",
-            "multiplier": Decimal("1"),
-        },
-        {
-            "sifra_dobavitelja": "3",
-            "naziv": "Multiplied",
-            "enota_norm": "",
-            "kolicina_norm": Decimal("1"),
-            "cena_pred_rabatom": Decimal("0"),
-            "rabata_pct": Decimal("0"),
-            "cena_po_rabatu": Decimal("0"),
-            "total_net": Decimal("0"),
-            "warning": "",
-            "wsm_naziv": "",
-            "dobavitelj": "",
-            "multiplier": Decimal("10"),
-        },
-    ])
+    df = pd.DataFrame(
+        [
+            {
+                "sifra_dobavitelja": "1",
+                "naziv": "Booked",
+                "enota_norm": "",
+                "kolicina_norm": Decimal("1"),
+                "cena_pred_rabatom": Decimal("0"),
+                "rabata_pct": Decimal("0"),
+                "cena_po_rabatu": Decimal("0"),
+                "total_net": Decimal("0"),
+                "warning": "",
+                "wsm_naziv": "",
+                "dobavitelj": "",
+            },
+            {
+                "sifra_dobavitelja": "2",
+                "naziv": "Unbooked",
+                "enota_norm": "",
+                "kolicina_norm": Decimal("1"),
+                "cena_pred_rabatom": Decimal("0"),
+                "rabata_pct": Decimal("0"),
+                "cena_po_rabatu": Decimal("0"),
+                "total_net": Decimal("0"),
+                "warning": "",
+                "wsm_naziv": "",
+                "dobavitelj": "",
+            },
+            {
+                "sifra_dobavitelja": "3",
+                "naziv": "Multiplied",
+                "enota_norm": "",
+                "kolicina_norm": Decimal("1"),
+                "cena_pred_rabatom": Decimal("0"),
+                "rabata_pct": Decimal("0"),
+                "cena_po_rabatu": Decimal("0"),
+                "total_net": Decimal("0"),
+                "warning": "",
+                "wsm_naziv": "",
+                "dobavitelj": "",
+            },
+        ]
+    )
+    df["multiplier"] = [Decimal("1"), Decimal("1"), Decimal("2")]
     df["naziv_ckey"] = df["naziv"].map(_clean)
 
     manual_old = pd.DataFrame([


### PR DESCRIPTION
## Summary
- extend unbooked highlight test with explicit `multiplier` column
- verify rows with multiplier >1 are not tagged `unbooked` while others are

## Testing
- `pytest tests/test_unbooked_highlight.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6899e01744ac83219c7a85a06953ca6a