### PR TITLE
add ddv column to parse_invoice output

### DIFF
--- a/tests/test_parse_invoice_eslog_string.py
+++ b/tests/test_parse_invoice_eslog_string.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-import io
 import builtins
 import pytest
 from wsm.parsing.eslog import parse_invoice
@@ -7,22 +6,21 @@ from wsm.parsing.eslog import parse_invoice
 
 def test_parse_invoice_eslog_string_no_fs(monkeypatch):
     xml = (
-        "<Invoice xmlns='urn:eslog:2.00'>"
+        "<Invoice xmlns='urn:eslog:2.00' "
+        "xmlns:cbc='urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2'>"
         "  <M_INVOIC>"
         "    <G_SG26>"
         "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
         "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
         "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
-        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>8</D_5004></C_C516></S_MOA>"
-        "      <G_SG39>"
-        "        <S_ALC><D_5463>A</D_5463></S_ALC>"
-        "        <G_SG42>"
-        "          <S_MOA><C_C516><D_5025>204</D_5025><D_5004>2</D_5004></C_C516></S_MOA>"
-        "        </G_SG42>"
-        "      </G_SG39>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "      <G_SG34>"
+        "        <cbc:TaxAmount>2.20</cbc:TaxAmount>"
+        "        <S_TAX><C_C243><D_5278>22</D_5278></C_C243></S_TAX>"
+        "      </G_SG34>"
         "    </G_SG26>"
         "    <G_SG50>"
-        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>7</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>9</D_5004></C_C516></S_MOA>"
         "    </G_SG50>"
         "    <G_SG50>"
         "      <S_ALC><D_5463>A</D_5463></S_ALC>"
@@ -38,6 +36,8 @@ def test_parse_invoice_eslog_string_no_fs(monkeypatch):
     monkeypatch.setattr(builtins, "open", fail_open)
 
     df, header_total, discount_total, gross_total = parse_invoice(xml)
-    assert header_total == Decimal("7")
+    assert header_total == Decimal("9")
     assert discount_total == Decimal("1")
     assert not df.empty
+    assert "ddv" in df.columns
+    assert df["ddv"].iloc[0] == Decimal("2.20")

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -1450,6 +1450,7 @@ def parse_invoice(source: str | Path):
                 "cena_netto": df_items["cena_netto"],
                 "kolicina": df_items["kolicina"],
                 "rabata_pct": df_items["rabata_pct"],
+                "ddv": df_items["ddv"],
                 "izracunana_vrednost": df_items["vrednost"],
             },
             dtype=object,


### PR DESCRIPTION
## Summary
- include VAT amounts in `parse_invoice` by forwarding `df_items['ddv']`
- ensure parsing from XML string exposes `ddv` values

## Testing
- `pytest tests/test_decimal_precision.py tests/test_missing_unit.py tests/test_validate_invoice.py tests/test_parse_invoice_eslog_string.py tests/test_parse_eslog_document_charge.py tests/test_parse_invoice_moa.py tests/test_parse_invoice_gross_total.py tests/test_allowance_204.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689afcfe587883218fc93e7f2e20ea5d