### PR TITLE
Fix invoice total calculation with allowances

### DIFF
--- a/tests/test_invoice_total_with_allowance.py
+++ b/tests/test_invoice_total_with_allowance.py
@@ -1,0 +1,52 @@
+from decimal import Decimal
+from wsm.parsing.eslog import (
+    parse_eslog_invoice,
+    extract_header_net,
+    extract_total_tax,
+    extract_grand_total,
+)
+
+
+def test_invoice_total_with_allowance(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE"\
+"</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>100"\
+"</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>100"\
+"</D_5004></C_C516></S_MOA>"
+        "      <G_SG34>"
+        "        <S_MOA><C_C516><D_5025>124</D_5025><D_5004>19.80"\
+"</D_5004></C_C516></S_MOA>"
+        "      </G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>260</D_5025><D_5004>-10"\
+"</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>19.80"\
+"</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>109.80"\
+"</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    xml_path = tmp_path / "allowance.xml"
+    xml_path.write_text(xml)
+
+    df, ok = parse_eslog_invoice(xml_path)
+    net = extract_header_net(xml_path)
+    vat = extract_total_tax(xml_path)
+    grand = extract_grand_total(xml_path)
+
+    assert ok
+    assert (net + vat).quantize(Decimal("0.01")) == grand

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -470,14 +470,10 @@ def _invoice_total(
 ) -> Decimal:
     """Return invoice gross total."""
 
-    if header_net != 0:
-        net = header_net
-    else:
-        net = line_net_total - doc_discount
-
-    return (net + doc_charge + tax_total).quantize(
-        DEC2, rounding=ROUND_HALF_UP
-    )
+    net = header_net if header_net != 0 else line_net_total
+    net -= doc_discount
+    net += doc_charge
+    return (net + tax_total).quantize(DEC2, ROUND_HALF_UP)
 
 
 # ───────────────────── vrsta računa ─────────────────────
@@ -1368,8 +1364,9 @@ def parse_eslog_invoice(
             ["sifra_dobavitelja", "naziv"], inplace=True, ignore_index=True
         )
 
+    header_base = header_net + doc_discount - doc_charge
     calculated_total = _invoice_total(
-        header_net, line_net_total, doc_discount, doc_charge, tax_total
+        header_base, line_net_total, doc_discount, doc_charge, tax_total
     )
     grand_total = extract_grand_total(xml_path)
     ok = True


### PR DESCRIPTION
## Summary
- correct invoice total calculation by applying document-level allowances and charges before tax
- adjust header net handling in parser to account for allowances
- add regression test ensuring invoices with MOA260 allowances calculate totals correctly

## Testing
- `pytest tests/test_invoice_total_with_allowance.py tests/test_parse_eslog_invoice_moa260.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689b00f47af8832192f7f6fb3ea29785