### PR TITLE
Clarify line net calculations and add tests

### DIFF
--- a/tests/test_line_net_125.py
+++ b/tests/test_line_net_125.py
@@ -2,7 +2,13 @@ from decimal import Decimal
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
-from wsm.parsing.eslog import parse_eslog_invoice, _line_net, _line_tax, NS
+from wsm.parsing.eslog import (
+    parse_eslog_invoice,
+    _line_net,
+    _line_net_before_discount,
+    _line_tax,
+    NS,
+)
 
 
 def test_line_net_and_tax_with_moa125():
@@ -13,10 +19,19 @@ def test_line_net_and_tax_with_moa125():
 
     root = ET.parse(xml_path).getroot()
     lines = root.findall(".//e:G_SG26", NS)
-    nets = [_line_net(sg) for sg in lines]
-    assert nets[0] == Decimal("10")
-    assert nets[1] == Decimal("8")
+    nets_after = [_line_net(sg) for sg in lines]
+    nets_before = [_line_net_before_discount(sg) for sg in lines]
+    assert nets_after[0] == Decimal("10")
+    assert nets_after[1] == Decimal("8")
+    assert nets_before[0] == Decimal("10")
+    assert nets_before[1] == Decimal("10")
 
     taxes = [_line_tax(sg)[0] for sg in lines]
     assert taxes[0] == Decimal("2.20")
     assert taxes[1] == Decimal("1.76")
+
+    # verify parser output prices before and after discount
+    assert df.loc[0, "cena_bruto"] == Decimal("10")
+    assert df.loc[0, "cena_netto"] == Decimal("10")
+    assert df.loc[1, "cena_bruto"] == Decimal("5")
+    assert df.loc[1, "cena_netto"] == Decimal("4")


### PR DESCRIPTION
## Summary
- Clarify `_line_net` docstring and add `_line_net_before_discount` helper
- Use explicit net-before/net-after discount amounts in parser
- Add unit test validating both net scenarios and price outputs

## Testing
- `pre-commit run --files wsm/parsing/eslog.py tests/test_line_net_125.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b1e9f5954832190aea062d86da34f