### PR TITLE
Adjust MOA9 with document discounts

### DIFF
--- a/tests/test_parse_eslog_invoice_doc_discount_moa9.py
+++ b/tests/test_parse_eslog_invoice_doc_discount_moa9.py
@@ -1,0 +1,44 @@
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from wsm.parsing.eslog import parse_eslog_invoice
+
+
+def test_parse_eslog_invoice_adjusts_moa9_with_doc_discount(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>10</D_5118></C_C509></S_PRI>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>10</D_5004></C_C516></S_MOA>"
+        "      <G_SG34><S_TAX><C_C243><D_5278>22</D_5278></C_C243></S_TAX></G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_ALC><D_5463>A</D_5463></S_ALC>"
+        "      <S_MOA><C_C516><D_5025>131</D_5025><D_5004>-1</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_TAX><C_C243><D_5278>22</D_5278></C_C243></S_TAX>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>2.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>12.20</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "moa9_discount.xml"
+    path.write_text(xml)
+
+    with caplog.at_level("WARNING"):
+        df, ok = parse_eslog_invoice(path)
+
+    assert ok
+    assert "Invoice total mismatch" not in caplog.text
+    gross = (df["vrednost"] + df["ddv"]).sum().quantize(Decimal("0.01"))
+    assert gross == Decimal("11.20")

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -1485,9 +1485,13 @@ def parse_eslog_invoice(
     calculated_total = _invoice_total(
         header_base, line_net_total, doc_discount, doc_charge, tax_total
     )
+
     grand_total = extract_grand_total(xml_path)
     ok = True
     if grand_total != 0:
+        grand_total = (grand_total - doc_discount + doc_charge).quantize(
+            Decimal("0.01"), ROUND_HALF_UP
+        )
         ok = abs(calculated_total - grand_total) <= Decimal("0.01")
         if not ok:
             log.warning(
@@ -1553,6 +1557,11 @@ def parse_invoice(source: str | Path):
         else:
             discount_total = sum_moa(
                 root, DEFAULT_DOC_DISCOUNT_CODES, negative_only=True
+            )
+
+        if gross_total != 0:
+            gross_total = (gross_total - discount_total).quantize(
+                Decimal("0.01"), rounding=ROUND_HALF_UP
             )
 
         # Če želimo posebej slediti tudi pribitkom:


### PR DESCRIPTION
## Summary
- adjust MOA 9 totals by subtracting document discounts and adding charges
- compute gross total with document allowance in parse_invoice
- add test ensuring MOA 9 matches calculated value when a document discount is present

## Testing
- `pytest tests/test_parse_eslog_invoice_doc_discount_moa9.py tests/test_parse_invoice_gross_total.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b3f60e5dc83218a8809ec9c8bbe41