### PR TITLE
Refine document discount handling in ESLOG parser

### DIFF
--- a/tests/test_doc_discount_from_line.py
+++ b/tests/test_doc_discount_from_line.py
@@ -74,6 +74,21 @@ def test_multiple_sg39_allowances_are_summed():
     assert eslog._doc_discount_from_line(seg) == Decimal("3.00")
 
 
+def test_moa260_discount():
+    seg = _seg(
+        """
+        <G_SG26 xmlns='urn:eslog:2.00'>
+          <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>
+          <S_LIN><C_C212><D_7140>DISC</D_7140></C_C212></S_LIN>
+          <S_PRI><C_C509><D_5125>AAA</D_5125><D_5118>0</D_5118></C_C509></S_PRI>
+          <S_MOA><C_C516><D_5025>203</D_5025><D_5004>0</D_5004></C_C516></S_MOA>
+          <S_MOA><C_C516><D_5025>260</D_5025><D_5004>5</D_5004></C_C516></S_MOA>
+        </G_SG26>
+        """
+    )
+    assert eslog._doc_discount_from_line(seg) == Decimal("5.00")
+
+
 def test_charge_is_ignored():
     seg = _seg(
         """


### PR DESCRIPTION
## Summary
- isolate helper functions for MOA value lookup and restrict document discount codes
- handle document-level discounts from zero lines and SG39 allowances
- fix invoice total reconciliation to account for document discounts correctly

## Testing
- `pre-commit run --files wsm/parsing/eslog.py`
- `python -m pytest tests/test_doc_discount_from_line.py -q`
- `python -m pytest tests/test_100pct_line_discount.py::test_100pct_line_discount tests/test_invoice_total_with_allowance.py::test_invoice_total_with_allowance tests/test_doc_discount_vat.py::test_doc_discount_no_vat_mismatch -q`
- `python -m pytest tests/test_line_discount_duplicates.py::test_line_discount_duplicates tests/test_line_discount_zero_qty.py::test_line_discount_zero_qty tests/test_parse_eslog_invoice_doc_discount_moa9.py::test_parse_eslog_invoice_adjusts_moa9_with_doc_discount tests/test_parse_eslog_supplier.py::test_line_discount_moa_and_pcd_are_summed -q`


------
https://chatgpt.com/codex/tasks/task_e_689b8cbae34483218f1ff463a4457ecd