### PR TITLE
feat(parser): add PCD% (line & document) with sequential ALC; reconcile gross with MOA9 — fix: prevent negative nets & allocate doc discount across VAT

### DIFF
--- a/tests/test_doc_allowances_pcd_moa.py
+++ b/tests/test_doc_allowances_pcd_moa.py
@@ -1,0 +1,29 @@
+# flake8: noqa
+"""Tests for document-level PCD and MOA allowances."""
+
+from decimal import Decimal
+from lxml import etree as LET
+
+from wsm.parsing.eslog import _apply_doc_allowances_sequential
+
+
+def test_doc_level_allowances_sequential():
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG50>"
+        "      <S_ALC><D_5463>A</D_5463></S_ALC>"
+        "      <S_PCD><C_C501><D_5482>10</D_5482></C_C501></S_PCD>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_ALC><D_5463>A</D_5463></S_ALC>"
+        "      <S_MOA><C_C516><D_5025>260</D_5025><D_5004>-5</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    root = LET.fromstring(xml)
+    net, allow, charge = _apply_doc_allowances_sequential(Decimal("100"), root)
+    assert net == Decimal("85.00")
+    assert allow == Decimal("15.00")
+    assert charge == Decimal("0.00")

--- a/tests/test_invoice_total_with_pcd.py
+++ b/tests/test_invoice_total_with_pcd.py
@@ -1,0 +1,44 @@
+# flake8: noqa
+"""Integration test ensuring gross total matches header with PCD."""
+
+from decimal import Decimal
+from wsm.parsing.eslog import parse_eslog_invoice
+
+
+def test_invoice_total_with_pcd(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_QTY><C_C186><D_6060>1</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <S_IMD><C_C273><D_7008>Item</D_7008></C_C273></S_IMD>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>100</D_5004></C_C516></S_MOA>"
+        "      <G_SG39>"
+        "        <S_ALC><D_5463>A</D_5463></S_ALC>"
+        "        <S_PCD><C_C501><D_5482>10</D_5482></C_C501></S_PCD>"
+        "      </G_SG39>"
+        "      <G_SG34>"
+        "        <S_MOA><C_C516><D_5025>124</D_5025><D_5004>19.80</D_5004></C_C516></S_MOA>"
+        "        <S_TAX><C_C243><D_5278>22</D_5278></C_C243></S_TAX>"
+        "      </G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_ALC><D_5463>A</D_5463></S_ALC>"
+        "      <S_PCD><C_C501><D_5482>10</D_5482></C_C501></S_PCD>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>98.82</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>17.82</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "inv.xml"
+    path.write_text(xml)
+    df, ok = parse_eslog_invoice(path)
+    assert ok
+    doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
+    assert doc_row["vrednost"] == Decimal("-9.00")

--- a/tests/test_pcd_line_sequential.py
+++ b/tests/test_pcd_line_sequential.py
@@ -1,0 +1,27 @@
+# flake8: noqa
+"""Tests for sequential PCD and MOA handling on lines."""
+
+from decimal import Decimal
+from lxml import etree as LET
+
+from wsm.parsing.eslog import _line_net
+
+
+def test_sequential_pcd_moa_on_line():
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_MOA><C_C516><D_5025>203</D_5025><D_5004>100</D_5004></C_C516></S_MOA>"
+        "      <G_SG39>"
+        "        <S_ALC><D_5463>A</D_5463></S_ALC>"
+        "        <S_PCD><C_C501><D_5482>10</D_5482></C_C501></S_PCD>"
+        "        <S_MOA><C_C516><D_5025>204</D_5025><D_5004>5</D_5004></C_C516></S_MOA>"
+        "      </G_SG39>"
+        "    </G_SG26>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    root = LET.fromstring(xml)
+    sg26 = root.find(".//{urn:eslog:2.00}G_SG26")
+    assert _line_net(sg26) == Decimal("85.00")

--- a/tests/test_vat_allocation.py
+++ b/tests/test_vat_allocation.py
@@ -1,0 +1,15 @@
+# flake8: noqa
+"""Tests for VAT allocation across rates."""
+
+from decimal import Decimal
+
+from wsm.parsing.eslog import _vat_total_after_doc
+
+
+def test_vat_allocation_proportional():
+    lines_by_rate = {
+        Decimal("9.5"): Decimal("100"),
+        Decimal("22"): Decimal("200"),
+    }
+    vat = _vat_total_after_doc(None, lines_by_rate, Decimal("30"))
+    assert vat == Decimal("48.15")


### PR DESCRIPTION
## Summary
- handle percentage discounts (PCD) alongside MOA amounts on line and document level
- distribute document discounts sequentially and allocate across VAT rates to reconcile gross totals
- add tests for mixed MOA/PCD discounts and VAT allocation

## Testing
- `pre-commit run --files wsm/parsing/eslog.py tests/test_pcd_line_sequential.py tests/test_doc_allowances_pcd_moa.py tests/test_vat_allocation.py tests/test_invoice_total_with_pcd.py`
- `pytest tests/test_pcd_line_sequential.py tests/test_doc_allowances_pcd_moa.py tests/test_vat_allocation.py tests/test_invoice_total_with_pcd.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b94a7fa588321826040e5db900bb7