### PR TITLE
Enforce eight-digit VAT and add tests

### DIFF
--- a/tests/test_norm_vat.py
+++ b/tests/test_norm_vat.py
@@ -1,0 +1,15 @@
+import pytest
+from wsm.supplier_store import _norm_vat
+
+
+def test_norm_vat_valid():
+    assert _norm_vat("si-123 456 78") == "SI12345678"
+
+
+def test_norm_vat_overlong_truncated():
+    assert _norm_vat("SI123456789") == "SI12345678"
+
+
+@pytest.mark.parametrize("value", ["abc", "SI1234567", None])
+def test_norm_vat_malformed(value):
+    assert _norm_vat(value) == ""

--- a/wsm/supplier_store.py
+++ b/wsm/supplier_store.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 def _norm_vat(s: str) -> str:
-    """Return VAT number with ``SI`` prefix and digits only."""
+    """Return VAT number with ``SI`` prefix and exactly eight digits."""
     if not isinstance(s, str):
         return ""
     s = s.strip()
@@ -23,7 +23,11 @@ def _norm_vat(s: str) -> str:
         digits = "".join(ch for ch in s[2:] if ch.isdigit())
     else:
         digits = "".join(ch for ch in s if ch.isdigit())
-    return f"SI{digits}" if digits else ""
+    if len(digits) > 8:
+        digits = digits[:8]
+    if len(digits) != 8:
+        return ""
+    return f"SI{digits}"
 
 
 def choose_supplier_key(vat: str | None, code: str | None = None) -> str:


### PR DESCRIPTION
## Summary
- Restrict VAT normalization to exactly eight digits and return empty string when invalid
- Add focused unit tests for VAT normalization including overlong and malformed inputs

## Testing
- `pytest tests/test_norm_vat.py -q`
- `pytest -q` *(fails: numerous pre-existing test failures, e.g., 34 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c4aeb1d88832198bfee610d01d297