### PR TITLE
test: ensure find_vat ignores numeric code

### DIFF
--- a/tests/test_find_vat_numeric.py
+++ b/tests/test_find_vat_numeric.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+from lxml import etree as LET
+from wsm.parsing.eslog import _find_vat
+
+
+def test_find_vat_prefers_valid_si_vat_over_numeric_code():
+    xml = Path("tests/vat_with_numeric.xml")
+    tree = LET.parse(xml)
+    root = tree.getroot()
+    assert _find_vat(root) == "SI12345678"

--- a/tests/vat_with_numeric.xml
+++ b/tests/vat_with_numeric.xml
@@ -1,0 +1,24 @@
+<Invoice xmlns='urn:eslog:2.00'>
+  <M_INVOIC>
+    <G_SG2>
+      <S_NAD>
+        <S_GLN><D_7402>3830045969997</D_7402></S_GLN>
+        <D_3035>SE</D_3035>
+      </S_NAD>
+      <G_SG3>
+        <S_RFF>
+          <C_C506>
+            <D_1153>VA</D_1153>
+            <D_1154>3830045969997</D_1154>
+          </C_C506>
+        </S_RFF>
+        <S_RFF>
+          <C_C506>
+            <D_1153>VA</D_1153>
+            <D_1154>SI12345678</D_1154>
+          </C_C506>
+        </S_RFF>
+      </G_SG3>
+    </G_SG2>
+  </M_INVOIC>
+</Invoice>


### PR DESCRIPTION
## Summary
- add fixture containing valid SI VAT alongside numeric identifier
- test `_find_vat` returns the VAT and skips numeric code

## Testing
- `pre-commit run --files tests/test_find_vat_numeric.py tests/vat_with_numeric.xml`
- `pytest tests/test_find_vat_numeric.py`


------
https://chatgpt.com/codex/tasks/task_e_689c4f07b00c8321a8faaba98aa1e211