### PR TITLE
Add parse_invoice_totals helper

### DIFF
--- a/wsm/parsing/__init__.py
+++ b/wsm/parsing/__init__.py
@@ -1,1 +1,6 @@
+"""Parsing utilities for various invoice formats."""
+
+from .eslog import parse_invoice_totals
+
+__all__ = ["parse_invoice_totals"]
 


### PR DESCRIPTION
## Summary
- expose new `parse_invoice_totals` helper to compute net, VAT, and gross invoice totals from an ESLOG tree
- re-export helper from `wsm.parsing` for easier importing

## Testing
- `pytest -q` *(fails: many failing tests)*
- `pytest tests/test_parse_invoice_gross_total.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c6959d81483219e6835d2cd092229