### PR TITLE
Add test fixture for informational line discounts

### DIFF
--- a/tests/test_informational_line_discounts.py
+++ b/tests/test_informational_line_discounts.py
@@ -2,11 +2,10 @@ from decimal import Decimal
 from lxml import etree
 from wsm.parsing.eslog import parse_invoice_totals
 
-
 def test_informational_line_discounts_align_with_header():
     tree = etree.parse("tests/data/PR6167-Slika2.XML")
     t = parse_invoice_totals(tree)
-    assert t["net"] == Decimal("843.40")
-    assert t["vat"] == Decimal("185.55")
+    assert t["net"]   == Decimal("843.40")
+    assert t["vat"]   == Decimal("185.55")
     assert t["gross"] == Decimal("1028.95")
     assert not t["mismatch"]


### PR DESCRIPTION
## Summary
- ensure informational discount totals test uses aligned assertions

## Testing
- `pytest -q tests/test_informational_line_discounts.py`
- `pytest -q` *(fails: No such file or directory: 'Xvfb'; 38 failed, 190 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689c7e815a1483219eb18ebdac293881