### PR TITLE
Refine ESLOG info-mode processing

### DIFF
--- a/tests/test_customerinvoices_2025_04_02_totals.py
+++ b/tests/test_customerinvoices_2025_04_02_totals.py
@@ -1,0 +1,17 @@
+from decimal import Decimal
+from pathlib import Path
+
+from wsm.parsing.eslog import parse_eslog_invoice
+
+
+def test_customerinvoices_2025_04_02_totals():
+    xml_path = Path("tests/CUSTOMERINVOICES_2025-04-02T14-27-29_2082483.xml")
+    df, ok = parse_eslog_invoice(xml_path)
+    net = df["vrednost"].sum().quantize(Decimal("0.01"))
+    vat = df["ddv"].sum().quantize(Decimal("0.01"))
+    gross = (net + vat).quantize(Decimal("0.01"))
+
+    assert abs(net - Decimal("468.76")) <= Decimal("0.01")
+    assert vat == Decimal("74.85")
+    assert gross == Decimal("543.61")
+    assert ok


### PR DESCRIPTION
## Summary
- allow signed MOA summation and header-level MOA125 detection
- recalc line values and VAT from MOA203 when operating in info mode
- cover MOA260 in document discount detection and add regression test

## Testing
- `pytest tests/test_doc_discount_from_line.py tests/test_line_discount_zero_qty.py tests/test_customerinvoices_2025_04_02_totals.py -q` *(fails: assert False, AssertionError: abs(net - Decimal("468.76")) <= Decimal("0.01"))*

------
https://chatgpt.com/codex/tasks/task_e_689c8f414168832190e3ee241a390336