### PR TITLE
Preserve signed MOA values in parsing

### DIFF
--- a/tests/test_parse_eslog_document_discount.py
+++ b/tests/test_parse_eslog_document_discount.py
@@ -18,7 +18,7 @@ def _compute_doc_discount(xml_path: Path) -> Decimal:
     codes = list(DEFAULT_DOC_DISCOUNT_CODES)
     if "204" not in codes:
         codes.append("204")
-    return sum_moa(root, codes, negative_only=True)
+    return sum_moa(root, codes)
 
 
 def test_parse_eslog_invoice_returns_doc_discount_row():
@@ -27,7 +27,7 @@ def test_parse_eslog_invoice_returns_doc_discount_row():
     df, ok = parse_eslog_invoice(xml_path)
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
-    assert doc_row["vrednost"] == -expected_discount
+    assert doc_row["vrednost"] == expected_discount
     assert doc_row["rabata_pct"] == Decimal("100.00")
     assert ok
 
@@ -134,7 +134,7 @@ def test_parse_eslog_invoice_handles_moa_176(tmp_path):
     df, _ = parse_eslog_invoice(xml_path)
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
-    assert doc_row["vrednost"] == -expected_discount
+    assert doc_row["vrednost"] == expected_discount
     assert doc_row["rabata_pct"] == Decimal("100.00")
 
 
@@ -205,7 +205,7 @@ def test_parse_eslog_invoice_handles_sg16_level_discount(tmp_path):
     df, _ = parse_eslog_invoice(xml_path)
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
-    assert doc_row["vrednost"] == -expected
+    assert doc_row["vrednost"] == expected
     assert doc_row["rabata_pct"] == Decimal("100.00")
 
 
@@ -215,7 +215,7 @@ def test_parse_eslog_invoice_handles_sg20_level_discount(tmp_path):
     df, _ = parse_eslog_invoice(xml_path)
     doc_row = df[df["sifra_dobavitelja"] == "_DOC_"].iloc[0]
 
-    assert doc_row["vrednost"] == -expected
+    assert doc_row["vrednost"] == expected
     assert doc_row["rabata_pct"] == Decimal("100.00")
 
 

--- a/tests/test_sum_moa_no_ns.py
+++ b/tests/test_sum_moa_no_ns.py
@@ -22,5 +22,5 @@ def test_sum_moa_handles_groups_without_namespace():
         "</Invoice>"
     )
     root = LET.fromstring(xml)
-    total = sum_moa(root, ["204"], negative_only=True)
-    assert total == Decimal("3.50")
+    total = sum_moa(root, ["204"])
+    assert total == Decimal("-3.50")


### PR DESCRIPTION
## Summary
- keep document allowance and charge totals signed instead of using absolutes
- simplify MOA aggregation to return signed sums
- update tests for new signed MOA behaviour

## Testing
- `pytest -q` *(fails: AssertionError in test_cli_env, test_customerinvoices_2025_04_02_totals, and others)*

------
https://chatgpt.com/codex/tasks/task_e_689d9fd0ba4c832198c35556130f9854