### PR TITLE
Ensure suggestion list closes cleanly

### DIFF
--- a/tests/test_last_price_confirm.py
+++ b/tests/test_last_price_confirm.py
@@ -102,6 +102,9 @@ class DummyListbox:
     def pack_forget(self):
         pass
 
+    def selection_clear(self, start, end):
+        pass
+
 
 def _extract_confirm(threshold=Decimal("5")):
     src = inspect.getsource(rl.review_links).splitlines()
@@ -121,6 +124,7 @@ def _extract_confirm(threshold=Decimal("5")):
         "log": rl.log,
         "price_warn_threshold": threshold,
         "_schedule_totals": lambda: None,
+        "_close_suggestions": lambda: None,
     }
     exec(snippet, ns)
     return ns["_confirm"], ns

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -1294,6 +1294,7 @@ def review_links(
         _schedule_totals()  # Update totals after confirming
         entry.delete(0, "end")
         _close_suggestions()
+        lb.selection_clear(0, "end")
         tree.focus_set()
         next_i = tree.next(sel_i)
         if next_i:


### PR DESCRIPTION
## Summary
- Use `_close_suggestions` helper in `_confirm`
- Clear listbox selection and refocus the tree when confirming
- Adjust tests for new close helper and focus behavior

## Testing
- `pytest tests/test_last_price_confirm.py::test_confirm_applies_price_warning tests/test_last_price_confirm.py::test_confirm_respects_threshold -q`
- `pytest tests/test_suggestion_listbox.py::test_listbox_hidden_after_confirm -q`
- `pytest tests/test_unbooked_highlight.py::test_unbooked_highlight -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc7f140188321ac83dc03ca6c9f05