### PR TITLE
Handle listbox double-click to accept suggestion

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -1419,7 +1419,7 @@ def review_links(
     bindings.append((lb, "<KP_Enter>"))
     lb.bind("<Button-1>", lambda e: lb.after(0, _accept_current_suggestion))
     bindings.append((lb, "<Button-1>"))
-    lb.bind("<Double-Button-1>", _accept_current_suggestion)
+    lb.bind("<Double-Button-1>", lambda e: _accept_current_suggestion())
     bindings.append((lb, "<Double-Button-1>"))
     lb.bind("<Down>", _nav_list)
     bindings.append((lb, "<Down>"))


### PR DESCRIPTION
## Summary
- bind listbox double-click to accept the current suggestion and stop event propagation
- add regression test ensuring double-click handler returns `"break"`

## Testing
- `pre-commit run --files wsm/ui/review/gui.py tests/test_suggestion_listbox.py`
- `pytest -vv tests/test_suggestion_listbox.py::test_double_click_returns_break`


------
https://chatgpt.com/codex/tasks/task_e_689dd1c8b59883219331681da0ea41e2