### PR TITLE
Improve ESLOG per-line logging

### DIFF
--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -1498,6 +1498,7 @@ def parse_eslog_invoice(
                 "moa203": base203,
                 "net_std": net_amount,
                 "doc_added": add_doc,
+                "carried_doc_disc": add_doc,
             }
         )
 
@@ -1755,25 +1756,15 @@ def parse_eslog_invoice(
     )
 
     for ln in line_logs:
-        net_used = ln["moa203"] if _INFO_DISCOUNTS else ln["net_std"]
-        if _INFO_DISCOUNTS:
-            # Debug: remove once sanity checks pass
-            log.info(
-                "line_idx=%s, base203=%s, line_net_used=%s",
-                ln["idx"],
-                ln["moa203"],
-                net_used,
-            )
-        else:
-            # Debug: remove once sanity checks pass
-            log.info(
-                "line_idx=%s, base203=%s, line_net_used=%s, "
-                "added_to_doc_discount=%s",
-                ln["idx"],
-                ln["moa203"],
-                net_used,
-                ln["doc_added"],
-            )
+        line_net_used = ln["moa203"] if _INFO_DISCOUNTS else ln["net_std"]
+        log.debug(
+            "line_idx=%s, moa203=%s, line_net_used=%s, doc_added=%s, carried_doc_disc=%s",
+            ln["idx"],
+            ln["moa203"],
+            line_net_used,
+            ln.get("doc_added", Decimal("0")),
+            ln.get("carried_doc_disc", Decimal("0")),
+        )
 
     for it in items:
         it.pop("_idx", None)


### PR DESCRIPTION
## Summary
- Record document discount carryover on each line item and log selected net value
- Emit summary log of hdr125, sum203, sum_line_net_std, hdr260_present, and mode
- Use debug-level logs for per-line details to reduce default output noise

## Testing
- `pytest -q` *(fails: 79 failed, 159 passed, 3 skipped, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_689df48165348321bfb385796c77aec7