### PR TITLE
Refactor summary utilities and discount calculations

### DIFF
--- a/tests/test_summary_df_from_records.py
+++ b/tests/test_summary_df_from_records.py
@@ -1,36 +1,12 @@
-import types
 from itertools import zip_longest
 
-import wsm.ui.review.gui as gui
-
-
-def _get_summary_helper():
-    """Extract `_summary_df_from_records` nested in `review_links`."""
-    for const in gui.review_links.__code__.co_consts:
-        if (
-            isinstance(const, types.CodeType)
-            and const.co_name == "_summary_df_from_records"
-        ):
-            return types.FunctionType(
-                const, gui.review_links.__globals__, "_summary_df_from_records"
-            )
-    raise AssertionError("_summary_df_from_records not found")
-
-
-_summary_df_from_records = _get_summary_helper()
+from wsm.ui.review.summary_utils import SUMMARY_COLS, summary_df_from_records
 
 
 def test_summary_empty_returns_empty_df():
-    df = _summary_df_from_records([])
+    df = summary_df_from_records([])
     assert df.empty
-    assert list(df.columns) == [
-        "WSM šifra",
-        "WSM Naziv",
-        "Količina",
-        "Znesek",
-        "Rabat (%)",
-        "Neto po rabatu",
-    ]
+    assert list(df.columns) == SUMMARY_COLS
 
 
 def test_summary_handles_mismatched_lengths():
@@ -41,7 +17,7 @@ def test_summary_handles_mismatched_lengths():
         {"WSM šifra": s, "WSM Naziv": n, "Količina": k}
         for s, n, k in zip_longest(sifre, nazivi, kolicine)
     ]
-    df = _summary_df_from_records(records)
+    df = summary_df_from_records(records)
     assert df.shape == (3, 6)
     assert df["WSM šifra"].tolist() == ["1", "2", "3"]
     assert df["WSM Naziv"].tolist() == ["A", "B", ""]

--- a/wsm/ui/review/summary_utils.py
+++ b/wsm/ui/review/summary_utils.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from .helpers import _safe_set_block
+
+SUMMARY_COLS = [
+    "WSM šifra",
+    "WSM Naziv",
+    "Količina",
+    "Znesek",
+    "Rabat (%)",
+    "Neto po rabatu",
+]
+
+
+def summary_df_from_records(records: Sequence[dict] | None) -> pd.DataFrame:
+    """Create summary DataFrame from ``records``.
+
+    Parameters
+    ----------
+    records:
+        Sequence of mapping objects with column data. Missing keys or
+        values are filled with defaults and the DataFrame is reindexed to
+        :data:`SUMMARY_COLS`.
+    """
+    df = pd.DataFrame.from_records(records or [])
+    df = df.reindex(columns=SUMMARY_COLS)
+
+    numeric_cols = ["Količina", "Znesek", "Rabat (%)", "Neto po rabatu"]
+    df = _safe_set_block(
+        df,
+        numeric_cols,
+        df[numeric_cols].apply(pd.to_numeric, errors="coerce").fillna(0),
+    )
+    text_cols = ["WSM šifra", "WSM Naziv"]
+    df = _safe_set_block(df, text_cols, df[text_cols].fillna(""))
+    return df
+
+
+def vectorized_discount_pct(base, after) -> pd.Series:
+    """Return discount percentage for ``base`` and ``after`` values.
+
+    Both inputs are converted to numeric form and division by zero is
+    handled gracefully. The result is expressed in percent with two
+    decimal places as :class:`~decimal.Decimal` values.
+    """
+    base_num = pd.to_numeric(base, errors="coerce")
+    after_num = pd.to_numeric(after, errors="coerce")
+    base_arr = base_num.to_numpy(dtype=float)
+    after_arr = after_num.to_numpy(dtype=float)
+    pct_arr = np.zeros_like(base_arr, dtype=float)
+    np.divide(base_arr - after_arr, base_arr, out=pct_arr, where=base_arr != 0)
+    pct_arr *= 100
+    pct_series = pd.Series(pct_arr, index=base_num.index if isinstance(base_num, pd.Series) else None)
+    pct_series = pct_series.fillna(0)
+    return pct_series.apply(lambda x: Decimal(str(x)).quantize(Decimal("0.01"), ROUND_HALF_UP))

--- a/wsm/ui_qt/review_links_qt.py
+++ b/wsm/ui_qt/review_links_qt.py
@@ -30,6 +30,7 @@ from wsm.ui.review.helpers import (
 )
 from wsm.ui.review.io import _save_and_close, _load_supplier_map
 from wsm.utils import short_supplier_name
+from wsm.ui.review.summary_utils import vectorized_discount_pct
 
 log = logging.getLogger(__name__)
 
@@ -118,15 +119,8 @@ def review_links_qt(
         ),
         axis=1,
     )
-    df["rabata_pct"] = df.apply(
-        lambda r: (
-            (
-                (r["rabata"] / (r["vrednost"] + r["rabata"])) * Decimal("100")
-            ).quantize(Decimal("0.01"))
-            if (r["vrednost"] + r["rabata"])
-            else Decimal("0.00")
-        ),
-        axis=1,
+    df["rabata_pct"] = vectorized_discount_pct(
+        df["vrednost"] + df["rabata"], df["vrednost"]
     )
     df["total_net"] = df["vrednost"]
     df["is_gratis"] = df["rabata_pct"] >= Decimal("99.9")


### PR DESCRIPTION
## Summary
- centralize summary helpers and discount percentage calculation in `summary_utils`
- refactor Tk and Qt review UIs to use shared summary utilities
- adjust tests to import the new utilities

## Testing
- `pytest tests/test_summary_df_from_records.py -q`
- `pytest -q` *(fails: 117 failed, 124 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e0ca73688321898ebe85ca9b7ff3