### PR TITLE
Add tests for review helpers and discount utilities

### DIFF
--- a/tests/test_safe_set_block.py
+++ b/tests/test_safe_set_block.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from wsm.ui.review.helpers import _safe_set_block
+
+
+def test_safe_set_block_empty_frame():
+    df = pd.DataFrame()
+    result = _safe_set_block(df, ["A", "B"], [])
+    assert result.empty
+    assert list(result.columns) == ["A", "B"]
+
+
+def test_safe_set_block_mismatched_list_lengths():
+    df = pd.DataFrame(index=[0, 1])
+    result = _safe_set_block(df, ["A", "B"], [pd.Series([1, 2, 3])])
+    assert (result[["A", "B"]] == 0).all().all()
+
+
+def test_safe_set_block_scalar_input():
+    df = pd.DataFrame({"existing": [0, 0, 0]})
+    result = _safe_set_block(df, ["A", "B"], 5)
+    assert (result[["A", "B"]] == 5).all().all()

--- a/tests/test_summary_df_from_records.py
+++ b/tests/test_summary_df_from_records.py
@@ -1,5 +1,3 @@
-from itertools import zip_longest
-
 from wsm.ui.review.summary_utils import SUMMARY_COLS, summary_df_from_records
 
 
@@ -9,19 +7,16 @@ def test_summary_empty_returns_empty_df():
     assert list(df.columns) == SUMMARY_COLS
 
 
-def test_summary_handles_mismatched_lengths():
-    sifre = ["1", "2", "3"]
-    nazivi = ["A", "B"]
-    kolicine = [1]
+def test_summary_missing_fields_filled():
     records = [
-        {"WSM šifra": s, "WSM Naziv": n, "Količina": k}
-        for s, n, k in zip_longest(sifre, nazivi, kolicine)
+        {"WSM šifra": "1", "Količina": 2},  # missing "WSM Naziv"
+        {"WSM Naziv": "B"},  # missing "WSM šifra" and "Količina"
     ]
     df = summary_df_from_records(records)
-    assert df.shape == (3, 6)
-    assert df["WSM šifra"].tolist() == ["1", "2", "3"]
-    assert df["WSM Naziv"].tolist() == ["A", "B", ""]
-    assert df["Količina"].tolist() == [1, 0, 0]
-    assert df["Znesek"].tolist() == [0, 0, 0]
-    assert df["Rabat (%)"].tolist() == [0, 0, 0]
-    assert df["Neto po rabatu"].tolist() == [0, 0, 0]
+    assert df.shape == (2, 6)
+    assert df["WSM šifra"].tolist() == ["1", ""]
+    assert df["WSM Naziv"].tolist() == ["", "B"]
+    assert df["Količina"].tolist() == [2, 0]
+    assert df["Znesek"].tolist() == [0, 0]
+    assert df["Rabat (%)"].tolist() == [0, 0]
+    assert df["Neto po rabatu"].tolist() == [0, 0]

--- a/tests/test_vectorized_discount_pct.py
+++ b/tests/test_vectorized_discount_pct.py
@@ -1,0 +1,17 @@
+import math
+from decimal import Decimal
+
+import pandas as pd
+
+from wsm.ui.review.summary_utils import vectorized_discount_pct
+
+
+def test_vectorized_discount_pct_zero_and_nan_base():
+    base = pd.Series([0, math.nan, 100])
+    after = pd.Series([10, 5, 75])
+    result = vectorized_discount_pct(base, after)
+    assert result.tolist() == [
+        Decimal("0.00"),
+        Decimal("0.00"),
+        Decimal("25.00"),
+    ]


### PR DESCRIPTION
## Summary
- test `_safe_set_block` for empty frames, mismatched list lengths, and scalar data
- cover `summary_df_from_records` with empty records and missing fields
- ensure `vectorized_discount_pct` handles zero or NaN bases

## Testing
- `pre-commit run --files tests/test_safe_set_block.py tests/test_summary_df_from_records.py tests/test_vectorized_discount_pct.py`
- `pytest tests/test_safe_set_block.py tests/test_summary_df_from_records.py tests/test_vectorized_discount_pct.py`
- `pytest` *(fails: missing supplier data and other unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e3a95c2c8321aaa2619cd53d62a7