### PR TITLE
Use catalog and keyword loaders

### DIFF
--- a/wsm/cli.py
+++ b/wsm/cli.py
@@ -14,6 +14,7 @@ from wsm.parsing.eslog import (
 )
 from wsm.parsing.pdf import parse_pdf, get_supplier_name_from_pdf
 from wsm.parsing.money import detect_round_step, round_to_step
+from wsm.io import load_catalog
 from wsm.utils import sanitize_folder_name, _load_supplier_map
 from wsm.supplier_store import _norm_vat
 from wsm.analyze import analyze_invoice
@@ -221,7 +222,7 @@ def review(invoice, wsm_codes, suppliers, keywords, price_warn_pct, use_pyqt):
 
     if sifre_path.exists():
         try:
-            wsm_df = pd.read_excel(sifre_path, dtype=str)
+            wsm_df = load_catalog(sifre_path)
         except Exception as exc:
             click.echo(f"[NAPAKA] Napaka pri branju {sifre_path}: {exc}")
             wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])

--- a/wsm/ui/common.py
+++ b/wsm/ui/common.py
@@ -7,13 +7,14 @@ import os
 from pathlib import Path
 from decimal import Decimal
 
-import pandas as pd
 import tkinter as tk
 from tkinter import filedialog, messagebox
 
 from wsm.analyze import analyze_invoice
 from wsm.parsing.pdf import parse_pdf, get_supplier_name_from_pdf
 from wsm.parsing.eslog import get_supplier_name, extract_grand_total
+import pandas as pd
+from wsm.io import load_catalog
 from wsm.utils import sanitize_folder_name, _load_supplier_map
 from wsm.supplier_store import _norm_vat, choose_supplier_key
 from wsm.ui.review.gui import review_links
@@ -132,7 +133,7 @@ def open_invoice_gui(
     sifre_file = wsm_codes
     if sifre_file.exists():
         try:
-            wsm_df = pd.read_excel(sifre_file, dtype=str)
+            wsm_df = load_catalog(sifre_file)
         except Exception as exc:
             logging.warning(f"Napaka pri branju {sifre_file}: {exc}")
             wsm_df = pd.DataFrame(columns=["wsm_sifra", "wsm_naziv"])


### PR DESCRIPTION
## Summary
- Read WSM catalog via `load_catalog` instead of direct Excel reads
- Normalize keywords using `load_keywords_map` and remove legacy `_coerce_keyword_column`
- Wire catalog loader into CLI and GUI entry points

## Testing
- `pytest` *(fails: 114 failed, 131 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ffa59f708321acb389ae0e38f30b