### PR TITLE
Use Decimal for summary columns

### DIFF
--- a/tests/test_summary_df_from_records.py
+++ b/tests/test_summary_df_from_records.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from wsm.ui.review.summary_utils import SUMMARY_COLS, summary_df_from_records
 
 
@@ -20,3 +22,5 @@ def test_summary_missing_fields_filled():
     assert df["Znesek"].tolist() == [0, 0]
     assert df["Rabat (%)"].tolist() == [0, 0]
     assert df["Neto po rabatu"].tolist() == [0, 0]
+    for col in ["Količina", "Znesek", "Rabat (%)", "Neto po rabatu"]:
+        assert all(isinstance(x, Decimal) for x in df[col])

--- a/wsm/ui/review/summary_utils.py
+++ b/wsm/ui/review/summary_utils.py
@@ -32,11 +32,14 @@ def summary_df_from_records(records: Sequence[dict] | None) -> pd.DataFrame:
     df = df.reindex(columns=SUMMARY_COLS)
 
     numeric_cols = ["Količina", "Znesek", "Rabat (%)", "Neto po rabatu"]
-    df = _safe_set_block(
-        df,
-        numeric_cols,
-        df[numeric_cols].apply(pd.to_numeric, errors="coerce").fillna(0),
-    )
+    for col in numeric_cols:
+        df[col] = df[col].apply(
+            lambda x: (
+                x
+                if isinstance(x, Decimal)
+                else Decimal(str(x)) if not pd.isna(x) and x != "" else Decimal("0")
+            )
+        )
     text_cols = ["WSM šifra", "WSM Naziv"]
     df = _safe_set_block(df, text_cols, df[text_cols].fillna(""))
     return df


### PR DESCRIPTION
## Summary
- Keep summary numeric columns as `Decimal` to avoid float conversions
- Test summary table ensures numeric columns are `Decimal`

## Testing
- `pytest tests/test_summary_df_from_records.py -q`
- `pytest -q` *(fails: numerous existing tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a3274014dc8321a26d9598b02246ae