### PR TITLE
Filter keyword mapping by supplier

### DIFF
--- a/tests/test_wsm_catalog_loader.py
+++ b/tests/test_wsm_catalog_loader.py
@@ -45,3 +45,16 @@ def test_load_keywords_map_aliases_and_duplicate_warning(kw_header, caplog):
         mapping = load_keywords_map(buf)
     assert mapping == {"foo": "1", "bar": "3"}
     assert "Duplicate keyword 'foo'" in caplog.text
+
+
+def test_load_keywords_map_filters_by_supplier():
+    df = pd.DataFrame(
+        {
+            "sifra_dobavitelja": ["A", "B"],
+            "wsm_sifra": ["1", "2"],
+            "keyword": ["Foo", "Bar"],
+        }
+    )
+    buf = _to_excel_bytes(df)
+    mapping = load_keywords_map(buf, supplier_code="A")
+    assert mapping == {"foo": "1"}

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -290,7 +290,8 @@ def load_wsm_data(
     """
     Vrne:
       • sifre_df  – celotno tabelo “sifre_wsm.xlsx”
-      • kw_df     – ključne besede filtrirane na dobavitelja, če je stolpec
+      • kw_df     – ključne besede; če datoteka vsebuje stolpec
+                   ``sifra_dobavitelja``, so filtrirane na dobavitelja
       • links_df  – ročne povezave za dobavitelja (če obstaja datoteka)
     """
     sifre_df = load_catalog(sifre_path)
@@ -300,7 +301,7 @@ def load_wsm_data(
             "WSM_KEYWORDS_FILE", "kljucne_besede_wsm_kode.xlsx"
         )
 
-    kw_map = load_keywords_map(keywords_path)
+    kw_map = load_keywords_map(keywords_path, supplier_code)
     kw_df = (
         pd.DataFrame(
             [


### PR DESCRIPTION
## Summary
- filter keyword mapping by supplier when `sifra_dobavitelja` column exists
- expand keyword header aliases to include supplier column
- update `load_wsm_data` docs and invocation
- add regression test for supplier filter

## Testing
- `pytest tests/test_wsm_catalog_loader.py -q`
- `pytest -q` *(fails: KeyError: 'sifra_dobavitelja' and other failures across many tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a32aa28fb0832185d55862fdfe97b6