### PR TITLE
Filter empty WSM codes in review summary

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -735,8 +735,11 @@ def review_links(
             "rabata_pct",
         }
         if required.issubset(df.columns):
+            valid = df["wsm_sifra"].notna() & (
+                df["wsm_sifra"].astype(str).str.strip() != ""
+            )
             agg = (
-                df[df["wsm_sifra"].notna()]
+                df[valid]
                 .groupby("wsm_sifra")
                 .agg(
                     {
@@ -780,9 +783,7 @@ def review_links(
                     row["WSM šifra"],
                     row.get("Neto po rabatu"),
                 )
-            log.debug(
-                f"Povzetek posodobljen: {len(summary_df)} WSM šifer"
-            )
+            log.debug(f"Povzetek posodobljen: {len(summary_df)} WSM šifer")
 
     # Skupni zneski pod povzetkom
     total_frame = tk.Frame(root)


### PR DESCRIPTION
## Summary
- Skip rows with empty or whitespace-only `wsm_sifra` values before aggregating review summaries

## Testing
- `pytest -q` *(fails: 116 failed, 134 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a33c21573883219c76070ed258b669