### PR TITLE
Centralize summary column definitions for GUI

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -26,11 +26,8 @@ from .helpers import (
     _safe_set_block,
 )
 from .io import _save_and_close, _load_supplier_map
-from .summary_utils import (
-    SUMMARY_COLS,
-    summary_df_from_records,
-    vectorized_discount_pct,
-)
+from .summary_columns import SUMMARY_COLS, SUMMARY_KEYS, SUMMARY_HEADS
+from .summary_utils import summary_df_from_records, vectorized_discount_pct
 
 builtins.tk = tk
 builtins.simpledialog = simpledialog
@@ -694,22 +691,11 @@ def review_links(
         font=("Arial", 12, "bold"),
     ).pack()
 
-    summary_cols = [
-        "wsm_sifra",
-        "wsm_naziv",
-        "kolicina_norm",
-        "neto_brez_popusta",
-        "rabata_pct",
-        "vrednost",
-    ]
-    summary_heads = [
-        "WSM Šifra",
-        "WSM Naziv",
-        "Količina",
-        "Znesek",
-        "Rabat (%)",
-        "Neto po rabatu",
-    ]
+    # Column keys and headers derive from :mod:`summary_columns` to stay in sync
+    # with :data:`SUMMARY_COLS` used throughout the project.
+    summary_cols = SUMMARY_KEYS
+    summary_heads = SUMMARY_HEADS
+    assert SUMMARY_COLS == summary_heads
     summary_tree = ttk.Treeview(
         summary_frame, columns=summary_cols, show="headings", height=5
     )

--- a/wsm/ui/review/summary_columns.py
+++ b/wsm/ui/review/summary_columns.py
@@ -1,0 +1,26 @@
+"""Shared column definitions for review summary tables."""
+
+from __future__ import annotations
+
+# Mapping of internal DataFrame keys to human-readable column headers.
+# Both :mod:`summary_utils` and :mod:`gui` import these definitions so that
+# changes in one place are reflected everywhere.
+SUMMARY_COLUMN_DEFS = [
+    ("wsm_sifra", "WSM šifra"),
+    ("wsm_naziv", "WSM Naziv"),
+    ("kolicina_norm", "Količina"),
+    ("neto_brez_popusta", "Znesek"),
+    ("rabata_pct", "Rabat (%)"),
+    ("vrednost", "Neto po rabatu"),
+]
+
+# Column headers used by :func:`summary_df_from_records` and displayed in the GUI.
+SUMMARY_COLS = [header for _, header in SUMMARY_COLUMN_DEFS]
+
+# Internal column keys used in the GUI ``Treeview`` widget.
+SUMMARY_KEYS = [key for key, _ in SUMMARY_COLUMN_DEFS]
+
+# Alias for readability when used in the GUI.
+SUMMARY_HEADS = SUMMARY_COLS
+
+__all__ = ["SUMMARY_COLS", "SUMMARY_KEYS", "SUMMARY_HEADS", "SUMMARY_COLUMN_DEFS"]

--- a/wsm/ui/review/summary_utils.py
+++ b/wsm/ui/review/summary_utils.py
@@ -7,15 +7,7 @@ import numpy as np
 import pandas as pd
 
 from .helpers import _safe_set_block
-
-SUMMARY_COLS = [
-    "WSM šifra",
-    "WSM Naziv",
-    "Količina",
-    "Znesek",
-    "Rabat (%)",
-    "Neto po rabatu",
-]
+from .summary_columns import SUMMARY_COLS
 
 
 def summary_df_from_records(records: Sequence[dict] | None) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- Share summary column names and keys via new `summary_columns` module
- Import shared definitions in `summary_utils` and GUI with runtime check to keep headers synced

## Testing
- `pytest tests/test_summary_df_from_records.py tests/test_open_invoice_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68a33d7deedc8321972ada285d864fd9