### PR TITLE
refactor: remove duplicate discount helper

### DIFF
--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -495,45 +495,6 @@ def _apply_price_warning(
 GRATIS_THRESHOLD = Decimal("99.9")
 
 
-def compute_eff_discount_pct(
-    rabata_pct,
-    doc_discount_pct: Decimal | float | int | None = None,
-) -> pd.Series:
-    """Return effective discount percentage combining line and document discounts.
-
-    Parameters
-    ----------
-    rabata_pct : pandas.Series | array-like
-        Line-level discount percentages.
-    doc_discount_pct : Decimal | float | int | None, optional
-        Document-level discount percentage applied uniformly to all lines.
-
-    Returns
-    -------
-    pandas.Series
-        Effective discount percentages as :class:`~decimal.Decimal` values rounded
-        to two decimal places. Lines meeting or exceeding
-        :data:`GRATIS_THRESHOLD` are reported as ``Decimal("100")``.
-    """
-
-    line_disc = pd.to_numeric(rabata_pct, errors="coerce").fillna(0).to_numpy(dtype=float)
-
-    try:
-        doc_disc = float(doc_discount_pct) if doc_discount_pct is not None else 0.0
-    except Exception:
-        doc_disc = 0.0
-
-    eff = 1 - (1 - line_disc / 100.0) * (1 - doc_disc / 100.0)
-    eff *= 100.0
-    eff = np.clip(eff, 0.0, 100.0)
-    eff = np.where(line_disc >= float(GRATIS_THRESHOLD), 100.0, eff)
-
-    idx = rabata_pct.index if isinstance(rabata_pct, pd.Series) else None
-    eff_series = pd.Series(eff, index=idx)
-    return eff_series.apply(
-        lambda x: Decimal(str(x)).quantize(Decimal("0.01"), ROUND_HALF_UP)
-    )
-
 def first_existing(df: pd.DataFrame, columns: Sequence[str]) -> pd.Series:
     """Return the first available column from ``df``.
 
@@ -576,9 +537,24 @@ def compute_eff_discount_pct(
 ) -> pd.Series:
     """Return effective discount percentage combining line and document discounts.
 
-    This enhanced version accepts a Series, array-like object or DataFrame for
-    ``rabata_pct``. When a DataFrame is provided the first existing column is
-    used. Both numeric and textual inputs are handled gracefully with numeric
+    Parameters
+    ----------
+    rabata_pct : pandas.Series | array-like | pandas.DataFrame
+        Line-level discount percentages. When a DataFrame is provided the first
+        existing column is used.
+    doc_discount_pct : Decimal | float | int | str | None, optional
+        Document-level discount percentage applied uniformly to all lines.
+
+    Returns
+    -------
+    pandas.Series
+        Effective discount percentages as :class:`~decimal.Decimal` values rounded
+        to two decimal places. Lines meeting or exceeding
+        :data:`GRATIS_THRESHOLD` are reported as ``Decimal("100")``.
+
+    Notes
+    -----
+    Both numeric and textual inputs are handled gracefully with numeric
     fallbacks defaulting to ``0`` and textual fallbacks defaulting to an empty
     string.
     """


### PR DESCRIPTION
## Summary
- remove outdated compute_eff_discount_pct definition
- document and retain enhanced discount calculation helper

## Testing
- `pytest -q` *(fails: multiple test failures, e.g., 56 failed, 197 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a44c70de308321b8cbd3f1ea872258