### PR TITLE
feat: compute discount from amounts

### DIFF
--- a/tests/test_eff_discount_pct.py
+++ b/tests/test_eff_discount_pct.py
@@ -1,0 +1,15 @@
+from decimal import Decimal
+import pandas as pd
+
+from wsm.ui.review.helpers import compute_eff_discount_pct
+
+
+def test_discount_derived_from_amounts_and_threshold():
+    df = pd.DataFrame(
+        {
+            "vrednost": [Decimal("18"), Decimal("0.1")],
+            "rabata": [Decimal("2"), Decimal("19.9")],
+        }
+    )
+    pct = compute_eff_discount_pct(df)
+    assert list(pct) == [Decimal("10.00"), Decimal("100.00")]

--- a/tests/test_gratis_total.py
+++ b/tests/test_gratis_total.py
@@ -12,7 +12,7 @@ def _calc_totals(xml_path: Path):
     doc_discount_total = df_doc["vrednost"].sum()
     df = df[df["sifra_dobavitelja"] != "_DOC_"].copy()
     df["total_net"] = df["vrednost"]
-    df["is_gratis"] = df["rabata_pct"] >= Decimal("99.9")
+    df["is_gratis"] = df["rabata_pct"] >= Decimal("99.5")
     df["wsm_sifra"] = pd.NA
     df.loc[df["naziv"] == "Normal", "wsm_sifra"] = "X"
 
@@ -55,6 +55,6 @@ def test_gratis_line_excluded_from_totals(tmp_path):
     xml_path.write_text(xml)
 
     net, vat, gross = _calc_totals(xml_path)
-    assert net == Decimal("10")
+    assert net == Decimal("5")
     assert vat == Decimal("0")
     assert gross == net

--- a/tests/test_totals_missing_389.py
+++ b/tests/test_totals_missing_389.py
@@ -11,7 +11,7 @@ def test_totals_missing_389():
 
     doc_discount = -df[df["sifra_dobavitelja"] == "_DOC_"]["vrednost"].sum()
     lines = df[df["sifra_dobavitelja"] != "_DOC_"]
-    lines = lines[lines["rabata_pct"] < Decimal("99.9")]
+    lines = lines[lines["rabata_pct"] < Decimal("99.5")]
     line_total = lines["vrednost"].sum()
 
     header_net = df["vrednost"].sum()

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -745,8 +745,7 @@ def review_links(
         )
         eur = first_existing(df, ["rabata", "popust_eur", "popust"])
         gross = gross.where(gross != 0, net + eur)
-        pct = first_existing(df, ["rabata_pct"])
-        eff_pct = compute_eff_discount_pct(pct, gross=gross, net=net, eur=eur)
+        eff_pct = compute_eff_discount_pct(df)
 
         valid = df["wsm_sifra"].notna() & (df["wsm_sifra"].astype(str).str.strip() != "")
         if not valid.any():


### PR DESCRIPTION
## Summary
- infer discount percentages from DataFrame columns, treating >=99.5% as 100%
- use new discount helper in review GUI
- adjust gratis handling and add coverage for euro-only discounts

## Testing
- `pytest tests/test_eff_discount_pct.py tests/test_gratis_total.py tests/test_totals_missing_389.py`
- `pytest` *(fails: assert Decimal('0') == Decimal('2.00') and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a458091120832193a3b9cce26fd3ed