### PR TITLE
Handle zero base in discount pct

### DIFF
--- a/tests/test_eff_discount_pct.py
+++ b/tests/test_eff_discount_pct.py
@@ -13,3 +13,20 @@ def test_discount_derived_from_amounts_and_threshold():
     )
     pct = compute_eff_discount_pct(df)
     assert list(pct) == [Decimal("10.00"), Decimal("100.00")]
+
+
+def test_doc_discount_ignored_when_base_zero():
+    df = pd.DataFrame(
+        {
+            "net_po_rab": [Decimal("0"), Decimal("100")],
+            "rabata": [Decimal("0"), Decimal("10")],
+        }
+    )
+    pct = compute_eff_discount_pct(df, doc_discount_pct=Decimal("10"))
+    assert pct.tolist() == [Decimal("0.00"), Decimal("19.00")]
+
+
+def test_doc_discount_ignored_when_no_amounts():
+    df = pd.DataFrame({"wsm_sifra": [1]})
+    pct = compute_eff_discount_pct(df, doc_discount_pct=Decimal("10"))
+    assert pct.tolist() == [Decimal("0.00")]


### PR DESCRIPTION
## Summary
- include rows with missing discount in summary by disabling groupby `dropna`
- ensure `compute_eff_discount_pct` returns 0 when base amount is missing or zero
- add tests covering document discount with zero base

## Testing
- `pre-commit run --files wsm/ui/review/gui.py wsm/ui/review/helpers.py tests/test_eff_discount_pct.py`
- `pytest` *(fails: 56 failed, 200 passed, 3 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68a45d0283dc8321b2425765b612bccd