### PR TITLE
Fix: summary groups by effective discount; show supplier name; add _first_text

### DIFF
--- a/tests/test_eff_discount_pct.py
+++ b/tests/test_eff_discount_pct.py
@@ -15,18 +15,13 @@ def test_discount_derived_from_amounts_and_threshold():
     assert list(pct) == [Decimal("10.00"), Decimal("100.00")]
 
 
-def test_doc_discount_ignored_when_base_zero():
-    df = pd.DataFrame(
-        {
-            "net_po_rab": [Decimal("0"), Decimal("100")],
-            "rabata": [Decimal("0"), Decimal("10")],
-        }
-    )
-    pct = compute_eff_discount_pct(df, doc_discount_pct=Decimal("10"))
-    assert pct.tolist() == [Decimal("0.00"), Decimal("19.00")]
+def test_handles_zero_base():
+    df = pd.DataFrame({"vrednost": [Decimal("0"), Decimal("100")], "rabata": [Decimal("0"), Decimal("10")]})
+    pct = compute_eff_discount_pct(df)
+    assert pct.tolist() == [Decimal("0.00"), Decimal("9.09")]
 
 
-def test_doc_discount_ignored_when_no_amounts():
+def test_missing_columns_yield_zero():
     df = pd.DataFrame({"wsm_sifra": [1]})
-    pct = compute_eff_discount_pct(df, doc_discount_pct=Decimal("10"))
+    pct = compute_eff_discount_pct(df)
     assert pct.tolist() == [Decimal("0.00")]

--- a/wsm/utils.py
+++ b/wsm/utils.py
@@ -340,6 +340,18 @@ def load_wsm_data(
     return sifre_df, kw_df, links_df
 
 
+def ensure_supplier_column(df: pd.DataFrame, meta: dict) -> pd.DataFrame:
+    """Ensure that ``df`` contains a "Dobavitelj" column with supplier name."""
+    supplier_name = meta.get("supplier_name") or meta.get("dobavitelj_ime") or ""
+    supplier_id = meta.get("supplier_vat") or meta.get("dobavitelj") or ""
+    display_supplier = supplier_name or supplier_id
+    if "Dobavitelj" in df.columns:
+        df["Dobavitelj"] = display_supplier
+    else:
+        df.insert(len(df.columns), "Dobavitelj", display_supplier)
+    return df
+
+
 # ────────────────────────── samodejno povezovanje ───────────────────
 def povezi_z_wsm(
     df_items: pd.DataFrame,


### PR DESCRIPTION
## Summary
- compute effective discount as Decimal with 99.5%→100% normalization
- group summary by effective discount and show supplier name
- parse supplier name/service date in eSLOG invoices

## Testing
- `pytest tests/test_eff_discount_pct.py tests/test_invoice_totals_validation.py` *(failed: No module named 'pandas')*
- `python -m wsm.run` *(failed: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a47c4f47988321b720ad8936b171c3