### PR TITLE
Adjust tests to pass Series to compute_eff_discount_pct

### DIFF
--- a/tests/test_eff_discount_pct.py
+++ b/tests/test_eff_discount_pct.py
@@ -11,17 +11,25 @@ def test_discount_derived_from_amounts_and_threshold():
             "rabata": [Decimal("2"), Decimal("19.9")],
         }
     )
-    pct = compute_eff_discount_pct(df)
-    assert list(pct) == [Decimal("10.00"), Decimal("100.00")]
+    pct = df.apply(compute_eff_discount_pct, axis=1)
+    expected = pd.Series([Decimal("10.00"), Decimal("100.00")])
+    pd.testing.assert_series_equal(pct, expected)
 
 
 def test_handles_zero_base():
-    df = pd.DataFrame({"vrednost": [Decimal("0"), Decimal("100")], "rabata": [Decimal("0"), Decimal("10")]})
-    pct = compute_eff_discount_pct(df)
-    assert pct.tolist() == [Decimal("0.00"), Decimal("9.09")]
+    df = pd.DataFrame(
+        {
+            "vrednost": [Decimal("0"), Decimal("100")],
+            "rabata": [Decimal("0"), Decimal("10")],
+        }
+    )
+    pct = df.apply(compute_eff_discount_pct, axis=1)
+    expected = pd.Series([Decimal("0.00"), Decimal("9.09")])
+    pd.testing.assert_series_equal(pct, expected)
 
 
 def test_missing_columns_yield_zero():
     df = pd.DataFrame({"wsm_sifra": [1]})
-    pct = compute_eff_discount_pct(df)
-    assert pct.tolist() == [Decimal("0.00")]
+    pct = df.apply(compute_eff_discount_pct, axis=1)
+    expected = pd.Series([Decimal("0.00")])
+    pd.testing.assert_series_equal(pct, expected)


### PR DESCRIPTION
## Summary
- Allow `compute_eff_discount_pct` to accept either DataFrames or row Series
- Update `compute_eff_discount_pct` tests to pass a Series via `DataFrame.apply` and assert Series results

## Testing
- `pre-commit run --files tests/test_eff_discount_pct.py wsm/ui/review/helpers.py`
- `pytest tests/test_eff_discount_pct.py -q`
- `pytest -q` *(fails: numerous unrelated test failures and missing dependencies such as Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a566feec38832192fd53bc576aadac