### PR TITLE
Adjust summary to show net after discount

### DIFF
--- a/tests/test_update_summary_net.py
+++ b/tests/test_update_summary_net.py
@@ -1,0 +1,61 @@
+import inspect
+import textwrap
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+import wsm.ui.review.gui as rl
+from wsm.ui.review.helpers import first_existing
+import wsm.ui.review.summary_utils as summary_utils
+
+
+def _extract_update_summary():
+    src = inspect.getsource(rl.review_links).splitlines()
+    start = next(i for i, line in enumerate(src) if "def _update_summary" in line)
+    end = next(
+        i for i, line in enumerate(src[start:], start)
+        if line.startswith("    # Skupni zneski")
+    )
+    snippet = textwrap.dedent("\n".join(src[start:end]))
+    ns = {
+        "pd": pd,
+        "Decimal": Decimal,
+        "first_existing": first_existing,
+        "compute_eff_discount_pct_robust":
+            lambda df, *a, **k: pd.Series([Decimal("0.00")] * len(df)),
+        "log": rl.log,
+    }
+    exec(snippet, ns)
+    return ns["_update_summary"], ns
+
+
+def test_update_summary_uses_discounted_net(monkeypatch):
+    records_holder: dict[str, list] = {}
+
+    def fake_summary_df_from_records(records):
+        records_holder["records"] = records
+        return pd.DataFrame()
+
+    monkeypatch.setattr(
+        summary_utils, "summary_df_from_records", fake_summary_df_from_records
+    )
+
+    _update_summary, ns = _extract_update_summary()
+    df = pd.DataFrame(
+        {
+            "wsm_sifra": ["1", "1"],
+            "wsm_naziv": ["Item", "Item"],
+            "vrednost": [100, 50],
+            "rabata": [20, 5],
+            "kolicina_norm": [1, 1],
+        }
+    )
+    ns.update({"df": df, "_render_summary": lambda df: None})
+
+    _update_summary()
+
+    records = records_holder["records"]
+    assert len(records) == 1
+    assert records[0]["Znesek"] == pytest.approx(150.0)
+    assert records[0]["Neto po rabatu"] == pytest.approx(125.0)

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -821,7 +821,10 @@ def review_links(
                     "Količina": float(row.get("kolicina_norm", 0) or 0),
                     "Znesek": float(row.get("vrednost", 0) or 0),
                     "Rabat (%)": row.get("eff_discount_pct", Decimal("0.00")),
-                    "Neto po rabatu": float(row.get("vrednost", 0) or 0),
+                    "Neto po rabatu": float(
+                        (row.get("vrednost", 0) or 0)
+                        - (row.get("rabata", 0) or 0)
+                    ),
                 }
             )
 


### PR DESCRIPTION
## Summary
- compute discounted net amount in GUI summary records
- test that summary reflects net amount after applying discount

## Testing
- `pytest tests/test_update_summary_net.py -q`
- `pytest -q` *(fails: many tests fail with IndexError/AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68a5815211288321b91f6f41ba6690c7