### PR TITLE
Use Decimal values in summary records

### DIFF
--- a/tests/test_update_summary_net.py
+++ b/tests/test_update_summary_net.py
@@ -3,7 +3,6 @@ import textwrap
 from decimal import Decimal
 
 import pandas as pd
-import pytest
 
 import wsm.ui.review.gui as rl
 from wsm.ui.review.helpers import first_existing
@@ -57,5 +56,5 @@ def test_update_summary_uses_discounted_net(monkeypatch):
 
     records = records_holder["records"]
     assert len(records) == 1
-    assert records[0]["Znesek"] == pytest.approx(150.0)
-    assert records[0]["Neto po rabatu"] == pytest.approx(125.0)
+    assert records[0]["Znesek"] == Decimal("150")
+    assert records[0]["Neto po rabatu"] == Decimal("125")

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -817,13 +817,11 @@ def review_links(
                 {
                     "WSM šifra": row["wsm_sifra"],
                     "WSM Naziv": row.get("wsm_naziv", ""),
-                    "Količina": float(row.get("kolicina_norm", 0) or 0),
-                    "Znesek": float(row.get("vrednost", 0) or 0),
+                    "Količina": Decimal(str(row.get("kolicina_norm", 0) or 0)),
+                    "Znesek": Decimal(str(row.get("vrednost", 0) or 0)),
                     "Rabat (%)": row.get("eff_discount_pct", Decimal("0.00")),
-                    "Neto po rabatu": float(
-                        (row.get("vrednost", 0) or 0)
-                        - (row.get("rabata", 0) or 0)
-                    ),
+                    "Neto po rabatu": Decimal(str(row.get("vrednost", 0) or 0))
+                    - Decimal(str(row.get("rabata", 0) or 0)),
                 }
             )
 

--- a/wsm/ui/review/summary_utils.py
+++ b/wsm/ui/review/summary_utils.py
@@ -24,14 +24,14 @@ def summary_df_from_records(records: Sequence[dict] | None) -> pd.DataFrame:
     df = df.reindex(columns=SUMMARY_COLS)
 
     numeric_cols = ["Količina", "Znesek", "Rabat (%)", "Neto po rabatu"]
+
+    def _to_decimal(x):
+        if isinstance(x, Decimal):
+            return x
+        return Decimal(str(x)) if not pd.isna(x) and x != "" else Decimal("0")
+
     for col in numeric_cols:
-        df[col] = df[col].apply(
-            lambda x: (
-                x
-                if isinstance(x, Decimal)
-                else Decimal(str(x)) if not pd.isna(x) and x != "" else Decimal("0")
-            )
-        )
+        df[col] = df[col].map(_to_decimal)
     text_cols = ["WSM šifra", "WSM Naziv"]
     df = _safe_set_block(df, text_cols, df[text_cols].fillna(""))
     return df


### PR DESCRIPTION
## Summary
- avoid float conversion when building summary records
- ensure summary_df_from_records handles Decimal inputs directly
- update tests to expect Decimal values

## Testing
- `pytest tests/test_summary_df_from_records.py tests/test_update_summary_net.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a58fdbbb088321b56db04a9d316321