### PR TITLE
Add test for discount-based summary separation

### DIFF
--- a/tests/test_update_summary_discounts.py
+++ b/tests/test_update_summary_discounts.py
@@ -1,0 +1,64 @@
+import inspect
+import textwrap
+from decimal import Decimal
+
+import pandas as pd
+
+import wsm.ui.review.gui as rl
+from wsm.ui.review.helpers import first_existing
+import wsm.ui.review.summary_utils as summary_utils
+
+
+def _extract_update_summary():
+    src = inspect.getsource(rl.review_links).splitlines()
+    start = next(i for i, line in enumerate(src) if "def _update_summary" in line)
+    end = next(
+        i for i, line in enumerate(src[start:], start)
+        if line.startswith("    # Skupni zneski")
+    )
+    snippet = textwrap.dedent("\n".join(src[start:end]))
+    ns = {
+        "pd": pd,
+        "Decimal": Decimal,
+        "first_existing": first_existing,
+        "compute_eff_discount_pct_robust":
+            lambda df, *a, **k: pd.Series([Decimal("0.00")] * len(df)),
+        "log": rl.log,
+    }
+    exec(snippet, ns)
+    return ns["_update_summary"], ns
+
+
+def test_update_summary_splits_per_discount(monkeypatch):
+    records_holder: dict[str, list] = {}
+
+    def fake_summary_df_from_records(records):
+        records_holder["records"] = records
+        return pd.DataFrame()
+
+    monkeypatch.setattr(
+        summary_utils, "summary_df_from_records", fake_summary_df_from_records
+    )
+
+    _update_summary, ns = _extract_update_summary()
+
+    df = pd.DataFrame(
+        {
+            "wsm_sifra": ["1", "1"],
+            "wsm_naziv": ["Item", "Item"],
+            "vrednost": [100, 100],
+            "rabata": [20, 10],
+            "kolicina_norm": [1, 1],
+        }
+    )
+    ns.update({"df": df, "_render_summary": lambda df: None})
+    ns["compute_eff_discount_pct_robust"] = lambda df, *a, **k: pd.Series(
+        [Decimal("20"), Decimal("10")]
+    )
+
+    _update_summary()
+
+    records = records_holder["records"]
+    assert len(records) == 2
+    discounts = {record["Rabat (%)"] for record in records}
+    assert discounts == {Decimal("20"), Decimal("10")}


### PR DESCRIPTION
## Summary
- verify `_update_summary` splits summary records by discount level

## Testing
- `pytest tests/test_update_summary_discounts.py`


------
https://chatgpt.com/codex/tasks/task_e_68a590ffbe808321bdf4a1c9460bc50f