### PR TITLE
Preserve Decimal values in summary

### DIFF
--- a/wsm/ui/review/summary_utils.py
+++ b/wsm/ui/review/summary_utils.py
@@ -20,7 +20,7 @@ def summary_df_from_records(records: Sequence[dict] | None) -> pd.DataFrame:
         values are filled with defaults and the DataFrame is reindexed to
         :data:`SUMMARY_COLS`.
     """
-    df = pd.DataFrame.from_records(records or [])
+    df = pd.DataFrame.from_records(records or [], coerce_float=False)
     df = df.reindex(columns=SUMMARY_COLS)
 
     numeric_cols = ["Količina", "Znesek", "Rabat (%)", "Neto po rabatu"]


### PR DESCRIPTION
## Summary
- avoid float conversion in review summary calculations by parsing values directly to Decimal
- allow `summary_df_from_records` to retain Decimal entries

## Testing
- `pytest tests/test_summary_df_from_records.py tests/test_update_summary_discounts.py tests/test_update_summary_net.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a2e8cad8832191af7323bda0e0d0