### PR TITLE
Handle robust summary grouping with decimals

### DIFF
--- a/tests/test_summary_column_flex.py
+++ b/tests/test_summary_column_flex.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from decimal import Decimal
+from wsm.ui.review.helpers import compute_eff_discount_pct_robust, first_existing_series
+
+def test_eff_pct_from_alternatives():
+    df = pd.DataFrame({
+        "WSM šifra": ["200607","200607"],
+        "Količina":  [6,6],
+        "Net. po rab.": [Decimal("0"), Decimal("4.84")],
+        "Skupna neto":  [Decimal("0"), Decimal("29.04")],
+        "Bruto":        [Decimal("29.04"), Decimal("29.04")],
+        "rabat":        [Decimal("29.04"), Decimal("0.00")],
+    })
+    pct = compute_eff_discount_pct_robust(df)
+    assert pct.iloc[0] == Decimal("100.00")
+    assert pct.iloc[1] == Decimal("0.00")

--- a/tests/test_update_summary_discounts.py
+++ b/tests/test_update_summary_discounts.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 import pandas as pd
 
 import wsm.ui.review.gui as rl
-from wsm.ui.review.helpers import first_existing
+from wsm.ui.review.helpers import first_existing, first_existing_series
 import wsm.ui.review.summary_utils as summary_utils
 
 
@@ -24,6 +24,10 @@ def _extract_update_summary():
         "compute_eff_discount_pct_robust":
             lambda df, *a, **k: pd.Series([Decimal("0.00")] * len(df)),
         "log": rl.log,
+        "first_existing_series": first_existing_series,
+        "series_to_dec": lambda s: s,
+        "to_dec": lambda x: x,
+        "np": __import__('numpy'),
     }
     exec(snippet, ns)
     return ns["_update_summary"], ns

--- a/tests/test_update_summary_flexible_cols.py
+++ b/tests/test_update_summary_flexible_cols.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 import pandas as pd
 
 import wsm.ui.review.gui as rl
-from wsm.ui.review.helpers import first_existing
+from wsm.ui.review.helpers import first_existing, first_existing_series
 import wsm.ui.review.summary_utils as summary_utils
 
 
@@ -25,6 +25,10 @@ def _extract_update_summary():
         "compute_eff_discount_pct_robust":
             lambda df, *a, **k: pd.Series([Decimal("0.00")] * len(df)),
         "log": rl.log,
+        "first_existing_series": first_existing_series,
+        "series_to_dec": lambda s: s,
+        "to_dec": lambda x: x,
+        "np": __import__('numpy'),
     }
     exec(snippet, ns)
     return ns["_update_summary"], ns

--- a/tests/test_update_summary_net.py
+++ b/tests/test_update_summary_net.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 import pandas as pd
 
 import wsm.ui.review.gui as rl
-from wsm.ui.review.helpers import first_existing
+from wsm.ui.review.helpers import first_existing, first_existing_series
 import wsm.ui.review.summary_utils as summary_utils
 
 
@@ -24,6 +24,10 @@ def _extract_update_summary():
         "compute_eff_discount_pct_robust":
             lambda df, *a, **k: pd.Series([Decimal("0.00")] * len(df)),
         "log": rl.log,
+        "first_existing_series": first_existing_series,
+        "series_to_dec": lambda s: s,
+        "to_dec": lambda x: x,
+        "np": __import__('numpy'),
     }
     exec(snippet, ns)
     return ns["_update_summary"], ns


### PR DESCRIPTION
## Summary
- add Decimal helpers and flexible column lookups for summary
- group invoice summary by effective discount and keep sums in Decimal
- test effective discount with alternative column names

## Testing
- `pytest` *(fails: assertion errors and missing data; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a58bb7dcb483219e6b6d1f13a30387