### PR TITLE
feat: add helper to ensure effective discount column

### DIFF
--- a/wsm/ui/review/__init__.py
+++ b/wsm/ui/review/__init__.py
@@ -1,5 +1,5 @@
 from wsm.constants import PRICE_DIFF_THRESHOLD
-from .helpers import _fmt, _norm_unit, _apply_price_warning
+from .helpers import _fmt, _norm_unit, _apply_price_warning, ensure_eff_discount_col
 from .gui import review_links, log
 from .io import _save_and_close, _load_supplier_map, _write_supplier_map
 
@@ -12,5 +12,6 @@ __all__ = [
     "_save_and_close",
     "_load_supplier_map",
     "_write_supplier_map",
+    "ensure_eff_discount_col",
     "log",
 ]

--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -715,3 +715,30 @@ def compute_eff_discount_pct(
 
     pct = pct.apply(_to_dec)
     return pct.iloc[0] if is_series else pct
+
+
+def ensure_eff_discount_col(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure an ``eff_discount_pct`` column with quantized ``Decimal`` values.
+
+    If the column is missing, it is calculated via
+    :func:`compute_eff_discount_pct_robust`.  When present, all existing values
+    are coerced to :class:`~decimal.Decimal` and quantized to two decimal places.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to operate on. Modified in-place and returned for
+        convenience.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The input ``df`` with a normalised ``eff_discount_pct`` column.
+    """
+
+    col = "eff_discount_pct"
+    if col not in df.columns:
+        df.loc[:, col] = compute_eff_discount_pct_robust(df)
+    else:
+        df.loc[:, col] = df[col].map(lambda v: q2(to_dec(v)))
+    return df


### PR DESCRIPTION
## Summary
- add `ensure_eff_discount_col` to normalise or compute `eff_discount_pct`
- expose new helper via the `wsm.ui.review` package

## Testing
- `pytest -q` *(fails: numerous tests failing; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b56eb86083219ac805d3baebf6a9