### PR TITLE
Reuse precomputed discounts in summary

### DIFF
--- a/tests/test_update_summary_discounts.py
+++ b/tests/test_update_summary_discounts.py
@@ -21,12 +21,11 @@ def _extract_update_summary():
         "pd": pd,
         "Decimal": Decimal,
         "first_existing": first_existing,
-        "compute_eff_discount_pct_robust":
-            lambda df, *a, **k: pd.Series([Decimal("0.00")] * len(df)),
         "log": rl.log,
         "first_existing_series": first_existing_series,
-        "series_to_dec": lambda s: s,
-        "to_dec": lambda x: x,
+        "series_to_dec": lambda s: s.map(Decimal),
+        "to_dec": Decimal,
+        "summary_df_from_records": summary_utils.summary_df_from_records,
         "np": __import__('numpy'),
     }
     exec(snippet, ns)
@@ -53,12 +52,11 @@ def test_update_summary_splits_per_discount(monkeypatch):
             "vrednost": [100, 100],
             "rabata": [20, 10],
             "kolicina_norm": [1, 1],
+            "Skupna neto": [80, 90],
+            "eff_discount_pct": [Decimal("20"), Decimal("10")],
         }
     )
     ns.update({"df": df, "_render_summary": lambda df: None})
-    ns["compute_eff_discount_pct_robust"] = lambda df, *a, **k: pd.Series(
-        [Decimal("20"), Decimal("10")]
-    )
 
     _update_summary()
 

--- a/tests/test_update_summary_net.py
+++ b/tests/test_update_summary_net.py
@@ -21,12 +21,11 @@ def _extract_update_summary():
         "pd": pd,
         "Decimal": Decimal,
         "first_existing": first_existing,
-        "compute_eff_discount_pct_robust":
-            lambda df, *a, **k: pd.Series([Decimal("0.00")] * len(df)),
         "log": rl.log,
         "first_existing_series": first_existing_series,
-        "series_to_dec": lambda s: s,
-        "to_dec": lambda x: x,
+        "series_to_dec": lambda s: s.map(Decimal),
+        "to_dec": Decimal,
+        "summary_df_from_records": summary_utils.summary_df_from_records,
         "np": __import__('numpy'),
     }
     exec(snippet, ns)
@@ -52,6 +51,8 @@ def test_update_summary_uses_discounted_net(monkeypatch):
             "vrednost": [100, 50],
             "rabata": [20, 5],
             "kolicina_norm": [1, 1],
+            "Skupna neto": [80, 45],
+            "eff_discount_pct": [Decimal("0"), Decimal("0")],
         }
     )
     ns.update({"df": df, "_render_summary": lambda df: None})

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -792,8 +792,9 @@ def review_links(
         m = need_bruto & net_line_d.notna() & rabat_d.notna()
         bruto_d.loc[m] = (net_line_d.loc[m] + rabat_d.loc[m]).map(to_dec)
 
-        # Uporabi že izračunan efektivni rabat
-        eff_pct = df["eff_discount_pct"].map(to_dec)
+        # Uporabi že izračunan efektivni rabat iz delovnega DF
+        eff_pct_raw = first_existing_series(df, ["eff_discount_pct"], 0)
+        eff_pct = series_to_dec(pd.to_numeric(eff_pct_raw, errors="coerce"))
 
         # če bruto še 0, ga izpelji iz net/(1-p)
         p = eff_pct.map(lambda d: (d / Decimal("100")).quantize(Decimal("0.0001")))


### PR DESCRIPTION
## Summary
- Pull effective discount percentages directly from the working dataframe in `_update_summary`
- Build summary records using the existing `eff_discount_pct` column
- Adjust tests to provide and validate the reuse of `eff_discount_pct`

## Testing
- `pytest tests/test_update_summary_discounts.py::test_update_summary_splits_per_discount -q`
- `pytest tests/test_update_summary_flexible_cols.py::test_update_summary_handles_flexible_columns -q`
- `pytest tests/test_update_summary_net.py::test_update_summary_uses_discounted_net -q`
- `pytest -q` *(fails: multiple unrelated tests and missing Xvfb)*


------
https://chatgpt.com/codex/tasks/task_e_68a5b89e0c008321b3563e81dbad28e0