### PR TITLE
Fix discount pct calc for non-default indexes

### DIFF
--- a/tests/test_eff_discount_pct.py
+++ b/tests/test_eff_discount_pct.py
@@ -47,14 +47,7 @@ def test_summary_distinguishes_discounts_without_pct_column():
             "kolicina_norm": [1, 1, 1],
         }
     )
-
-    pct = compute_eff_discount_pct_robust(
-        df,
-        ["Rabat (%)"],
-        ["neto_brez_popusta"],
-        ["vrednost"],
-        ["rabata"],
-    )
+    pct = compute_eff_discount_pct_robust(df)
     df["pct"] = pct
     agg = (
         df.groupby(["wsm_sifra", "pct"], dropna=False)
@@ -73,29 +66,23 @@ def test_summary_distinguishes_discounts_without_pct_column():
 def test_discount_from_gross_and_net_only():
     df = pd.DataFrame(
         {
-            "gross": [Decimal("10"), Decimal("5")],
-            "net": [Decimal("7.18"), Decimal("0")],
+            "Bruto": [Decimal("10"), Decimal("5")],
+            "Neto po rabatu": [Decimal("7.18"), Decimal("0")],
         }
     )
-    pct = compute_eff_discount_pct_robust(
-        df,
-        ["pct"],
-        ["gross"],
-        ["net"],
-        ["disc"],
-    )
-    expected = pd.Series([Decimal("28.20"), Decimal("100.00")])
+    pct = compute_eff_discount_pct_robust(df)
+    expected = pd.Series([Decimal("28.20"), Decimal("100.00")], index=df.index)
     pd.testing.assert_series_equal(pct, expected)
 
 
 def test_detects_100pct_discount_from_amounts():
-    df = pd.DataFrame({"net": [Decimal("0")], "rabata": [Decimal("5")]})
-    pct = compute_eff_discount_pct_robust(
-        df,
-        ["pct"],
-        ["gross"],
-        ["net"],
-        ["rabata"],
+    df = pd.DataFrame(
+        {
+            "Neto po rabatu": [Decimal("10"), Decimal("0")],
+            "rabata": [Decimal("5"), Decimal("5")],
+        },
+        index=[2, 5],
     )
-    expected = pd.Series([Decimal("100.00")])
+    pct = compute_eff_discount_pct_robust(df)
+    expected = pd.Series([Decimal("33.33"), Decimal("100.00")], index=[2, 5])
     pd.testing.assert_series_equal(pct, expected)


### PR DESCRIPTION
## Summary
- avoid label-based indexing of discount amounts by iterating with `zip`
- adjust tests for `compute_eff_discount_pct_robust`, including a case with non-range index

## Testing
- `pre-commit run --files wsm/ui/review/helpers.py`
- `pre-commit run --files tests/test_eff_discount_pct.py`
- `pytest tests/test_eff_discount_pct.py tests/test_summary_column_flex.py`
- `pytest` *(fails: tests/test_parse_eslog_invoice_moa260.py::test_parse_eslog_invoice_moa260, tests/test_parse_eslog_supplier.py::test_line_discount_is_applied, tests/test_parse_eslog_supplier.py::test_line_discount_factor, tests/test_parse_eslog_supplier.py::test_line_discount_amount, tests/test_parse_eslog_supplier.py::test_line_discount_moa_and_pcd_are_summed, tests/test_parse_eslog_supplier.py::test_line_discount_without_namespace, tests/test_parse_eslog_supplier.py::test_line_discount_direct_pcd, tests/test_parse_invoice_eslog_string.py::test_parse_invoice_eslog_string_no_fs, tests/test_price_watch.py::test_load_price_histories_vat_dir, tests/test_split_totals_doc_discount.py::test_split_totals_linked_discount, tests/test_split_totals_doc_discount.py::test_split_totals_unlinked_discount, tests/test_split_totals_no_doc_row.py::test_split_totals_matches_header_without_doc_row, tests/test_supplier_edit_save.py::test_supplier_edit_saved_to_custom_dir, tests/test_supplier_edit_save.py::test_supplier_folder_renamed_on_vat_change, tests/test_supplier_edit_save.py::test_unknown_folder_removed_when_vat_exists, tests/test_supplier_move_fallback.py::test_supplier_move_fallback, tests/test_unbooked_highlight.py::test_unbooked_highlight, tests/test_update_summary_net.py::test_update_summary_uses_discounted_net, tests/test_use_existing_folder.py::test_open_invoice_gui_uses_vat_from_map)`


------
https://chatgpt.com/codex/tasks/task_e_68a6e9c3cb948321b6bcf5aa0b5fd6fe