### PR TITLE
Handle None in merge and centralize discount candidates

### DIFF
--- a/tests/test_merge_same_items.py
+++ b/tests/test_merge_same_items.py
@@ -99,3 +99,42 @@ def test_merge_same_items_merges_duplicates_keeps_gratis():
 
     # VAT should sum across merged rows as expected
     assert result["ddv"].sum() == Decimal("13.2")
+
+
+def test_merge_same_items_handles_none_in_numeric_columns():
+    df = pd.DataFrame(
+        [
+            {
+                "code": "A",
+                "naziv": "ItemA",
+                "kolicina": None,
+                "kolicina_norm": None,
+                "vrednost": Decimal("10"),
+                "rabata": Decimal("0"),
+                "total_net": Decimal("10"),
+                "ddv": Decimal("2.2"),
+                "is_gratis": False,
+            },
+            {
+                "code": "A",
+                "naziv": "ItemA",
+                "kolicina": Decimal("1"),
+                "kolicina_norm": Decimal("1"),
+                "vrednost": Decimal("10"),
+                "rabata": Decimal("0"),
+                "total_net": Decimal("10"),
+                "ddv": Decimal("2.2"),
+                "is_gratis": False,
+            },
+        ]
+    )
+
+    result = _merge_same_items(df)
+
+    assert len(result) == 1
+    merged = result.iloc[0]
+    assert merged["kolicina"] == Decimal("1")
+    assert merged["kolicina_norm"] == Decimal("1")
+    assert merged["vrednost"] == Decimal("20")
+    assert merged["total_net"] == Decimal("20")
+    assert merged["ddv"] == Decimal("4.4")

--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -48,6 +48,35 @@ PRICE_DIFF_THRESHOLD = (
 )
 
 
+NET_CANDIDATES = [
+    "Neto po rabatu",
+    "vrednost",
+    "Skupna neto",
+    "vrednost_po_rabatu",
+    "total_net",
+    "net_line",
+    "neto",
+    "cena_po_rabatu",
+]
+
+DISC_CANDIDATES = [
+    "rabata",
+    "rabat",
+    "discount_amount",
+    "rabat_znesek",
+    "znesek_rabata",
+    "moa204",
+]
+
+GROSS_CANDIDATES = [
+    "Bruto",
+    "vrednost_bruto",
+    "bruto_line",
+    "Skupna bruto",
+    "cena_bruto",
+]
+
+
 def _fmt(v) -> str:
     """Return a human-friendly representation of ``v``.
 
@@ -398,6 +427,7 @@ def _merge_same_items(df: pd.DataFrame) -> pd.DataFrame:
     ):
         group_cols.append("eff_discount_pct")
 
+    to_merge[existing_numeric] = to_merge[existing_numeric].fillna(Decimal("0"))
     merged = (
         to_merge.groupby(group_cols, dropna=False)
         .agg({c: "sum" for c in existing_numeric})
@@ -707,40 +737,18 @@ def compute_eff_discount_pct_robust(df: pd.DataFrame) -> pd.Series:
     if pct is None:
         # 2) kandidati za neto, rabat in bruto
         net = None
-        for c in [
-            "Neto po rabatu",
-            "vrednost",
-            "Skupna neto",
-            "vrednost_po_rabatu",
-            "total_net",
-            "net_line",
-            "neto",
-            "cena_po_rabatu",
-        ]:
+        for c in NET_CANDIDATES:
             if c in df.columns:
                 net = df[c].map(_to_dec)
                 break
         # 3) znesek rabata
         disc = None
-        for c in [
-            "rabata",
-            "rabat",
-            "discount_amount",
-            "rabat_znesek",
-            "znesek_rabata",
-            "moa204",
-        ]:
+        for c in DISC_CANDIDATES:
             if c in df.columns:
                 disc = df[c].map(_to_dec)
                 break
         gross = None
-        for c in [
-            "Bruto",
-            "vrednost_bruto",
-            "bruto_line",
-            "Skupna bruto",
-            "cena_bruto",
-        ]:
+        for c in GROSS_CANDIDATES:
             if c in df.columns:
                 gross = df[c].map(_to_dec)
                 break


### PR DESCRIPTION
## Summary
- Avoid Decimal/None summation errors by filling missing numeric values before merging rows
- Extract candidate column lists for net, discount, and gross values into module-level constants
- Test merging when numeric fields contain None

## Testing
- `pytest -q` *(fails: numerous existing tests fail in this environment)*
- `pytest tests/test_merge_same_items.py tests/test_eff_discount_pct.py tests/test_summary_column_flex.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6edb4c1e88321a1a8a67814e305f7