### PR TITLE
feat: split items by discount

### DIFF
--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -427,7 +427,16 @@ def _merge_same_items(df: pd.DataFrame) -> pd.DataFrame:
     ):
         group_cols.append("eff_discount_pct")
 
-    to_merge[existing_numeric] = to_merge[existing_numeric].fillna(Decimal("0"))
+    # Respect discount/price bucket when present
+    if (
+        "_discount_bucket" in to_merge.columns
+        and "_discount_bucket" not in group_cols
+    ):
+        group_cols.append("_discount_bucket")
+
+    to_merge[existing_numeric] = to_merge[existing_numeric].fillna(
+        Decimal("0")
+    )
     merged = (
         to_merge.groupby(group_cols, dropna=False)
         .agg({c: "sum" for c in existing_numeric})


### PR DESCRIPTION
## Summary
- group GUI rows by discount and net price per item to prevent merging at different rates
- note discount and unit price in warning column and summary
- keep discount buckets when merging and use typing.Tuple for compatibility

## Testing
- `pre-commit run --files wsm/ui/review/gui.py wsm/ui/review/helpers.py`
- `pytest` *(fails: 56 failed, 208 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f15cdda48321965c12255eed60ff