### PR TITLE
Propagate parser line buckets for discount-aware merging

### DIFF
--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -71,6 +71,7 @@ XML_PARSER = LET.XMLParser(resolve_entities=False)
 # Use higher precision to avoid premature rounding when summing values.
 decimal.getcontext().prec = 28  # Python's default precision
 DEC2 = Decimal("0.01")
+DEC4 = Decimal("0.0001")
 TOL = Decimal("0.01")
 
 
@@ -1659,8 +1660,8 @@ def parse_eslog_invoice(
             else:
                 rabata_pct = Decimal("0.00")
 
-        is_gratis = rabata_pct >= Decimal("99.9")
-
+        eff_discount_pct = rabata_pct
+        is_gratis = (qty > 0 and net_amount == 0) or rabata_pct >= Decimal("99.9")
         item.update(
             {
                 "sifra_dobavitelja": supplier_code,
@@ -1671,6 +1672,11 @@ def parse_eslog_invoice(
                 "cena_netto": cena_post,
                 "rabata": rebate,
                 "rabata_pct": rabata_pct,
+                "eff_discount_pct": eff_discount_pct,
+                "line_bucket": (
+                    eff_discount_pct,
+                    cena_post.quantize(DEC4, rounding=ROUND_HALF_UP),
+                ),
                 "is_gratis": is_gratis,
                 "vrednost": net_amount,
                 "ddv_stopnja": vat_rate,

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -583,9 +583,12 @@ def review_links(
         )
         df.loc[(q > 0) & (t == 0), "is_gratis"] = True
 
-    # 2) po potrebi pripravi 'discount bucket' za stabilno grupiranje
+    # 2) pripravimo 'discount bucket' za stabilno grupiranje
     if GROUP_BY_DISCOUNT:
-        df["_discount_bucket"] = df.apply(_discount_bucket, axis=1)
+        if "line_bucket" in df.columns:
+            df["_discount_bucket"] = df["line_bucket"]
+        else:
+            df["_discount_bucket"] = df.apply(_discount_bucket, axis=1)
 
     if os.getenv("WSM_DEBUG_BUCKET") == "1":
         for i, r in df.iterrows():
@@ -890,7 +893,10 @@ def review_links(
             tree.item(str(i), tags=("gratis",) + current_tags)
 
             #  ➜ besedilo v stolpcu »Opozorilo«
-            tree.set(str(i), "warning", "GRATIS")
+            df.at[i, "warning"] = (
+                (df.at[i, "warning"] + " · ") if df.at[i, "warning"] else ""
+            ) + "GRATIS"
+            tree.set(str(i), "warning", df.at[i, "warning"])
     tree.focus("0")
     tree.selection_set("0")
 

--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -433,6 +433,8 @@ def _merge_same_items(df: pd.DataFrame) -> pd.DataFrame:
         and "_discount_bucket" not in group_cols
     ):
         group_cols.append("_discount_bucket")
+    if "line_bucket" in to_merge.columns and "line_bucket" not in group_cols:
+        group_cols.append("line_bucket")
 
     to_merge[existing_numeric] = to_merge[existing_numeric].fillna(
         Decimal("0")


### PR DESCRIPTION
## Summary
- Track effective line discount and bucket in `parse_eslog_invoice`
- Respect parser-provided buckets when merging UI review rows
- Mark free lines with a "GRATIS" warning in the review GUI

## Testing
- `pytest` *(fails: 56 failed, 208 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a7014db1a48321a8a9221fb3ce9c94