### PR TITLE
Guard discount bucket dtype and merge keys

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -589,6 +589,7 @@ def review_links(
             df["_discount_bucket"] = df["line_bucket"]
         else:
             df["_discount_bucket"] = df.apply(_discount_bucket, axis=1)
+
         # Sanacija: poskrbi, da je na VSAKI vrstici tuple (pct, unit)
         def _is_valid_bucket(val):
             return (
@@ -605,6 +606,8 @@ def review_links(
             return _discount_bucket(row)
 
         df["_discount_bucket"] = df.apply(_coerce_bucket, axis=1)
+        # nikoli ne dovoli implicitne pretvorbe v float (npr. zaradi NaN)
+        df["_discount_bucket"] = df["_discount_bucket"].astype(object)
 
     if os.getenv("WSM_DEBUG_BUCKET") == "1":
         for i, r in df.iterrows():


### PR DESCRIPTION
## Summary
- prevent `_discount_bucket` from implicitly converting to float after sanitization
- enforce item identity columns when merging and skip merge if it collapses distinct items

## Testing
- `pre-commit run --files wsm/ui/review/gui.py wsm/ui/review/helpers.py`
- `pytest` *(fails: assert errors and missing fixture dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a70c84f71c83218b989aad5fe4bf80