### PR TITLE
Handle NaN multipliers and default merged rows to non-gratis

### DIFF
--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -501,6 +501,12 @@ def _merge_same_items(df: pd.DataFrame) -> pd.DataFrame:
         to_merge.groupby(group_cols, dropna=False).agg(agg_dict).reset_index()
     )
 
+    # plačljive (ne-gratis) vrstice po merge naj bodo eksplicitno False
+    if "is_gratis" not in merged.columns:
+        merged["is_gratis"] = False
+    else:
+        merged["is_gratis"] = merged["is_gratis"].fillna(False)
+
     # če je na voljo bucket, nastavi/poravna enotno ceno iz njega
     if "_discount_bucket" in merged.columns:
         merged["cena_po_rabatu"] = merged.apply(


### PR DESCRIPTION
## Summary
- add `_as_dec` utility for robust Decimal coercion
- clean `multiplier` column in `review_links` to avoid `InvalidOperation`
- ensure merged paid rows set `is_gratis` to `False`

## Testing
- `pytest` *(fails: 58 failed, 206 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a75cdb2224832199a011cbe69cc9c0