### PR TITLE
Handle NaN multipliers in review GUI

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -1058,6 +1058,8 @@ def review_links(
                 multiplier = Decimal(str(multiplier_raw))
             except Exception:
                 multiplier = Decimal("1")
+            if not multiplier.is_finite():
+                multiplier = Decimal("1")
             if multiplier <= 1:
                 current_tags = tree.item(str(i)).get("tags", ())
                 if not isinstance(current_tags, tuple):


### PR DESCRIPTION
## Summary
- Prevent InvalidOperation when multiplier is NaN by falling back to 1 before comparison

## Testing
- `pytest` *(fails: 58 failed, 206 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c12ef7148321b77cd47ccdf99b36