### PR TITLE
Ensure pandas is imported at review_links start

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -338,6 +338,10 @@ def review_links(
         rows.
     """
 
+    # Poskrbi, da je 'pd' vedno na voljo v tem scope-u (prepreči UnboundLocalError,
+    # če se kasneje kje pojavi lokalni 'import pandas as pd').
+    import pandas as pd
+
     df = df.copy()
     log.debug("Initial invoice DataFrame:\n%s", df.to_string())
     if {"cena_bruto", "cena_netto"}.issubset(df.columns):


### PR DESCRIPTION
## Summary
- Avoid `UnboundLocalError` in `review_links` by explicitly importing pandas at the start of the function, ensuring `pd` is available even if later local imports appear.

## Testing
- `pytest -q` *(fails: 62 failed, 202 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7316ed0883219869d14b3cddbc0e