### PR TITLE
Prefer tolerant price key in merge and align price display

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -1027,6 +1027,16 @@ def review_links(
         df["warning"] = df.apply(_format_opozorilo, axis=1)
     except Exception as exc:
         log.debug("warning format (post-merge) failed: %s", exc)
+
+    # Za prikaz poravnaj ceno na "tolerantni" bucket (3 dec) – čisto kozmetika
+    def _price_from_bucket(row):
+        b = row.get("_discount_bucket")
+        if isinstance(b, (tuple, list)) and len(b) == 2:
+            return _as_dec(b[1], "0")
+        return _as_dec(row.get("cena_po_rabatu", "0"), "0")
+
+    if "_discount_bucket" in df.columns:
+        df["cena_po_rabatu"] = df.apply(_price_from_bucket, axis=1)
     _t(
         "STEP5 after merge: rows=%d head=%s",
         len(df),


### PR DESCRIPTION
## Summary
- Prefer `_price_key` derived from the tolerant `_discount_bucket` for merging so rows with the same rounded price collapse even if discount percentages differ
- Align displayed price with the tolerant discount bucket in the review grid

## Testing
- `pip install pyvirtualdisplay`
- `pytest` *(fails: 57 failed, 207 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1a68047883218eba8fb770a058ea