### PR TITLE
feat: add toggle for grouping by discount

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -1041,13 +1041,14 @@ def review_links(
         log.debug("warning format (post-merge) failed: %s", exc)
 
     # Za prikaz poravnaj ceno na "tolerantni" bucket (3 dec) – čisto kozmetika
+    # Samo, če grupiramo po ceni/rabatu; če ne, smo že izračunali tehtano ceno.
     def _price_from_bucket(row):
         b = row.get("_discount_bucket")
         if isinstance(b, (tuple, list)) and len(b) == 2:
             return _as_dec(b[1], "0")
         return _as_dec(row.get("cena_po_rabatu", "0"), "0")
 
-    if "_discount_bucket" in df.columns:
+    if GROUP_BY_DISCOUNT and "_discount_bucket" in df.columns:
         df["cena_po_rabatu"] = df.apply(_price_from_bucket, axis=1)
     _t(
         "STEP5 after merge: rows=%d head=%s",


### PR DESCRIPTION
## Summary
- make discount/price grouping optional via WSM_GROUP_BY_DISCOUNT
- compute weighted unit price when grouping disabled and adjust buckets accordingly
- only derive display price from bucket when grouping is enabled

## Testing
- `pre-commit run --files wsm/ui/review/helpers.py wsm/ui/review/gui.py`
- `python -m pytest` *(fails: 57 failed, 208 passed, 2 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68ac2a91c5808321bb1fe9e241de7da2