### PR TITLE
Use grid WSM fields for summary

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -1459,6 +1459,10 @@ def review_links(
                 except Exception:
                     pass
                 try:
+                    _update_summary()
+                except Exception as e:
+                    log.warning("Povzetka ni bilo mogoče osvežiti: %s", e)
+                try:
                     w.destroy()
                 except Exception:
                     pass
@@ -1566,14 +1570,12 @@ def review_links(
         "<KeyPress-KP_Enter>", _squelch_return_keypress_if_blocked, add="+"
     )
 
-    def _squelch_return_if_blocked(evt):
-        # Če smo ravno zaključili prejšnji vnos, ignoriraj release,
-        # da se editor na naslednji vrstici ne odpre.
-        if _block_next_begin["val"]:
-            return "break"
+    def _eat_return_release(evt):
+        # po commit-u in premiku selekcije ne sme nič odpreti editorja
+        return "break"
 
-    tree.bind("<KeyRelease-Return>", _squelch_return_if_blocked, add="+")
-    tree.bind("<KeyRelease-KP_Enter>", _squelch_return_if_blocked, add="+")
+    tree.bind("<KeyRelease-Return>", _eat_return_release, add="+")
+    tree.bind("<KeyRelease-KP_Enter>", _eat_return_release, add="+")
 
     # Če editor izgubi fokus (klik nekam drugam), zapri editor in skrij kurzor
     def _editor_focus_out(evt):
@@ -1836,10 +1838,17 @@ def review_links(
             df, ["Bruto", "vrednost_bruto", "Skupna bruto"]
         )
         qty_s = first_existing_series(df, ["Količina", "kolicina_norm"])
-        # za prikaz povzetka vedno raje vzemi _summary_key (če obstaja)
+
+        # ⬇️ KLJUČNO: najprej "WSM šifra" iz grida, šele nato _summary_key
         wsm_s = first_existing_series(
-            df, ["_summary_key", "WSM šifra", "wsm_sifra"]
+            df, ["WSM šifra", "_summary_key", "wsm_sifra"]
         )
+
+        # Naziv prav tako iz grida, če obstaja
+        name_s = first_existing_series(df, ["WSM naziv", "wsm_naziv"])
+        if name_s is None:
+            name_s = pd.Series([""] * len(df), index=df.index, dtype=object)
+
         # normaliziraj ključ na "OSTALO" kjer je prazno/NA
         if wsm_s is not None:
             wsm_s = (
@@ -1855,14 +1864,11 @@ def review_links(
                     }
                 )
             )
-        name_s = (
-            df["wsm_naziv"]
-            if "wsm_naziv" in df.columns
-            else pd.Series([""] * len(df), index=df.index, dtype=object)
-        )
-        eff_s = df[
-            "eff_discount_pct"
-        ]  # točno ta, ki je bil izračunan pred merge
+
+        # če je ključ OSTALO => naziv naj bo vedno "ostalo"
+        name_s = name_s.astype(object).fillna("")
+        if wsm_s is not None:
+            name_s = name_s.where(~wsm_s.astype(str).eq("OSTALO"), "ostalo")
 
         # Če ključni stolpci manjkajo, izpiši prazen povzetek
         if wsm_s is None or val_s is None:
@@ -1871,30 +1877,28 @@ def review_links(
 
         work = pd.DataFrame(
             {
-                # v povzetku prikažemo "OSTALO" za vse manjkajoče
-                # (ločeno astype(object) -> replace tudi ujame None)
-                "wsm_sifra": wsm_s.astype(object)
-                .replace(
-                    {
-                        None: "OSTALO",
-                        "": "OSTALO",
-                        "<NA>": "OSTALO",
-                        "nan": "OSTALO",
-                        "NaN": "OSTALO",
-                    }
-                )
-                .astype(str),
-                "wsm_naziv": name_s.astype(str),
-                "eff_discount_pct": eff_s,
-                "znesek": val_s,
+                "wsm_sifra": (
+                    wsm_s
+                    if wsm_s is not None
+                    else pd.Series(["OSTALO"] * len(df), index=df.index)
+                ),
+                "wsm_naziv": name_s,
+                "znesek": (
+                    val_s
+                    if val_s is not None
+                    else pd.Series([Decimal("0")] * len(df), index=df.index)
+                ),
+                "kolicina": (
+                    qty_s
+                    if qty_s is not None
+                    else pd.Series([Decimal("0")] * len(df), index=df.index)
+                ),
                 "bruto": (
                     bruto_s
                     if bruto_s is not None
-                    else pd.Series(
-                        [Decimal("0")] * len(df), index=df.index, dtype=object
-                    )
+                    else pd.Series([Decimal("0")] * len(df), index=df.index)
                 ),
-                "kolicina": qty_s if qty_s is not None else Decimal("0"),
+                "eff_discount_pct": df["eff_discount_pct"],
             }
         )
         group_by_discount = globals().get("GROUP_BY_DISCOUNT", True)
@@ -1937,67 +1941,58 @@ def review_links(
 
         df_summary = summary_df_from_records(records)
 
-        # 1) Normaliziraj oznako OSTALO → prazen WSM šifra, naziv "ostalo"
+        # --- normaliziraj/združi OSTALO ---
         try:
             if "WSM šifra" in df_summary.columns:
-                mask_ostalo_sifra = (
+                mask_ost_sifra = (
                     df_summary["WSM šifra"].astype(str).eq("OSTALO")
                 )
-                df_summary.loc[mask_ostalo_sifra, "WSM šifra"] = ""
-                if "WSM Naziv" in df_summary.columns:
-                    df_summary.loc[mask_ostalo_sifra, "WSM Naziv"] = "ostalo"
-        except Exception:
-            pass
-
-        # 2) Združi VSE 'ostalo' vrstice v ENO (ne glede na rabat/bucket)
-        try:
-            import pandas as pd
-            from decimal import Decimal
-
-            if "WSM Naziv" in df_summary.columns:
-                mask_ost = (
+                df_summary.loc[mask_ost_sifra, "WSM šifra"] = ""
+            else:
+                mask_ost_sifra = (
                     df_summary["WSM Naziv"]
                     .astype(str)
                     .str.lower()
                     .eq("ostalo")
                 )
-            else:
-                # fallback: prazna šifra pomeni 'ostalo'
-                mask_ost = df_summary["WSM šifra"].astype(str).eq("")
 
-            if mask_ost.any():
+            if "WSM Naziv" in df_summary.columns:
+                df_summary.loc[mask_ost_sifra, "WSM Naziv"] = "ostalo"
 
-                def dsum(series):
+            # zlij vse 'ostalo' vrstice v eno vrstico
+            if mask_ost_sifra.any():
+                from decimal import Decimal
+
+                def dsum(col):
                     s = Decimal("0")
-                    for v in series:
-                        if v is None or (hasattr(pd, "isna") and pd.isna(v)):
+                    for v in col:
+                        if v is None:
                             continue
                         s += Decimal(str(v))
                     return s
 
-                agg_row = {
-                    "WSM šifra": "",
-                    "WSM Naziv": "ostalo",
-                }
+                agg = {"WSM šifra": "", "WSM Naziv": "ostalo"}
                 if "Količina" in df_summary.columns:
-                    agg_row["Količina"] = dsum(
-                        df_summary.loc[mask_ost, "Količina"]
+                    agg["Količina"] = dsum(
+                        df_summary.loc[mask_ost_sifra, "Količina"]
                     )
                 if "Znesek" in df_summary.columns:
-                    agg_row["Znesek"] = dsum(
-                        df_summary.loc[mask_ost, "Znesek"]
+                    agg["Znesek"] = dsum(
+                        df_summary.loc[mask_ost_sifra, "Znesek"]
                     )
                 if "Neto po rabatu" in df_summary.columns:
-                    agg_row["Neto po rabatu"] = dsum(
-                        df_summary.loc[mask_ost, "Neto po rabatu"]
+                    agg["Neto po rabatu"] = dsum(
+                        df_summary.loc[mask_ost_sifra, "Neto po rabatu"]
                     )
                 if "Rabat (%)" in df_summary.columns:
-                    # v povzetku nas rabat pri OSTALO ne zanima → 0
-                    agg_row["Rabat (%)"] = Decimal("0")
+                    agg["Rabat (%)"] = Decimal("0")
 
-                df_non = df_summary.loc[~mask_ost].copy()
                 df_summary = pd.concat(
-                    [df_non, pd.DataFrame([agg_row])], ignore_index=True
+                    [
+                        df_summary.loc[~mask_ost_sifra].copy(),
+                        pd.DataFrame([agg]),
+                    ],
+                    ignore_index=True,
                 )
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- prioritize grid `WSM šifra`/`WSM naziv` when computing summary
- normalize empty codes to `OSTALO` and keep its name as `ostalo`
- build summary work table from these fields with safe defaults
- merge all `OSTALO` rows into a single entry and refresh summary after commits
- swallow Return key releases so focus stays on the tree

## Testing
- `pre-commit run --files wsm/ui/review/gui.py`
- `pytest` *(fails: 57 failed, 208 passed, 3 skipped, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ad828c0c4c8321b5470f4c08dea2c8