### PR TITLE
feat: edit on enter and improve summary counts

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -2362,7 +2362,8 @@ def review_links(
         lb.delete(0, "end")
         matches = [n for n in nazivi if not txt or txt in n.lower()]
         if matches:
-            lb.pack(side="top", fill="x")
+            if not _dropdown_is_open(lb):
+                lb.pack(side="top", fill="x")
             for m in matches:
                 lb.insert("end", m)
             lb.selection_set(0)
@@ -2391,7 +2392,8 @@ def review_links(
             return
         matches = [n for n in nazivi if txt in n.lower()]
         if matches:
-            lb.pack(side="top", fill="x")
+            if not _dropdown_is_open(lb):
+                lb.pack(side="top", fill="x")
             for m in matches:
                 lb.insert("end", m)
             lb.selection_set(0)
@@ -2696,6 +2698,10 @@ def review_links(
             tree.item(sel_i, tags=tuple(tags))
         except Exception:
             pass
+        # počisti opozorilo/tooltip
+        if "warning" in df.columns:
+            df.at[idx, "warning"] = ""
+        _hide_tooltip()
         log.debug(
             f"Povezava odstranjena: idx={idx}, wsm_naziv=NaN, wsm_sifra=NaN"
         )


### PR DESCRIPTION
## Summary
- ensure Enter confirms current row, moves to next, and refreshes totals
- keep tooltip on selection while editing only begins on Enter
- split totals indicator from booked counts and fix quantity label typo
- centralize booking mask logic and update row tags on link/unlink
- preserve existing row tags when adding price warnings
- use consistent pack geometry for suggestion listbox
- exclude NaN/empty codes from booked mask and debounce total warnings
- avoid duplicating gratis tags and let F2 start editing
- streamline refresh logic, re-arm warnings within tolerance, and add keypad Enter support
- prevent double row jumps by removing redundant navigation in `_confirm`
- remove lingering price warnings when unlinking and keep global key bindings intact

## Testing
- `pre-commit run --files wsm/ui/review/gui.py`
- `pip install pyvirtualdisplay`
- `python -m pytest` *(fails: 63 failed, 202 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8da2b88c832193ea1fc5900e902a