### PR TITLE
Add manual link application toggle and clean summary naming

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,3 +2,4 @@ AVG_COST_SKIP_ZERO=1
 WSM_LINKS_DIR=links
 WSM_KEYWORDS_FILE=kljucne_besede_wsm_kode.xlsx
 WSM_CODES_FILE=sifre_wsm.xlsx
+WSM_AUTO_APPLY_LINKS=0


### PR DESCRIPTION
## Summary
- allow disabling automatic link application with `WSM_AUTO_APPLY_LINKS` and add UI button to apply saved links
- avoid using WSM codes as fallback names and fill missing names from catalog
- sync display columns with internal mapping after loading links

## Testing
- `pre-commit run --files wsm/ui/review/gui.py .env.template`
- `pytest` *(fails: many assertions and missing definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0e3686088321896bef9869b73fb1