### PR TITLE
Fix booking status handling and WSM code sync

### DIFF
--- a/tests/test_update_summary_ostalo.py
+++ b/tests/test_update_summary_ostalo.py
@@ -27,6 +27,7 @@ def _extract_update_summary():
         "ONLY_BOOKED_IN_SUMMARY": rl.ONLY_BOOKED_IN_SUMMARY,
         "EXCLUDED_CODES": rl.EXCLUDED_CODES,
         "_booked_mask_from": rl._booked_mask_from,
+        "wsm_df": pd.DataFrame(),
     }
     exec(snippet, ns)
     return ns["_update_summary"], ns


### PR DESCRIPTION
## Summary
- Treat rows as booked only when status is `POVEZANO`
- Prevent automatic keyword links when AUTO_APPLY_LINKS=0 and keep WSM code columns in sync
- Ensure Treeview displays WSM codes correctly on confirm/clear actions
- Stop relying on global `wsm_df` by using the function parameter instead
- Recalculate totals after confirming a WSM mapping

## Testing
- `pytest tests/test_update_summary_ostalo.py::test_update_summary_preserves_discount_for_unbooked tests/test_update_summary_ostalo.py::test_update_summary_mixed_booked_unbooked -q`
- `pytest` *(failures: assertion errors, missing data, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ae13ff2b448321b20a4219cbac401b