### PR TITLE
Handle WSM Naziv correctly and hide header lines

### DIFF
--- a/tests/test_hide_header_lines.py
+++ b/tests/test_hide_header_lines.py
@@ -1,0 +1,92 @@
+import importlib
+import os
+
+import pandas as pd
+
+import wsm.ui.review.gui as rl
+
+
+def test_header_line_filter():
+    df = pd.DataFrame(
+        {
+            "naziv": ["Racun 123", "Racun 456"],
+            "kolicina_norm": [0, 1],
+            "vrednost": [0, 0],
+        }
+    )
+    mask = rl._mask_header_like_rows(df)
+    assert mask.tolist() == [True, False]
+    df_filtered = df.loc[~mask]
+    assert df_filtered["naziv"].tolist() == ["Racun 456"]
+
+
+def test_header_line_filter_diacritics():
+    df = pd.DataFrame(
+        {
+            "naziv": ["Račun 123", "Racun 456"],
+            "kolicina_norm": [0, 1],
+            "vrednost": [0, 0],
+        }
+    )
+    mask = rl._mask_header_like_rows(df)
+    assert mask.tolist() == [True, False]
+
+
+def test_header_line_filter_storno():
+    df = pd.DataFrame(
+        {
+            "naziv": ["Storno 1", "Artikel"],
+            "kolicina_norm": [0, 1],
+            "vrednost": [0, 0],
+        }
+    )
+    mask = rl._mask_header_like_rows(df)
+    assert mask.tolist() == [True, False]
+
+
+def test_header_line_filter_bremepis():
+    df = pd.DataFrame(
+        {
+            "naziv": ["Bremepis 7", "Artikel"],
+            "kolicina_norm": [0, 1],
+            "vrednost": [0, 0],
+        }
+    )
+    mask = rl._mask_header_like_rows(df)
+    assert mask.tolist() == [True, False]
+
+
+def test_header_line_filter_toggle_off(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "naziv": ["Racun 123"],
+            "kolicina_norm": [0],
+            "vrednost": [0],
+        }
+    )
+    mask = rl._mask_header_like_rows(df)
+    monkeypatch.setenv("WSM_HIDE_HEADER_LINES", "0")
+    # simulate STEP0.5 behaviour
+    if os.environ.get("WSM_HIDE_HEADER_LINES", "1") != "0":
+        df_filtered = df.loc[~mask]
+    else:
+        df_filtered = df
+    assert df_filtered.equals(df)
+
+
+def test_header_line_filter_custom_prefix(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "naziv": ["Dobavnica 1", "Racun 2"],
+            "kolicina_norm": [0, 0],
+            "vrednost": [0, 0],
+        }
+    )
+    monkeypatch.setenv("WSM_HEADER_PREFIX", r"(?i)^\s*Dobavnica")
+    importlib.reload(rl)
+    try:
+        mask = rl._mask_header_like_rows(df)
+        assert mask.tolist() == [True, False]
+    finally:
+        monkeypatch.delenv("WSM_HEADER_PREFIX", raising=False)
+        importlib.reload(rl)

--- a/tests/test_norm_wsm_code.py
+++ b/tests/test_norm_wsm_code.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import wsm.ui.review.gui as rl
+
+
+def test_norm_wsm_code_edges_and_booked_mask():
+    values = ["0", "0,0", "", None, "<NA>", "nan", "X1", "1,5"]
+    normalized = [rl._norm_wsm_code(x) for x in values]
+    assert normalized[:6] == ["OSTALO"] * 6
+    assert normalized[6] == "X1"
+    assert normalized[7] == "1.5"
+
+    s = pd.Series(values)
+    mask = rl._booked_mask_from(s)
+    assert mask.tolist() == [
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+    ]
+
+
+def test_booked_mask_excluded_codes_case_insensitive():
+    s = pd.Series(["other", "unknown"])
+    assert rl._booked_mask_from(s).tolist() == [False, False]
+
+
+def test_booked_mask_respects_runtime_excluded(monkeypatch):
+    s = pd.Series(["X1"])
+    assert rl._booked_mask_from(s).tolist() == [True]
+    monkeypatch.setattr(rl, "EXCLUDED_CODES", rl.EXCLUDED_CODES | {"X1"})
+    assert rl._booked_mask_from(s).tolist() == [False]

--- a/tests/test_update_summary_ostalo.py
+++ b/tests/test_update_summary_ostalo.py
@@ -11,9 +11,12 @@ import wsm.ui.review.summary_utils as summary_utils
 
 def _extract_update_summary():
     src = inspect.getsource(rl.review_links).splitlines()
-    start = next(i for i, line in enumerate(src) if "def _update_summary" in line)
+    start = next(
+        i for i, line in enumerate(src) if "def _update_summary" in line
+    )
     end = next(
-        i for i, line in enumerate(src[start:], start)
+        i
+        for i, line in enumerate(src[start:], start)
         if line.startswith("    # Skupni zneski")
     )
     snippet = textwrap.dedent("\n".join(src[start:end]))
@@ -26,7 +29,9 @@ def _extract_update_summary():
         "summary_df_from_records": summary_utils.summary_df_from_records,
         "ONLY_BOOKED_IN_SUMMARY": rl.ONLY_BOOKED_IN_SUMMARY,
         "EXCLUDED_CODES": rl.EXCLUDED_CODES,
+        "_excluded_codes_upper": rl._excluded_codes_upper,
         "_booked_mask_from": rl._booked_mask_from,
+        "_norm_wsm_code": rl._norm_wsm_code,
         "wsm_df": pd.DataFrame(),
     }
     exec(snippet, ns)
@@ -57,7 +62,7 @@ def test_update_summary_preserves_discount_for_unbooked():
     df_summary = captured["df_summary"]
     assert "Rabat (%)" in df_summary.columns
     assert df_summary.loc[0, "Rabat (%)"] == Decimal("0.00")
-    assert df_summary.loc[0, "WSM Naziv"] == "ostalo"
+    assert df_summary.loc[0, "WSM Naziv"] == "Ostalo"
 
 
 def test_update_summary_mixed_booked_unbooked():
@@ -83,10 +88,8 @@ def test_update_summary_mixed_booked_unbooked():
 
     out = captured["df_summary"]
     assert any(
-        (out["WSM šifra"] == "123")
-        & (out["Rabat (%)"] == Decimal("15.00"))
+        (out["WSM šifra"] == "123") & (out["Rabat (%)"] == Decimal("15.00"))
     )
     assert any(
-        (out["WSM Naziv"].str.lower() == "ostalo")
-        & (out["Rabat (%)"] == Decimal("0.00"))
+        (out["WSM Naziv"] == "Ostalo") & (out["Rabat (%)"] == Decimal("0.00"))
     )


### PR DESCRIPTION
## Summary
- Pre-compute uppercase exclusion codes on demand via `_excluded_codes_upper` so runtime changes to `EXCLUDED_CODES` propagate
- Exercise header-line filtering with a `Bremepis` example and confirm booking masks honor dynamic exclusion tweaks

## Testing
- `pre-commit run --files wsm/ui/review/gui.py tests/test_hide_header_lines.py tests/test_norm_wsm_code.py tests/test_update_summary_ostalo.py`
- `pytest tests/test_update_summary_ostalo.py tests/test_hide_header_lines.py tests/test_norm_wsm_code.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyvirtualdisplay')*


------
https://chatgpt.com/codex/tasks/task_e_68b6bd75de7483219fca8e1b534b8fd3