### PR TITLE
Prevent summary panel redraw artifacts and fix Series truthiness

### DIFF
--- a/tests/test_helpers_scalar_and_fmt.py
+++ b/tests/test_helpers_scalar_and_fmt.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from decimal import Decimal
+from wsm.ui.review.helpers import _fmt, _first_scalar
+
+
+def test_fmt_with_series_and_none():
+    assert _fmt(pd.Series([Decimal("1.50")])) == "1.5"
+    assert _fmt(pd.Series([None])) == ""
+
+
+def test_fmt_with_bools():
+    assert _fmt(True) == "1"
+    assert _fmt(False) == "0"
+
+
+def test_first_scalar_basic():
+    s = pd.Series([None, "X"]).replace({None: pd.NA})
+    assert _first_scalar(s) == "X"
+    assert _first_scalar(pd.Series([], dtype="object")) is None


### PR DESCRIPTION
## Summary
- Track summary counts with `StringVar`s so the info panel updates without recreating widgets
- Initialize summary info panel with default counts and expose a `_first_scalar` helper to strip scalars from `Series`
- Wrap summary tree and scrollbar in a dedicated frame and align labels for a stable layout
- Safeguard grid cell refresh, formatting helpers, and bool handling to avoid ambiguous pandas `Series` values
- Document NumPy import for `_fmt` boolean normalization
- Add regression tests for `_fmt` and `_first_scalar` covering `Series` inputs, booleans, and empty data

## Testing
- `pre-commit run --files wsm/ui/review/helpers.py tests/test_helpers_scalar_and_fmt.py`
- `pytest tests/test_helpers_scalar_and_fmt.py -q`
- `pytest -q` *(fails: 65 failed, 217 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b98824a48c832183a7d34ce2dc25d2