### PR TITLE
Fix summary columns to fixed keys

### DIFF
--- a/wsm/ui/review/summary_columns.py
+++ b/wsm/ui/review/summary_columns.py
@@ -9,9 +9,9 @@ SUMMARY_COLUMN_DEFS = [
     ("wsm_sifra", "WSM šifra"),
     ("wsm_naziv", "WSM Naziv"),
     ("kolicina_norm", "Količina"),
-    ("neto_brez_popusta", "Znesek"),
+    ("vrednost", "Znesek"),
     ("rabata_pct", "Rabat (%)"),
-    ("vrednost", "Neto po rabatu"),
+    ("neto_po_rabatu", "Neto po rabatu"),
 ]
 
 # Column headers used by :func:`summary_df_from_records` and displayed in the GUI.

--- a/wsm/ui/review/summary_utils.py
+++ b/wsm/ui/review/summary_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from .helpers import _safe_set_block
-from .summary_columns import SUMMARY_COLS
+from .summary_columns import SUMMARY_HEADS, SUMMARY_COLS  # noqa: F401
 
 
 def summary_df_from_records(records: Sequence[dict] | None) -> pd.DataFrame:
@@ -18,10 +18,10 @@ def summary_df_from_records(records: Sequence[dict] | None) -> pd.DataFrame:
     records:
         Sequence of mapping objects with column data. Missing keys or
         values are filled with defaults and the DataFrame is reindexed to
-        :data:`SUMMARY_COLS`.
+        :data:`SUMMARY_HEADS`.
     """
     df = pd.DataFrame.from_records(records or [], coerce_float=False)
-    df = df.reindex(columns=SUMMARY_COLS)
+    df = df.reindex(columns=SUMMARY_HEADS)
 
     numeric_cols = ["Količina", "Znesek", "Rabat (%)", "Neto po rabatu"]
 


### PR DESCRIPTION
## Summary
- keep review summary limited to six standard columns and remove dynamic deduplication
- map `_render_summary` to fetch by key or header with stable numeric column pairs
- align `SUMMARY_COLUMN_DEFS` and `summary_df_from_records` with the fixed columns

## Testing
- `ruff check wsm/ui/review/gui.py wsm/ui/review/summary_columns.py wsm/ui/review/summary_utils.py`
- `pytest tests/test_summary_df_from_records.py`
- `pytest` *(fails: NameError: name '_norm_wsm_code' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bff4a92db8832197d2aba4a816fb72