### PR TITLE
Handle DataFrame columns in first_existing

### DIFF
--- a/tests/test_first_existing_dataframe.py
+++ b/tests/test_first_existing_dataframe.py
@@ -1,0 +1,13 @@
+import pandas as pd
+from wsm.ui.review.helpers import first_existing, first_existing_series
+
+
+def test_first_existing_duplicate_columns():
+    df = pd.DataFrame([[1, 2], [None, 3]], columns=["x", "x"])
+    result = first_existing(df, ["x"])
+    assert isinstance(result, pd.Series)
+    assert result.tolist() == [1, 0]
+
+    result_series = first_existing_series(df, ["x"])
+    assert isinstance(result_series, pd.Series)
+    assert result_series.tolist() == [1, 0]

--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -920,7 +920,10 @@ def first_existing(
 
     for col in columns:
         if col in df:
-            return df[col].fillna(fill_value)
+            series = df[col]
+            if isinstance(series, pd.DataFrame):
+                series = series.iloc[:, 0]
+            return series.fillna(fill_value)
 
     # No column found – return a default series
     return pd.Series(fill_value, index=df.index)


### PR DESCRIPTION
## Summary
- ensure `first_existing` extracts the first column when pandas returns a DataFrame
- add regression test covering duplicate column names and delegation through `first_existing_series`

## Testing
- `pytest tests/test_first_existing_dataframe.py`
- `pytest tests/test_first_existing_dataframe.py tests/test_update_summary_net.py tests/test_update_summary_ostalo.py tests/test_update_summary_flexible_cols.py tests/test_update_summary_discounts.py tests/test_summary_column_flex.py` *(fails: NameError: name '_excluded_codes_upper' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a016e9c48321b4860a3107209c22