### PR TITLE
Deduplicate DataFrame columns in summary and guard column access

### DIFF
--- a/wsm/ui/review/helpers.py
+++ b/wsm/ui/review/helpers.py
@@ -921,7 +921,7 @@ def first_existing(
     for col in columns:
         if col in df:
             series = df[col]
-            if isinstance(series, pd.DataFrame):
+            if hasattr(series, "ndim") and series.ndim == 2:
                 series = series.iloc[:, 0]
             return series.fillna(fill_value)
 


### PR DESCRIPTION
## Summary
- Warn when duplicate grid columns persist after dropping extras in `_update_summary`
- Harden `_col` and `first_existing` helpers to always return 1‑D Series, defaulting to empty data when a column is missing

## Testing
- `pytest -q tests/test_norm_wsm_code.py::test_norm_wsm_code_basic tests/test_summary_returns.py::test_aggregate_summary_handles_returns_and_ostalo tests/test_summary_df_from_records.py::test_summary_missing_fields_filled`

------
https://chatgpt.com/codex/tasks/task_e_68c2aaa18a5083219eb98225edcf982d