### PR TITLE
Disable automatic application of saved links

### DIFF
--- a/Fix-Run.ps1
+++ b/Fix-Run.ps1
@@ -56,7 +56,8 @@ $env:WSM_CODES_FILE     = '\\PisarnaNAS\wsm_program_vnasanje_povezave\sifre_wsm.
 
 
 # ─────────────────────────────── zagon programa ───────────────────────────────
-$env:AUTO_APPLY_LINKS = "1"
+# Onemogoči samodejno uveljavljanje shranjenih povezav.
+$env:AUTO_APPLY_LINKS = "0"
 Write-Host "[run] python -m wsm.run" -f Cyan
 python -m wsm.run
 $exitCode = $LASTEXITCODE


### PR DESCRIPTION
## Summary
- prevent script from auto-applying saved WSM links by default
- clarify behavior with a comment

## Testing
- `python -m pre_commit run --files Fix-Run.ps1`
- `pytest` *(fails: tests failing: assert False, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e262b07083218c4d5160e1d8b0a2