### PR TITLE
Handle inconsistent header totals by preferring best match

### DIFF
--- a/tests/test_extract_header_net.py
+++ b/tests/test_extract_header_net.py
@@ -51,3 +51,33 @@ def test_extract_header_net_handles_doc_charge(tmp_path):
     path = tmp_path / "charge.xml"
     path.write_text(xml)
     assert extract_header_net(path) == Decimal("105.00")
+
+
+def test_extract_header_net_prefers_best_header_match(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>2</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>100.02</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "moa_mismatch.xml"
+    path.write_text(xml)
+    assert extract_header_net(path) == Decimal("100.02")


### PR DESCRIPTION
## Summary
- prefer the header MOA value that best matches the summed line amounts when computing the net total
- add a regression test covering invoices where header MOA 389 and 79 differ slightly

## Testing
- pytest tests/test_extract_header_net.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c93f4aa3a88321bd0b5eed37f170e9