### PR TITLE
Refine header net selection using gross totals

### DIFF
--- a/tests/test_extract_header_net.py
+++ b/tests/test_extract_header_net.py
@@ -51,3 +51,69 @@ def test_extract_header_net_handles_doc_charge(tmp_path):
     path = tmp_path / "charge.xml"
     path.write_text(xml)
     assert extract_header_net(path) == Decimal("105.00")
+
+
+def test_extract_header_net_prefers_best_header_match(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>2</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>100.02</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "moa_mismatch.xml"
+    path.write_text(xml)
+    assert extract_header_net(path) == Decimal("100.02")
+
+
+def test_extract_header_net_prefers_gross_match_when_available(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>2</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>100.02</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>109.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>9.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "moa_with_gross.xml"
+    path.write_text(xml)
+    assert extract_header_net(path) == Decimal("100.00")

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -574,12 +574,27 @@ def extract_header_net(source: Path | str | Any) -> Decimal:
         _force_ns_for_doc(root)
 
         header_base = Decimal("0")
+        header_candidates: list[tuple[str, Decimal]] = []
         for code in ("203", "389", "79"):
+            value = Decimal("0")
             for moa in root.findall(".//e:G_SG50/e:S_MOA", NS):
                 if _text(moa.find("./e:C_C516/e:D_5025", NS)) == code:
-                    header_base = _decimal(moa.find("./e:C_C516/e:D_5004", NS))
+                    value = _decimal(moa.find("./e:C_C516/e:D_5004", NS))
                     break
-            if header_base != 0:
+            if value != 0:
+                header_candidates.append((code, value))
+                if header_base == 0:
+                    header_base = value
+
+        header_gross = Decimal("0")
+        for gross_code in ("9", "388"):
+            gross_val = Decimal("0")
+            for moa in root.findall(".//e:G_SG50/e:S_MOA", NS):
+                if _text(moa.find("./e:C_C516/e:D_5025", NS)) == gross_code:
+                    gross_val = _decimal(moa.find("./e:C_C516/e:D_5004", NS))
+                    break
+            if gross_val != 0:
+                header_gross = gross_val
                 break
 
         line_base = Decimal("0")
@@ -642,7 +657,51 @@ def extract_header_net(source: Path | str | Any) -> Decimal:
         if line_base != 0:
             base = line_base
             line_adjusted = line_base + doc_discount + doc_charge
-            if header_base != 0 and abs(header_base - line_adjusted) > DEC2:
+            if header_candidates:
+                line_adjusted_q = line_adjusted.quantize(DEC2, ROUND_HALF_UP)
+
+                best_value = None
+                best_diff = None
+
+                if header_gross != 0:
+                    scores: list[tuple[Decimal, Decimal, Decimal, Decimal]] = []
+                    for _, value in header_candidates:
+                        adjusted_net = value + doc_discount + doc_charge
+                        gross_estimate = (adjusted_net + tax_total).quantize(
+                            DEC2, ROUND_HALF_UP
+                        )
+                        gross_diff = abs(gross_estimate - header_gross)
+                        line_diff = abs(value - line_adjusted_q)
+                        header_diff = (
+                            abs(value - header_base)
+                            if header_base != 0
+                            else line_diff
+                        )
+                        scores.append((gross_diff, line_diff, header_diff, value))
+
+                    within_tol = [s for s in scores if s[0] <= DEC2]
+                    if within_tol:
+                        gross_diff, line_diff, _, cand_val = min(
+                            within_tol, key=lambda s: (s[0], s[1], s[2])
+                        )
+                        best_value = cand_val
+                        best_diff = line_diff
+
+                if best_value is None:
+                    value, diff = min(
+                        (
+                            (value, abs(value - line_adjusted_q))
+                            for _, value in header_candidates
+                        ),
+                        key=lambda item: item[1],
+                    )
+                    best_value, best_diff = value, diff
+
+                if best_diff is not None and best_diff <= DEC2:
+                    base = best_value
+                elif header_base != 0 and abs(header_base - line_adjusted_q) > DEC2:
+                    base = header_base
+            elif header_base != 0 and abs(header_base - line_adjusted) > DEC2:
                 base = header_base
         else:
             base = header_base


### PR DESCRIPTION
## Summary
- prefer header MOA values whose adjusted totals align with document grand totals when extracting the net amount
- fall back to the previous best-match logic when gross totals are unavailable or outside tolerance
- add regression coverage ensuring invoices with matching MOA 9 favour the correct net candidate

## Testing
- pytest tests/test_extract_header_net.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c93f4aa3a88321bd0b5eed37f170e9