### PR TITLE
Reconcile totals when header values agree

### DIFF
--- a/tests/test_extract_header_net.py
+++ b/tests/test_extract_header_net.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from pathlib import Path
 
-from wsm.parsing.eslog import extract_header_net
+from wsm.parsing.eslog import extract_header_net, parse_eslog_invoice
 
 
 def test_extract_header_net_falls_back_to_moa_79(tmp_path):
@@ -51,3 +51,123 @@ def test_extract_header_net_handles_doc_charge(tmp_path):
     path = tmp_path / "charge.xml"
     path.write_text(xml)
     assert extract_header_net(path) == Decimal("105.00")
+
+
+def test_extract_header_net_prefers_best_header_match(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>2</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>100.02</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "moa_mismatch.xml"
+    path.write_text(xml)
+    assert extract_header_net(path) == Decimal("100.02")
+
+
+def test_extract_header_net_prefers_gross_match_when_available(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>2</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>100.02</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>109.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>9.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "moa_with_gross.xml"
+    path.write_text(xml)
+    assert extract_header_net(path) == Decimal("100.00")
+
+
+def test_parse_eslog_invoice_trusts_consistent_header_totals(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><D_1082>1</D_1082></S_LIN>"
+        "      <S_QTY><C_C186><D_6063>47</D_6063><D_6060>1.00</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "      <G_SG34>"
+        "        <S_TAX><C_C241><D_5153>VAT</D_5153></C_C241></S_TAX>"
+        "        <S_MOA><C_C516><D_5025>124</D_5025><D_5004>4.50</D_5004></C_C516></S_MOA>"
+        "        <S_MOA><C_C516><D_5025>125</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_LIN><D_1082>2</D_1082></S_LIN>"
+        "      <S_QTY><C_C186><D_6063>47</D_6063><D_6060>1.00</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "      <G_SG34>"
+        "        <S_TAX><C_C241><D_5153>VAT</D_5153></C_C241></S_TAX>"
+        "        <S_MOA><C_C516><D_5025>124</D_5025><D_5004>4.50</D_5004></C_C516></S_MOA>"
+        "        <S_MOA><C_C516><D_5025>125</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>100.02</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>109.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>9.00</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>125</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "header_totals.xml"
+    path.write_text(xml)
+
+    df, ok = parse_eslog_invoice(path)
+
+    assert ok
+    assert not df.attrs.get("gross_mismatch", False)
+    assert df.attrs["gross_calc"] == Decimal("109.00")


### PR DESCRIPTION
## Summary
- let parse_eslog_invoice recompute gross differences after substituting header net and VAT values so consistent header totals no longer trigger mismatches
- avoid spurious mismatch warnings by only logging when the adjusted totals still diverge beyond tolerance
- add a regression test covering invoices whose line sums differ from the header net by a few cents but match the header grand total once rounded

## Testing
- pytest tests/test_extract_header_net.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c93f4aa3a88321bd0b5eed37f170e9