### PR TITLE
Handle line allowances when reconciling totals

### DIFF
--- a/tests/test_extract_header_net.py
+++ b/tests/test_extract_header_net.py
@@ -1,7 +1,13 @@
 from decimal import Decimal
 from pathlib import Path
 
-from wsm.parsing.eslog import extract_header_net
+from lxml import etree as LET
+
+from wsm.parsing.eslog import (
+    extract_header_net,
+    parse_eslog_invoice,
+    parse_invoice_totals,
+)
 
 
 def test_extract_header_net_falls_back_to_moa_79(tmp_path):
@@ -51,3 +57,186 @@ def test_extract_header_net_handles_doc_charge(tmp_path):
     path = tmp_path / "charge.xml"
     path.write_text(xml)
     assert extract_header_net(path) == Decimal("105.00")
+
+
+def test_extract_header_net_prefers_best_header_match(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>2</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>100.02</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "moa_mismatch.xml"
+    path.write_text(xml)
+    assert extract_header_net(path) == Decimal("100.02")
+
+
+def test_extract_header_net_prefers_gross_match_when_available(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>1</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_LIN><C_C212><D_7140>2</D_7140></C_C212></S_LIN>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>100.02</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>109.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>9.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "moa_with_gross.xml"
+    path.write_text(xml)
+    assert extract_header_net(path) == Decimal("100.00")
+
+
+def test_parse_eslog_invoice_trusts_consistent_header_totals(tmp_path):
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><D_1082>1</D_1082></S_LIN>"
+        "      <S_QTY><C_C186><D_6063>47</D_6063><D_6060>1.00</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "      <G_SG34>"
+        "        <S_TAX><C_C241><D_5153>VAT</D_5153></C_C241></S_TAX>"
+        "        <S_MOA><C_C516><D_5025>124</D_5025><D_5004>4.50</D_5004></C_C516></S_MOA>"
+        "        <S_MOA><C_C516><D_5025>125</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_LIN><D_1082>2</D_1082></S_LIN>"
+        "      <S_QTY><C_C186><D_6063>47</D_6063><D_6060>1.00</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "      <G_SG34>"
+        "        <S_TAX><C_C241><D_5153>VAT</D_5153></C_C241></S_TAX>"
+        "        <S_MOA><C_C516><D_5025>124</D_5025><D_5004>4.50</D_5004></C_C516></S_MOA>"
+        "        <S_MOA><C_C516><D_5025>125</D_5025><D_5004>50.01</D_5004></C_C516></S_MOA>"
+        "      </G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>79</D_5025><D_5004>100.02</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>109.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>9.00</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>125</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path = tmp_path / "header_totals.xml"
+    path.write_text(xml)
+
+    df, ok = parse_eslog_invoice(path)
+
+    assert ok
+    assert not df.attrs.get("gross_mismatch", False)
+    assert df.attrs["gross_calc"] == Decimal("109.00")
+
+
+def _write_allowance_invoice(path: Path) -> Path:
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><D_1082>1</D_1082></S_LIN>"
+        "      <S_QTY><C_C186><D_6063>47</D_6063><D_6060>1.00</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "      <G_SG34>"
+        "        <S_TAX><D_5283>7</D_5283><C_C241><D_5153>VAT</D_5153></C_C241><C_C243><D_5278>20.00</D_5278></C_C243><D_5305>S</D_5305></S_TAX>"
+        "        <S_MOA><C_C516><D_5025>124</D_5025><D_5004>8.00</D_5004></C_C516></S_MOA>"
+        "        <S_MOA><C_C516><D_5025>125</D_5025><D_5004>40.00</D_5004></C_C516></S_MOA>"
+        "      </G_SG34>"
+        "      <G_SG39>"
+        "        <S_ALC><D_5463>A</D_5463><C_C552><D_5189>95</D_5189></C_C552></S_ALC>"
+        "        <G_SG42>"
+        "          <S_MOA><C_C516><D_5025>204</D_5025><D_5004>60.00</D_5004></C_C516></S_MOA>"
+        "        </G_SG42>"
+        "      </G_SG39>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>40.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>48.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG52>"
+        "      <S_TAX><D_5283>7</D_5283><C_C241><D_5153>VAT</D_5153></C_C241><C_C243><D_5278>20.00</D_5278></C_C243><D_5305>S</D_5305></S_TAX>"
+        "      <S_MOA><C_C516><D_5025>124</D_5025><D_5004>8.00</D_5004></C_C516></S_MOA>"
+        "      <S_MOA><C_C516><D_5025>125</D_5025><D_5004>40.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG52>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+    path.write_text(xml)
+    return path
+
+
+def test_parse_eslog_invoice_respects_line_allowance_header_totals(tmp_path):
+    path = _write_allowance_invoice(tmp_path / "allowance.xml")
+
+    df, ok = parse_eslog_invoice(path)
+
+    assert ok
+    assert df.attrs["gross_calc"] == Decimal("48.00")
+    assert not df.attrs.get("gross_mismatch", False)
+    assert df["vrednost"].sum() == Decimal("40.00")
+
+
+def test_parse_invoice_totals_uses_header_amounts_with_allowance(tmp_path):
+    path = _write_allowance_invoice(tmp_path / "allowance_totals.xml")
+
+    tree = LET.parse(str(path))
+    totals = parse_invoice_totals(tree)
+
+    assert totals["net"] == Decimal("40.00")
+    assert totals["vat"] == Decimal("8.00")
+    assert totals["gross"] == Decimal("48.00")
+    assert totals["mismatch"] is False

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -574,12 +574,27 @@ def extract_header_net(source: Path | str | Any) -> Decimal:
         _force_ns_for_doc(root)
 
         header_base = Decimal("0")
+        header_candidates: list[tuple[str, Decimal]] = []
         for code in ("203", "389", "79"):
+            value = Decimal("0")
             for moa in root.findall(".//e:G_SG50/e:S_MOA", NS):
                 if _text(moa.find("./e:C_C516/e:D_5025", NS)) == code:
-                    header_base = _decimal(moa.find("./e:C_C516/e:D_5004", NS))
+                    value = _decimal(moa.find("./e:C_C516/e:D_5004", NS))
                     break
-            if header_base != 0:
+            if value != 0:
+                header_candidates.append((code, value))
+                if header_base == 0:
+                    header_base = value
+
+        header_gross = Decimal("0")
+        for gross_code in ("9", "388"):
+            gross_val = Decimal("0")
+            for moa in root.findall(".//e:G_SG50/e:S_MOA", NS):
+                if _text(moa.find("./e:C_C516/e:D_5025", NS)) == gross_code:
+                    gross_val = _decimal(moa.find("./e:C_C516/e:D_5004", NS))
+                    break
+            if gross_val != 0:
+                header_gross = gross_val
                 break
 
         line_base = Decimal("0")
@@ -642,7 +657,51 @@ def extract_header_net(source: Path | str | Any) -> Decimal:
         if line_base != 0:
             base = line_base
             line_adjusted = line_base + doc_discount + doc_charge
-            if header_base != 0 and abs(header_base - line_adjusted) > DEC2:
+            if header_candidates:
+                line_adjusted_q = line_adjusted.quantize(DEC2, ROUND_HALF_UP)
+
+                best_value = None
+                best_diff = None
+
+                if header_gross != 0:
+                    scores: list[tuple[Decimal, Decimal, Decimal, Decimal]] = []
+                    for _, value in header_candidates:
+                        adjusted_net = value + doc_discount + doc_charge
+                        gross_estimate = (adjusted_net + tax_total).quantize(
+                            DEC2, ROUND_HALF_UP
+                        )
+                        gross_diff = abs(gross_estimate - header_gross)
+                        line_diff = abs(value - line_adjusted_q)
+                        header_diff = (
+                            abs(value - header_base)
+                            if header_base != 0
+                            else line_diff
+                        )
+                        scores.append((gross_diff, line_diff, header_diff, value))
+
+                    within_tol = [s for s in scores if s[0] <= DEC2]
+                    if within_tol:
+                        gross_diff, line_diff, _, cand_val = min(
+                            within_tol, key=lambda s: (s[0], s[1], s[2])
+                        )
+                        best_value = cand_val
+                        best_diff = line_diff
+
+                if best_value is None:
+                    value, diff = min(
+                        (
+                            (value, abs(value - line_adjusted_q))
+                            for _, value in header_candidates
+                        ),
+                        key=lambda item: item[1],
+                    )
+                    best_value, best_diff = value, diff
+
+                if best_diff is not None and best_diff <= DEC2:
+                    base = best_value
+                elif header_base != 0 and abs(header_base - line_adjusted_q) > DEC2:
+                    base = header_base
+            elif header_base != 0 and abs(header_base - line_adjusted) > DEC2:
                 base = header_base
         else:
             base = header_base
@@ -1715,11 +1774,12 @@ def parse_eslog_invoice(
         gross_amount = _line_gross(sg26)
 
         net_amount_moa: Decimal | None = None
-        for moa in sg26.findall(".//e:S_MOA", NS):
-            if _text(moa.find("./e:C_C516/e:D_5025", NS)) == Moa.NET.value:
-                net_amount_moa = _decimal(
-                    moa.find("./e:C_C516/e:D_5004", NS)
-                ).quantize(Decimal("0.01"), ROUND_HALF_UP)
+        net_amount_code = ""
+        for candidate in ("125", Moa.NET.value):
+            val = _first_moa(sg26, {candidate})
+            if val != 0:
+                net_amount_moa = _dec2(val)
+                net_amount_code = candidate
                 break
 
         net_amount = _line_net(sg26)
@@ -1763,9 +1823,13 @@ def parse_eslog_invoice(
 
         item["ddv"] = tax_amount
 
-        if net_amount_moa is not None and net_amount != net_amount_moa:
+        if (
+            net_amount_moa is not None
+            and abs(net_amount - net_amount_moa) > DEC2
+        ):
             log.warning(
-                "Line net mismatch: MOA 203 %s vs calculated %s",
+                "Line net mismatch: MOA %s %s vs calculated %s",
+                net_amount_code or Moa.NET.value,
                 net_amount_moa,
                 net_amount,
             )
@@ -2149,6 +2213,7 @@ def parse_eslog_invoice(
     header_gross = _first_moa(root, {"9", "388"}, ignore_sg26=True)
     diff_gross = Decimal("0")
     ok = True
+    warn_gross = False
     if header_gross != 0:
         header_gross = header_gross.quantize(DEC2, ROUND_HALF_UP)
         diff_gross = abs(gross_calc - header_gross)
@@ -2163,12 +2228,7 @@ def parse_eslog_invoice(
             if diff_alt < diff_gross:
                 return df_alt, ok_alt
         ok = diff_gross <= DEC2
-        if not ok:
-            log.warning(
-                "Invoice total mismatch: MOA 9/38/388 %s vs calculated %s",
-                header_gross,
-                gross_calc,
-            )
+        warn_gross = diff_gross > DEC2
 
     if hdr125 is not None:
         net_total = _dec2(hdr125)
@@ -2177,11 +2237,26 @@ def parse_eslog_invoice(
     if header_gross != 0:
         gross_calc = header_gross
 
+    final_diff = diff_gross
+    if header_gross != 0:
+        gross_check = (net_total + vat_total).quantize(DEC2, ROUND_HALF_UP)
+        final_diff = abs(gross_check - header_gross)
+        if final_diff <= DEC2:
+            ok = True
+        elif warn_gross:
+            log.warning(
+                "Invoice total mismatch: MOA 9/38/388 %s vs calculated %s",
+                header_gross,
+                gross_check,
+            )
+    else:
+        final_diff = Decimal("0")
+
     df = pd.DataFrame(items)
     df.attrs["vat_mismatch"] = vat_mismatch
     df.attrs["info_discounts"] = _INFO_DISCOUNTS
     df.attrs["gross_calc"] = gross_calc
-    df.attrs["gross_mismatch"] = header_gross != 0 and diff_gross > DEC2
+    df.attrs["gross_mismatch"] = header_gross != 0 and final_diff > DEC2
     if "sifra_dobavitelja" in df.columns and not df["sifra_dobavitelja"].any():
         df["sifra_dobavitelja"] = supplier_code
     if not df.empty:


### PR DESCRIPTION
## Summary
- prefer line MOA 125 values when checking net amounts and only log mismatches beyond a one-cent tolerance so steep allowances no longer raise false warnings
- add regression coverage for invoices whose line allowances diverge from MOA 203 to ensure both `parse_eslog_invoice` and `parse_invoice_totals` respect header net, VAT, and gross totals

## Testing
- pytest tests/test_extract_header_net.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c93f4aa3a88321bd0b5eed37f170e9