### PR TITLE
Handle missing VAT totals when gross provided

### DIFF
--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -2236,6 +2236,8 @@ def parse_eslog_invoice(
         net_total = _dec2(hdr125)
     if header_vat != 0:
         vat_total = header_vat
+    elif header_gross != 0:
+        vat_total = _dec2(header_gross - net_total)
     if header_gross != 0:
         gross_calc = header_gross
 
@@ -2333,6 +2335,8 @@ def parse_invoice_totals(
 
     if vat_total == 0 and header_vat != 0:
         vat_total = header_vat
+    elif header_gross != 0 and header_vat == 0:
+        vat_total = _dec2(header_gross - net_total)
 
     gross_total = _dec2(net_total + vat_total)
 


### PR DESCRIPTION
## Summary
- derive VAT from header net/gross totals in `parse_eslog_invoice` when only the gross header is provided
- mirror the same fallback inside `parse_invoice_totals`
- add a regression test covering invoices with MOA 125 + MOA 9 but no MOA 124

## Testing
- pytest tests/test_extract_header_net.py


------
https://chatgpt.com/codex/tasks/task_e_68cbdc76c298832187c038b22f8351b0