### PR TITLE
Align parse_invoice_totals with header amounts

### DIFF
--- a/tests/test_extract_header_net.py
+++ b/tests/test_extract_header_net.py
@@ -288,6 +288,49 @@ def test_parse_invoice_totals_prefers_header_vat_summary(tmp_path):
     assert totals["mismatch"] is False
 
 
+def test_parse_invoice_totals_trusts_header_net_without_moa124():
+    xml = (
+        "<Invoice xmlns='urn:eslog:2.00'>"
+        "  <M_INVOIC>"
+        "    <G_SG26>"
+        "      <S_LIN><D_1082>1</D_1082></S_LIN>"
+        "      <S_QTY><C_C186><D_6063>47</D_6063><D_6060>1.00</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.02</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "      <G_SG34>"
+        "        <S_MOA><C_C516><D_5025>125</D_5025><D_5004>50.02</D_5004></C_C516></S_MOA>"
+        "      </G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG26>"
+        "      <S_LIN><D_1082>2</D_1082></S_LIN>"
+        "      <S_QTY><C_C186><D_6063>47</D_6063><D_6060>1.00</D_6060><D_6411>PCE</D_6411></C_C186></S_QTY>"
+        "      <G_SG27>"
+        "        <S_MOA><C_C516><D_5025>203</D_5025><D_5004>50.02</D_5004></C_C516></S_MOA>"
+        "      </G_SG27>"
+        "      <G_SG34>"
+        "        <S_MOA><C_C516><D_5025>125</D_5025><D_5004>50.02</D_5004></C_C516></S_MOA>"
+        "      </G_SG34>"
+        "    </G_SG26>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>389</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "    <G_SG50>"
+        "      <S_MOA><C_C516><D_5025>9</D_5025><D_5004>100.00</D_5004></C_C516></S_MOA>"
+        "    </G_SG50>"
+        "  </M_INVOIC>"
+        "</Invoice>"
+    )
+
+    root = LET.fromstring(xml.encode())
+    totals = parse_invoice_totals(root)
+
+    assert totals["net"] == Decimal("100.00")
+    assert totals["vat"] == Decimal("0.00")
+    assert totals["gross"] == Decimal("100.00")
+    assert totals["mismatch"] is False
+
+
 def _write_allowance_invoice(path: Path) -> Path:
     xml = (
         "<Invoice xmlns='urn:eslog:2.00'>"

--- a/wsm/parsing/eslog.py
+++ b/wsm/parsing/eslog.py
@@ -2333,16 +2333,23 @@ def parse_invoice_totals(
     header_vat = extract_total_tax(xml_root)
     header_gross = extract_grand_total(xml_root)
 
-    if header_vat != 0:
-        vat_total = header_vat
-    elif header_gross != 0 and header_vat == 0:
-        vat_total = _dec2(header_gross - net_total)
+    header_net_q = _dec2(header_net) if header_net != 0 else Decimal("0")
+    header_vat_q = _dec2(header_vat) if header_vat != 0 else Decimal("0")
+    header_gross_q = _dec2(header_gross) if header_gross != 0 else Decimal("0")
 
-    gross_total = _dec2(net_total + vat_total)
+    if header_net_q != 0:
+        net_total = header_net_q
 
-    calc_gross = gross_total
+    if header_vat_q != 0:
+        vat_total = header_vat_q
+    elif header_gross_q != 0:
+        vat_total = _dec2(header_gross_q - net_total)
+
+    calc_gross = _dec2(net_total + vat_total)
+    gross_total = header_gross_q if header_gross_q != 0 else calc_gross
+
     header_total = _dec2(
-        header_gross if header_gross != 0 else header_net + header_vat
+        header_gross_q if header_gross_q != 0 else header_net_q + header_vat_q
     )
 
     mismatch = bool(df.attrs.get("vat_mismatch", False))


### PR DESCRIPTION
## Summary
- trust the header net total when present in `parse_invoice_totals` and quantize it before overriding the line sum
- ensure the VAT fallback uses the overridden net amount and keep the reported gross total aligned with header MOA 9 when provided
- add a regression test covering a header-only VAT scenario with MOA 125/9 but mismatched line sums

## Testing
- pytest tests/test_extract_header_net.py

------
https://chatgpt.com/codex/tasks/task_e_68cbf192c5c48321bff6bcf286cdf0e6