### PR TITLE
Enable auto applying saved links via env override

### DIFF
--- a/Fix-Run.ps1
+++ b/Fix-Run.ps1
@@ -56,8 +56,9 @@ $env:WSM_CODES_FILE     = '\\PisarnaNAS\wsm_program_vnasanje_povezave\sifre_wsm.
 
 
 # ─────────────────────────────── zagon programa ───────────────────────────────
-# Onemogoči samodejno uveljavljanje shranjenih povezav.
-$env:AUTO_APPLY_LINKS = "0"
+# Omogoči samodejno uveljavljanje shranjenih povezav.
+$env:WSM_AUTO_APPLY_LINKS = "1"
+$env:AUTO_APPLY_LINKS = "1"
 Write-Host "[run] python -m wsm.run" -f Cyan
 python -m wsm.run
 $exitCode = $LASTEXITCODE

--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -67,9 +67,14 @@ ONLY_BOOKED_IN_SUMMARY = getenv("WSM_SUMMARY_ONLY_BOOKED", "0") not in {
 
 # Naj se shranjene povezave uporabijo samodejno ob odprtju?
 # (privzeto NE)
-AUTO_APPLY_LINKS = getenv(
-    "AUTO_APPLY_LINKS", getenv("WSM_AUTO_APPLY_LINKS", "0")
-) not in {
+_AUTO_APPLY_ENV = getenv("WSM_AUTO_APPLY_LINKS")
+_AUTO_APPLY_ENV_SRC = "WSM_AUTO_APPLY_LINKS"
+if _AUTO_APPLY_ENV is None:
+    _AUTO_APPLY_ENV = getenv("AUTO_APPLY_LINKS", "0")
+    _AUTO_APPLY_ENV_SRC = "AUTO_APPLY_LINKS"
+AUTO_APPLY_LINKS_RAW = _AUTO_APPLY_ENV
+AUTO_APPLY_LINKS_SOURCE = _AUTO_APPLY_ENV_SRC
+AUTO_APPLY_LINKS = _AUTO_APPLY_ENV not in {
     "0",
     "false",
     "False",
@@ -1143,6 +1148,11 @@ def review_links(
 
     log.info("=== ENVIRONMENT CHECK ===")
     log.info("AUTO_APPLY_LINKS = %s", AUTO_APPLY_LINKS)
+    log.info(
+        "AUTO_APPLY_LINKS raw (%s) = %s",
+        AUTO_APPLY_LINKS_SOURCE,
+        AUTO_APPLY_LINKS_RAW,
+    )
     log.info("WSM_AUTO_APPLY_LINKS env = %s", os.getenv("WSM_AUTO_APPLY_LINKS"))
     log.info("AUTO_APPLY_LINKS env = %s", os.getenv("AUTO_APPLY_LINKS"))
 


### PR DESCRIPTION
## Summary
- prefer the WSM_AUTO_APPLY_LINKS flag when deciding whether to auto-apply saved links and expose the chosen source in the logs
- log the raw environment value that determined the AUTO_APPLY_LINKS setting for easier diagnostics
- update Fix-Run.ps1 to enable automatic link application by default via both legacy and new environment variables

## Testing
- pytest -q *(fails: requires extensive fixtures and GUI dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11077ce208321b7a251d10f59c997