### PR TITLE
Fix clearing WSM connections and duplicate link saving

### DIFF
--- a/wsm/ui/review/io.py
+++ b/wsm/ui/review/io.py
@@ -193,6 +193,16 @@ def _write_excel_links(
             how="all",
         )
         manual_old["naziv_ckey"] = manual_old["naziv"].map(_clean)
+        before = len(manual_old)
+        manual_old = manual_old.drop_duplicates(
+            subset=["sifra_dobavitelja", "naziv_ckey"],
+            keep="last",
+        )
+        if len(manual_old) != before:
+            log.warning(
+                "Odstranjenih podvojenih povezav: %s",
+                before - len(manual_old),
+            )
         manual_new = manual_old.set_index(["sifra_dobavitelja", "naziv_ckey"])
         if "status" not in manual_new.columns:
             manual_new["status"] = pd.Series(


### PR DESCRIPTION
## Summary
- expose the grid value helper so clearing a WSM connection no longer crashes when refreshing the row
- de-duplicate supplier mappings before saving links to avoid pandas multi-index assignment errors

## Testing
- python -m compileall wsm/ui/review

------
https://chatgpt.com/codex/tasks/task_e_68d3b295da948321a38070b10b56442e