### PR TITLE
Fix clearing WSM connections and duplicate link saving

### DIFF
--- a/wsm/ui/review/io.py
+++ b/wsm/ui/review/io.py
@@ -193,6 +193,16 @@ def _write_excel_links(
             how="all",
         )
         manual_old["naziv_ckey"] = manual_old["naziv"].map(_clean)
+        before = len(manual_old)
+        manual_old = manual_old.drop_duplicates(
+            subset=["sifra_dobavitelja", "naziv_ckey"],
+            keep="last",
+        )
+        if len(manual_old) != before:
+            log.warning(
+                "Odstranjenih podvojenih povezav: %s",
+                before - len(manual_old),
+            )
         manual_new = manual_old.set_index(["sifra_dobavitelja", "naziv_ckey"])
         if "status" not in manual_new.columns:
             manual_new["status"] = pd.Series(
@@ -249,6 +259,40 @@ def _write_excel_links(
         ["naziv", "wsm_sifra", "dobavitelj", "enota_norm", "multiplier"]
     ].copy()
     df_links["status"] = status_values
+
+    if not df_links.index.is_unique:
+        df_links = df_links.reset_index()
+        df_links["_has_code"] = (
+            df_links["wsm_sifra"].astype("string").fillna("").str.strip().ne("")
+        )
+        df_links = df_links.sort_values(
+            by=["sifra_dobavitelja", "naziv_ckey", "_has_code"],
+            ascending=[True, True, False],
+            kind="stable",
+        )
+        before = len(df_links)
+        dup_preview = df_links[
+            df_links.duplicated(
+                subset=["sifra_dobavitelja", "naziv_ckey"], keep=False
+            )
+        ].head()
+        df_links = df_links.drop_duplicates(
+            subset=["sifra_dobavitelja", "naziv_ckey"],
+            keep="first",
+        )
+        removed = before - len(df_links)
+        if removed:
+            log.warning(
+                "Odstranjenih podvojenih vrstic pri pripravi shranjevanja: %s",
+                removed,
+            )
+            log.debug(
+                "Primer podvojenih povezav pred filtriranjem: %s",
+                dup_preview.to_dict(orient="records"),
+            )
+        df_links = df_links.drop(columns="_has_code").set_index(
+            ["sifra_dobavitelja", "naziv_ckey"]
+        )
 
     if "status" not in manual_new.columns:
         manual_new["status"] = pd.Series(


### PR DESCRIPTION
## Summary
- expose the grid value helper so clearing a WSM connection no longer crashes when refreshing the row
- de-duplicate supplier mappings before saving links to avoid pandas multi-index assignment errors
- collapse duplicate invoice rows when preparing Excel links so clearing repeated items no longer triggers non-unique MultiIndex errors

## Testing
- python -m compileall wsm/ui/review

------
https://chatgpt.com/codex/tasks/task_e_68d3b295da948321a38070b10b56442e