### PR TITLE
Enable WSM name suggestions by default

### DIFF
--- a/wsm/ui/review/gui.py
+++ b/wsm/ui/review/gui.py
@@ -90,9 +90,9 @@ OVERWRITE_OSTALO_IN_GRID = getenv(
     "WSM_OVERWRITE_OSTALO_IN_GRID", "1"
 ) not in {"0", "false", "False"}
 
-# Ali naj se med urejanjem prikazujejo predlogi WSM nazivov? (privzeto NE)
+# Ali naj se med urejanjem prikazujejo predlogi WSM nazivov? (privzeto DA)
 ENABLE_WSM_SUGGESTIONS = getenv(
-    "WSM_ENABLE_SUGGESTIONS", "0"
+    "WSM_ENABLE_SUGGESTIONS", "1"
 ) not in {"0", "false", "False", ""}
 
 DEC2 = Decimal("0.01")


### PR DESCRIPTION
## Summary
- enable the Tk review UI's WSM suggestion dropdown by default by turning on the `WSM_ENABLE_SUGGESTIONS` flag

## Testing
- pytest tests/test_suggestion_listbox.py -k test_double_click_returns_break

------
https://chatgpt.com/codex/tasks/task_e_68d3c746b3a88321b6d36f1d950126c0